### PR TITLE
test(operator): add unit tests for reconciler core functions

### DIFF
--- a/crates/nuages-operator/Cargo.toml
+++ b/crates/nuages-operator/Cargo.toml
@@ -22,6 +22,9 @@ anyhow = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }
+tower = "0.5"
+http = "1"
+http-body-util = "0.1"
 
 [lints]
 workspace = true

--- a/crates/nuages-operator/src/reconciler.rs
+++ b/crates/nuages-operator/src/reconciler.rs
@@ -454,20 +454,36 @@ mod tests {
 
 	// ── error_policy tests ───────────────────────────────────────────
 
+	/// Creates a `kube::Client` backed by a dummy service for unit tests.
+	///
+	/// The returned client will never be used for real API calls; it only
+	/// satisfies the type signature of `error_policy`.
+	fn dummy_client() -> Client {
+		use http::Response;
+		use http_body_util::Empty;
+		use tower::service_fn;
+
+		let svc = service_fn(|_req: http::Request<kube::client::Body>| async {
+			Ok::<_, std::convert::Infallible>(Response::builder().body(Empty::new()).unwrap())
+		});
+		Client::new(svc, "default")
+	}
+
 	#[rstest]
-	fn test_error_policy_returns_requeue_action() {
+	#[tokio::test]
+	async fn test_error_policy_returns_requeue_action() {
 		// Arrange
-		// error_policy ignores both obj and ctx, but the type system requires
-		// them.  kube::Client cannot be constructed without a cluster, so we
-		// verify the expected Action structure via Debug output instead.
-		let _app = Arc::new(make_test_app("error-app"));
-		let _error = Error::MissingNamespace("error-app".to_string());
+		let app = Arc::new(make_test_app("error-app"));
+		let error = Error::MissingNamespace("error-app".to_string());
+		let ctx = Arc::new(Context {
+			client: dummy_client(),
+		});
 
 		// Act
-		let expected = Action::requeue(Duration::from_secs(30));
+		let action = error_policy(app, &error, ctx);
 
-		// Assert — confirm the requeue duration matches error_policy's constant
-		let debug_repr = format!("{expected:?}");
-		assert!(debug_repr.contains("30"));
+		// Assert — error_policy must return a 30-second requeue
+		let expected = Action::requeue(Duration::from_secs(30));
+		assert_eq!(format!("{action:?}"), format!("{expected:?}"));
 	}
 }


### PR DESCRIPTION
## Summary

- Extract `build_status()` pure function from `update_status()` for testability
- Add 7 unit tests for `build_status()` covering phase, conditions, transition time
- Add 1 unit test for `error_policy()` verifying requeue behavior

## Type of Change

- [x] Code quality improvements
- [x] Refactoring (code change that neither fixes a bug nor adds a feature)

## Motivation and Context

The reconciler's core logic (status building, error policy) lacked unit test coverage. Extracting the pure status-building logic from `update_status()` enables thorough testing without requiring a Kubernetes cluster.

Fixes #29

Related to: #28

## How Was This Tested?

- `cargo nextest run --package nuages-operator --all-features` — all 25 tests pass
- `cargo clippy --package nuages-operator --all-features -- -D warnings` — no warnings

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label (select one)
- [x] `code-quality` - Code quality improvements

### Scope Label (select all that apply)
- [x] `kubernetes` - Kubernetes resources, controllers, operators

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)