### PR TITLE
test(app): add Bruno API test collection for REST endpoints

### DIFF
--- a/app/tests/bruno/bruno.json
+++ b/app/tests/bruno/bruno.json
@@ -1,0 +1,6 @@
+{
+  "version": "1",
+  "name": "Nuages API",
+  "type": "collection",
+  "ignore": ["node_modules", ".git"]
+}

--- a/app/tests/bruno/collection.bru
+++ b/app/tests/bruno/collection.bru
@@ -1,0 +1,3 @@
+headers {
+  Content-Type: application/json
+}

--- a/app/tests/bruno/environments/Local.bru
+++ b/app/tests/bruno/environments/Local.bru
@@ -1,0 +1,9 @@
+vars {
+  baseUrl: http://localhost:8000
+  jwtToken:
+  testUsername: testuser
+  testPassword: testpassword
+  testEmail: test@local.dev
+  clusterId:
+  deploymentId:
+}

--- a/app/tests/bruno/environments/Production.bru
+++ b/app/tests/bruno/environments/Production.bru
@@ -1,0 +1,9 @@
+vars {
+  baseUrl: https://nuages.dev
+  jwtToken:
+  testUsername:
+  testPassword:
+  testEmail:
+  clusterId:
+  deploymentId:
+}

--- a/app/tests/bruno/environments/Staging.bru
+++ b/app/tests/bruno/environments/Staging.bru
@@ -1,0 +1,9 @@
+vars {
+  baseUrl: https://staging.nuages.dev
+  jwtToken:
+  testUsername: staging-testuser
+  testPassword: staging-testpassword
+  testEmail: test@staging.nuages.dev
+  clusterId:
+  deploymentId:
+}

--- a/app/tests/bruno/scenarios/01 Register User.bru
+++ b/app/tests/bruno/scenarios/01 Register User.bru
@@ -1,0 +1,38 @@
+meta {
+  name: 01 Register User
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/api/auth/register/
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "username": "{{testUsername}}",
+    "email": "{{testEmail}}",
+    "password": "{{testPassword}}"
+  }
+}
+
+assert {
+  res.status: eq 201
+  res.body.token_type: eq Bearer
+  res.body.token: isString
+}
+
+tests {
+  test("should register user and return JWT token", function() {
+    const body = res.getBody();
+    expect(body.token_type).to.equal("Bearer");
+    expect(body.token).to.be.a("string");
+    expect(body.token.length).to.be.greaterThan(0);
+  });
+}
+
+script:post-response {
+  bru.setEnvVar("jwtToken", res.body.token);
+}

--- a/app/tests/bruno/scenarios/02 Login User.bru
+++ b/app/tests/bruno/scenarios/02 Login User.bru
@@ -1,0 +1,37 @@
+meta {
+  name: 02 Login User
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/api/auth/login/
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "username": "{{testUsername}}",
+    "password": "{{testPassword}}"
+  }
+}
+
+assert {
+  res.status: eq 200
+  res.body.token_type: eq Bearer
+  res.body.token: isString
+}
+
+tests {
+  test("should login and return JWT token", function() {
+    const body = res.getBody();
+    expect(body.token_type).to.equal("Bearer");
+    expect(body.token).to.be.a("string");
+    expect(body.token.length).to.be.greaterThan(0);
+  });
+}
+
+script:post-response {
+  bru.setEnvVar("jwtToken", res.body.token);
+}

--- a/app/tests/bruno/scenarios/03 Create Cluster.bru
+++ b/app/tests/bruno/scenarios/03 Create Cluster.bru
@@ -1,0 +1,43 @@
+meta {
+  name: 03 Create Cluster
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/api/clusters/
+  body: json
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{jwtToken}}
+}
+
+body:json {
+  {
+    "name": "production-cluster",
+    "api_url": "https://k8s.example.com:6443"
+  }
+}
+
+assert {
+  res.status: eq 201
+  res.body.name: eq production-cluster
+  res.body.api_url: eq https://k8s.example.com:6443
+  res.body.is_active: eq true
+}
+
+tests {
+  test("should create cluster and return details", function() {
+    const body = res.getBody();
+    expect(body.name).to.equal("production-cluster");
+    expect(body.api_url).to.equal("https://k8s.example.com:6443");
+    expect(body.is_active).to.equal(true);
+    expect(body.id).to.be.a("number");
+  });
+}
+
+script:post-response {
+  bru.setEnvVar("clusterId", res.body.id);
+}

--- a/app/tests/bruno/scenarios/04 List Clusters.bru
+++ b/app/tests/bruno/scenarios/04 List Clusters.bru
@@ -1,0 +1,32 @@
+meta {
+  name: 04 List Clusters
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}/api/clusters/
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{jwtToken}}
+}
+
+assert {
+  res.status: eq 200
+}
+
+tests {
+  test("should return cluster list containing created cluster", function() {
+    const body = res.getBody();
+    expect(body).to.be.an("array");
+    expect(body.length).to.be.greaterThan(0);
+
+    const cluster = body.find(c => c.name === "production-cluster");
+    expect(cluster).to.not.be.undefined;
+    expect(cluster.api_url).to.equal("https://k8s.example.com:6443");
+    expect(cluster.is_active).to.equal(true);
+  });
+}

--- a/app/tests/bruno/scenarios/05 Create Deployment.bru
+++ b/app/tests/bruno/scenarios/05 Create Deployment.bru
@@ -1,0 +1,45 @@
+meta {
+  name: 05 Create Deployment
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{baseUrl}}/api/deployments/
+  body: json
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{jwtToken}}
+}
+
+body:json {
+  {
+    "app_name": "my-web-app",
+    "cluster_id": {{clusterId}},
+    "image": "registry.example.com/my-web-app:v1.0.0"
+  }
+}
+
+assert {
+  res.status: eq 201
+  res.body.app_name: eq my-web-app
+  res.body.status: eq pending
+  res.body.image: eq registry.example.com/my-web-app:v1.0.0
+}
+
+tests {
+  test("should create deployment and return details", function() {
+    const body = res.getBody();
+    expect(body.app_name).to.equal("my-web-app");
+    expect(body.status).to.equal("pending");
+    expect(body.image).to.equal("registry.example.com/my-web-app:v1.0.0");
+    expect(body.id).to.be.a("number");
+    expect(body.cluster_id).to.be.a("number");
+  });
+}
+
+script:post-response {
+  bru.setEnvVar("deploymentId", res.body.id);
+}

--- a/app/tests/bruno/scenarios/06 List Deployments.bru
+++ b/app/tests/bruno/scenarios/06 List Deployments.bru
@@ -1,0 +1,33 @@
+meta {
+  name: 06 List Deployments
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{baseUrl}}/api/deployments/
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{jwtToken}}
+}
+
+assert {
+  res.status: eq 200
+}
+
+tests {
+  test("should return deployment list containing created deployment", function() {
+    const body = res.getBody();
+    expect(body).to.be.an("array");
+    expect(body.length).to.be.greaterThan(0);
+
+    const deployment = body.find(d => d.app_name === "my-web-app");
+    expect(deployment).to.not.be.undefined;
+    expect(deployment.status).to.equal("pending");
+    expect(deployment.image).to.equal("registry.example.com/my-web-app:v1.0.0");
+    expect(deployment.cluster_id).to.be.a("number");
+  });
+}

--- a/app/tests/bruno/scenarios/folder.bru
+++ b/app/tests/bruno/scenarios/folder.bru
@@ -1,0 +1,3 @@
+meta {
+  name: Scenarios
+}

--- a/app/tests/bruno/unit/auth/Login.bru
+++ b/app/tests/bruno/unit/auth/Login.bru
@@ -1,0 +1,33 @@
+meta {
+  name: Login
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/api/auth/login/
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "username": "testuser",
+    "password": "testpassword"
+  }
+}
+
+assert {
+  res.status: eq 200
+  res.body.token_type: eq Bearer
+  res.body.token: isString
+}
+
+tests {
+  test("should return 200 with JWT token", function() {
+    const body = res.getBody();
+    expect(body.token_type).to.equal("Bearer");
+    expect(body.token).to.be.a("string");
+    expect(body.token.length).to.be.greaterThan(0);
+  });
+}

--- a/app/tests/bruno/unit/auth/Register.bru
+++ b/app/tests/bruno/unit/auth/Register.bru
@@ -1,0 +1,34 @@
+meta {
+  name: Register
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/api/auth/register/
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "username": "newuser",
+    "email": "newuser@example.com",
+    "password": "securepassword"
+  }
+}
+
+assert {
+  res.status: eq 201
+  res.body.token_type: eq Bearer
+  res.body.token: isString
+}
+
+tests {
+  test("should return 201 with JWT token", function() {
+    const body = res.getBody();
+    expect(body.token_type).to.equal("Bearer");
+    expect(body.token).to.be.a("string");
+    expect(body.token.length).to.be.greaterThan(0);
+  });
+}

--- a/app/tests/bruno/unit/auth/folder.bru
+++ b/app/tests/bruno/unit/auth/folder.bru
@@ -1,0 +1,3 @@
+meta {
+  name: Auth
+}

--- a/app/tests/bruno/unit/clusters/Create Cluster.bru
+++ b/app/tests/bruno/unit/clusters/Create Cluster.bru
@@ -1,0 +1,35 @@
+meta {
+  name: Create Cluster
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/api/clusters/
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "name": "production-cluster",
+    "api_url": "https://k8s.example.com:6443"
+  }
+}
+
+assert {
+  res.status: eq 201
+  res.body.name: eq production-cluster
+  res.body.api_url: eq https://k8s.example.com:6443
+  res.body.is_active: eq true
+}
+
+tests {
+  test("should return 201 with created cluster", function() {
+    const body = res.getBody();
+    expect(body.name).to.equal("production-cluster");
+    expect(body.api_url).to.equal("https://k8s.example.com:6443");
+    expect(body.is_active).to.equal(true);
+    expect(body.id).to.be.a("number");
+  });
+}

--- a/app/tests/bruno/unit/clusters/List Clusters.bru
+++ b/app/tests/bruno/unit/clusters/List Clusters.bru
@@ -1,0 +1,22 @@
+meta {
+  name: List Clusters
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/clusters/
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+}
+
+tests {
+  test("should return 200 with array", function() {
+    const body = res.getBody();
+    expect(body).to.be.an("array");
+  });
+}

--- a/app/tests/bruno/unit/clusters/folder.bru
+++ b/app/tests/bruno/unit/clusters/folder.bru
@@ -1,0 +1,7 @@
+meta {
+  name: Clusters
+}
+
+headers {
+  Authorization: Bearer {{jwtToken}}
+}

--- a/app/tests/bruno/unit/deployments/Create Deployment.bru
+++ b/app/tests/bruno/unit/deployments/Create Deployment.bru
@@ -1,0 +1,37 @@
+meta {
+  name: Create Deployment
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/api/deployments/
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "app_name": "my-web-app",
+    "cluster_id": {{clusterId}},
+    "image": "registry.example.com/my-web-app:v1.0.0"
+  }
+}
+
+assert {
+  res.status: eq 201
+  res.body.app_name: eq my-web-app
+  res.body.status: eq pending
+  res.body.image: eq registry.example.com/my-web-app:v1.0.0
+}
+
+tests {
+  test("should return 201 with created deployment", function() {
+    const body = res.getBody();
+    expect(body.app_name).to.equal("my-web-app");
+    expect(body.status).to.equal("pending");
+    expect(body.image).to.equal("registry.example.com/my-web-app:v1.0.0");
+    expect(body.id).to.be.a("number");
+    expect(body.cluster_id).to.be.a("number");
+  });
+}

--- a/app/tests/bruno/unit/deployments/List Deployments.bru
+++ b/app/tests/bruno/unit/deployments/List Deployments.bru
@@ -1,0 +1,22 @@
+meta {
+  name: List Deployments
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/deployments/
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+}
+
+tests {
+  test("should return 200 with array", function() {
+    const body = res.getBody();
+    expect(body).to.be.an("array");
+  });
+}

--- a/app/tests/bruno/unit/deployments/folder.bru
+++ b/app/tests/bruno/unit/deployments/folder.bru
@@ -1,0 +1,7 @@
+meta {
+  name: Deployments
+}
+
+headers {
+  Authorization: Bearer {{jwtToken}}
+}


### PR DESCRIPTION
## Summary

- Add Bruno API test collection for all REST endpoints (auth, clusters, deployments)
- Include environment configurations for Local, Staging, and Production
- Provide both unit tests (per-endpoint) and scenario tests (sequential workflow)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Motivation and Context

Manual API testing during development requires a structured, repeatable approach. Bruno provides a git-friendly, offline-first API client that integrates well with the existing codebase. This collection enables developers to quickly validate endpoint behavior across environments.

## How Was This Tested?

- Bruno collection structure validated with Bruno CLI
- Endpoint definitions verified against existing route configuration in `app/src/config/urls.rs`
- Environment variable interpolation confirmed for Local, Staging, and Production configs

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label
- [x] `enhancement` - New feature or improvement

### Scope Label
- [x] `api` - REST API, serializers, handlers
- [x] `auth` - Authentication, authorization, RBAC

---

**Additional Context:**

The Bruno collection is organized into two test categories:
- **unit/**: Individual endpoint tests (auth, clusters, deployments)
- **scenarios/**: Sequential workflow tests (register → login → create cluster → list → create deployment → list)

Each scenario test extracts variables (e.g., JWT token, cluster ID) via post-response scripts for use in subsequent requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)