### PR TITLE
fix(app): move env::set_var before tokio runtime initialization

### DIFF
--- a/app/src/bin/manage.rs
+++ b/app/src/bin/manage.rs
@@ -39,14 +39,21 @@ impl BaseCommand for SyncClustersCommand {
 	}
 }
 
-#[tokio::main]
-async fn main() {
-	// Set settings module environment variable
-	// SAFETY: This is safe because we're setting it before any other code runs
+fn main() {
+	// SAFETY: Called before tokio runtime initialization, so no other
+	// threads exist. env::set_var is safe in single-threaded context.
 	unsafe {
 		std::env::set_var("REINHARDT_SETTINGS_MODULE", "nuages.config.settings");
 	}
 
+	tokio::runtime::Builder::new_multi_thread()
+		.enable_all()
+		.build()
+		.expect("Failed to build tokio runtime")
+		.block_on(async_main());
+}
+
+async fn async_main() {
 	// Register project-specific custom commands
 	let mut registry = CommandRegistry::new();
 	registry.register(Box::new(SyncClustersCommand));


### PR DESCRIPTION
## Summary

- Build tokio runtime manually to ensure `env::set_var` is called before any threads are spawned
- Replaces `#[tokio::main]` with explicit runtime construction for safe `unsafe` env::set_var usage

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

In Rust 2024 edition, `env::set_var` is unsafe because it is not thread-safe. The current code uses `#[tokio::main]` which initializes the tokio runtime before `env::set_var` is called, meaning other threads may already exist.

By building the runtime manually, we guarantee `env::set_var` executes in a single-threaded context before any runtime threads are spawned.

Fixes #49

## How Was This Tested?

- [x] Verified the change compiles correctly
- [x] Binary entry point behavior is unchanged

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `cli` - Command-line interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)