### PR TITLE
fix(ci): pin semgrep Docker image to specific version

### DIFF
--- a/.github/workflows/todo-check.yml
+++ b/.github/workflows/todo-check.yml
@@ -36,7 +36,8 @@ jobs:
       - name: Run Semgrep TODO/FIXME scan
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: docker run --rm -v "${{ github.workspace }}:/src" -w /src semgrep/semgrep semgrep scan --config .semgrep/ --baseline-commit "$BASE_SHA" --error --metrics off
+        # Pin semgrep to v1.155.0 — update version and digest together when upgrading
+        run: docker run --rm -v "${{ github.workspace }}:/src" -w /src semgrep/semgrep:1.155.0@sha256:3dab091ee3247fce7e4ed3df9f92b3bd72692c083295f53cec3f135b86404db1 semgrep scan --config .semgrep/ --baseline-commit "$BASE_SHA" --error --metrics off
 
   clippy-todo-check:
     name: Clippy TODO/unimplemented/dbg lint


### PR DESCRIPTION
## Summary

This PR addresses:

- Pin `semgrep/semgrep` Docker image in `todo-check.yml` to version `1.155.0` with SHA digest
- Add version comment for future upgrades

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

- Using an untagged Docker image (`semgrep/semgrep`) pulls `:latest` which changes unpredictably
- Pinning to a specific version with SHA digest ensures reproducible builds and prevents unexpected breaking changes

Fixes #53

## How Was This Tested?

- YAML syntax validated with Python yaml.safe_load
- Docker image digest verified via Docker Registry API v2

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #53

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

---

**Additional Context:**

Pinned to `semgrep/semgrep:1.155.0@sha256:3dab091ee3247fce7e4ed3df9f92b3bd72692c083295f53cec3f135b86404db1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)