### PR TITLE
fix(operator): replace string literals with typed status structs

### DIFF
--- a/crates/nuages-operator/src/reconciler.rs
+++ b/crates/nuages-operator/src/reconciler.rs
@@ -15,8 +15,8 @@ use tracing::{error, info};
 
 use crate::error::Error;
 use crate::resources::{build_deployment, build_service};
-use nuages_types::ConditionType;
-use nuages_types::crd::ReinhardtApp;
+use nuages_types::crd::{AppCondition, AppPhase, ReinhardtApp, ReinhardtAppStatus};
+use nuages_types::{ConditionStatus, ConditionType};
 
 const FINALIZER_NAME: &str = "paas.nuages.dev/cleanup";
 
@@ -118,11 +118,15 @@ async fn update_status(
 	ready_replicas: i32,
 ) -> Result<(), Error> {
 	let api: Api<ReinhardtApp> = Api::namespaced(client.clone(), namespace);
-	let phase = if ready { "Running" } else { "Deploying" };
-	let condition_status = if ready {
-		nuages_types::ConditionStatus::True
+	let phase = if ready {
+		AppPhase::Running
 	} else {
-		nuages_types::ConditionStatus::False
+		AppPhase::Deploying
+	};
+	let condition_status = if ready {
+		ConditionStatus::True
+	} else {
+		ConditionStatus::False
 	};
 	let reason = if ready {
 		"ReconcileSuccess"
@@ -139,7 +143,7 @@ async fn update_status(
 	let existing_ready_condition = app.status.as_ref().and_then(|s| {
 		s.conditions
 			.iter()
-			.find(|c| c.type_ == nuages_types::ConditionType::Ready)
+			.find(|c| c.type_ == ConditionType::Ready)
 	});
 
 	let last_transition_time = match existing_ready_condition {
@@ -153,21 +157,20 @@ async fn update_status(
 		}
 	};
 
-	let status = serde_json::json!({
-		"status": {
-			"phase": phase,
-			"observedGeneration": app.metadata.generation,
-			"readyReplicas": ready_replicas,
-			"conditions": [{
-				"type": ConditionType::Ready,
-				"status": condition_status,
-				"reason": reason,
-				"message": message,
-				"lastTransitionTime": last_transition_time,
-				"observedGeneration": app.metadata.generation,
-			}]
-		}
-	});
+	let typed_status = ReinhardtAppStatus {
+		phase: Some(phase),
+		conditions: vec![AppCondition {
+			type_: ConditionType::Ready,
+			status: condition_status,
+			reason: reason.to_string(),
+			message: message.to_string(),
+			last_transition_time,
+			observed_generation: app.metadata.generation,
+		}],
+		observed_generation: app.metadata.generation,
+		ready_replicas: Some(ready_replicas),
+	};
+	let status = serde_json::json!({ "status": typed_status });
 
 	api.patch_status(
 		&app.name_any(),


### PR DESCRIPTION
## Summary

- Replace phase string literals (`"Running"`, `"Deploying"`) with `AppPhase` enum variants for compile-time safety
- Replace `serde_json::json!()` status patch with typed `ReinhardtAppStatus` struct
- Update imports to use typed CRD types from `nuages_types::crd`

Fixes #30
Fixes #40
Refs #42

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The reconciler was using string literals for phase values and `serde_json::json!()` for status patch construction, which bypasses compile-time type checking. Using raw JSON means typos in field names or incorrect types are only caught at runtime. This change replaces both with strongly typed constructs (`AppPhase` enum and `ReinhardtAppStatus` struct) for compile-time safety.

## How Was This Tested?

- `cargo check --workspace --all --all-features` passes
- `cargo nextest run -p nuages-operator` — all 10 tests pass
- `cargo fmt --check` — no formatting issues
- `cargo clippy -p nuages-operator --all-features -- -D warnings` — no warnings

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `kubernetes` - Kubernetes resources, controllers, operators

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)