### PR TITLE
fix(cli): suppress dead_code warnings on scaffold API items

### DIFF
--- a/crates/nuages-cli/src/client.rs
+++ b/crates/nuages-cli/src/client.rs
@@ -4,6 +4,9 @@ use reqwest::{Client, Url};
 use thiserror::Error;
 
 /// Errors from API client operations.
+// allow(dead_code): Part of the CLI client API scaffold; will be used
+// when deploy/status/login commands call the REST API.
+#[allow(dead_code)]
 #[derive(Debug, Error)]
 pub(crate) enum ClientError {
 	#[error("HTTP request failed: {0}")]
@@ -19,8 +22,13 @@ pub(crate) enum ClientError {
 /// REST API client for the nuages platform.
 #[derive(Debug, Clone)]
 pub(crate) struct NuagesClient {
+	// allow(dead_code): Fields are read by methods below; warnings appear
+	// because the methods themselves are not yet called from commands.
+	#[allow(dead_code)]
 	http: Client,
+	#[allow(dead_code)]
 	base_url: Url,
+	#[allow(dead_code)]
 	token: Option<String>,
 }
 
@@ -40,12 +48,16 @@ impl NuagesClient {
 	}
 
 	/// Sets the authentication token.
+	// allow(dead_code): Will be called once login command stores a JWT token.
+	#[allow(dead_code)]
 	pub(crate) fn with_token(mut self, token: String) -> Self {
 		self.token = Some(token);
 		self
 	}
 
 	/// Returns the base URL as a string (without trailing slash).
+	// allow(dead_code): Used in tests; will be used by commands for URL display.
+	#[allow(dead_code)]
 	pub(crate) fn base_url(&self) -> &str {
 		self.base_url.as_str().trim_end_matches('/')
 	}
@@ -54,6 +66,8 @@ impl NuagesClient {
 	///
 	/// The `path` is joined onto the base URL using [`Url::join`], which
 	/// handles leading slashes and relative segments correctly.
+	// allow(dead_code): Will be called by deploy/status/login command implementations.
+	#[allow(dead_code)]
 	pub(crate) fn request(
 		&self,
 		method: reqwest::Method,

--- a/crates/nuages-cli/src/config.rs
+++ b/crates/nuages-cli/src/config.rs
@@ -5,6 +5,9 @@ use std::path::Path;
 use thiserror::Error;
 
 /// Errors from configuration loading.
+// allow(dead_code): Returned by from_file(); will be used when CLI loads
+// nuages.toml configuration on startup.
+#[allow(dead_code)]
 #[derive(Debug, Error)]
 pub(crate) enum ConfigError {
 	#[error("failed to read config file: {0}")]
@@ -15,7 +18,7 @@ pub(crate) enum ConfigError {
 }
 
 /// CLI-specific configuration (read from `nuages.toml` or environment).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub(crate) struct CliConfig {
 	/// API server base URL
 	pub api_url: Option<String>,
@@ -25,6 +28,8 @@ pub(crate) struct CliConfig {
 
 impl CliConfig {
 	/// Loads configuration from a `nuages.toml` file.
+	// allow(dead_code): Will be called when CLI implements config file loading.
+	#[allow(dead_code)]
 	pub(crate) fn from_file(path: &Path) -> Result<Self, ConfigError> {
 		let content = std::fs::read_to_string(path)?;
 		let config: CliConfig = toml::from_str(&content)?;
@@ -40,14 +45,6 @@ impl CliConfig {
 	}
 }
 
-impl Default for CliConfig {
-	fn default() -> Self {
-		Self {
-			api_url: None,
-			app_name: None,
-		}
-	}
-}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary

- Add `#[allow(dead_code)]` with explanatory comments to CLI client and config items that are part of the scaffold but not yet called from command implementations
- Replace manual `Default` impl with `#[derive(Default)]` to fix `clippy::derivable_impls` warning

## Type of Change

- [x] Code quality improvements

## Motivation and Context

`cargo clippy -- -D warnings` failed with dead_code warnings for `ClientError`, `NuagesClient` fields/methods, `ConfigError`, and `CliConfig::from_file`. These are intentional scaffold items awaiting command implementation.

## How Was This Tested?

- `cargo clippy -p nuages-cli -- -D warnings` — passes with zero warnings

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have checked the code with `cargo make clippy-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)