### PR TITLE
refactor(auth): move jwt_secret() from views.rs to views/utils.rs

### DIFF
--- a/app/src/apps/auth/views.rs
+++ b/app/src/apps/auth/views.rs
@@ -2,16 +2,7 @@
 
 pub mod login;
 pub mod register;
+pub mod utils;
 
 pub use login::login;
 pub use register::register;
-
-/// Get JWT secret from environment.
-///
-/// Falls back to a default value suitable only for development.
-/// In production, `NUAGES_JWT_SECRET` MUST be set to a cryptographically
-/// random string of at least 32 bytes.
-pub(crate) fn jwt_secret() -> String {
-	std::env::var("NUAGES_JWT_SECRET")
-		.unwrap_or_else(|_| "change-me-in-production-minimum-32-bytes!".to_string())
-}

--- a/app/src/apps/auth/views/login.rs
+++ b/app/src/apps/auth/views/login.rs
@@ -7,9 +7,9 @@ use reinhardt::http::ViewResult;
 use reinhardt::post;
 use reinhardt::{BaseUser, Json, JwtAuth, Response, StatusCode};
 
+use super::utils::jwt_secret;
 use crate::apps::auth::models::User;
 use crate::apps::auth::serializers::{LoginRequest, TokenResponse};
-use crate::apps::auth::views::jwt_secret;
 
 /// Authenticate user against database and return JWT token.
 #[post("/auth/login/", name = "auth_login", pre_validate = true)]

--- a/app/src/apps/auth/views/register.rs
+++ b/app/src/apps/auth/views/register.rs
@@ -7,9 +7,9 @@ use reinhardt::http::ViewResult;
 use reinhardt::post;
 use reinhardt::{BaseUser, Json, JwtAuth, Response, StatusCode};
 
+use super::utils::jwt_secret;
 use crate::apps::auth::models::User;
 use crate::apps::auth::serializers::{RegisterRequest, TokenResponse};
-use crate::apps::auth::views::jwt_secret;
 
 /// Register new user, persist to database, and return JWT token.
 #[post("/auth/register/", name = "auth_register", pre_validate = true)]

--- a/app/src/apps/auth/views/utils.rs
+++ b/app/src/apps/auth/views/utils.rs
@@ -1,0 +1,11 @@
+//! Utility functions for auth views.
+
+/// Get JWT secret from environment.
+///
+/// Falls back to a default value suitable only for development.
+/// In production, `NUAGES_JWT_SECRET` MUST be set to a cryptographically
+/// random string of at least 32 bytes.
+pub(crate) fn jwt_secret() -> String {
+	std::env::var("NUAGES_JWT_SECRET")
+		.unwrap_or_else(|_| "change-me-in-production-minimum-32-bytes!".to_string())
+}

--- a/app/src/config/middleware.rs
+++ b/app/src/config/middleware.rs
@@ -10,7 +10,7 @@ use reinhardt::async_trait::async_trait;
 use reinhardt::http::AuthState;
 use reinhardt::{Handler, JwtAuth, Middleware, Request, Response};
 
-use crate::apps::auth::views::jwt_secret;
+use crate::apps::auth::views::utils::jwt_secret;
 
 /// JWT authentication middleware.
 ///


### PR DESCRIPTION
## Summary

- Extract `jwt_secret()` from `views.rs` aggregator into `views/utils.rs`
- Update import paths in `login.rs`, `register.rs`, and `middleware.rs`

## Type of Change

- [x] Refactoring (code change that neither fixes a bug nor adds a feature)

## Motivation and Context

Enforce MF-1 convention: aggregator module files should contain only `pub mod` declarations and `pub use` re-exports, not utility functions.

Split from #13 (WU-1: 1 PR = 1 fix pattern).

## How Was This Tested?

- `cargo check --workspace --all --all-features` — passes
- `cargo make fmt-check` — passes
- `cargo make clippy-check` — passes

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)