### PR TITLE
fix(ci): handle 404 errors when listing workflow runs

### DIFF
--- a/.github/workflows/cancel-on-pr-close.yml
+++ b/.github/workflows/cancel-on-pr-close.yml
@@ -26,11 +26,17 @@ jobs:
             const cancelledRunIds = [];
 
             for (const wf of targetWorkflows) {
-              const { data } = await github.rest.actions.listWorkflowRuns({
-                owner, repo,
-                workflow_id: wf,
-                branch,
-              });
+              let data;
+              try {
+                ({ data } = await github.rest.actions.listWorkflowRuns({
+                  owner, repo,
+                  workflow_id: wf,
+                  branch,
+                }));
+              } catch (e) {
+                console.log(`Skipping ${wf}: ${e.message}`);
+                continue;
+              }
 
               const staleRuns = data.workflow_runs.filter(r =>
                 r.status !== 'completed'


### PR DESCRIPTION
## Summary

This PR addresses:

- Fix the `cancel-on-pr-close` workflow crashing when `listWorkflowRuns` API returns 404 for unrecognized workflows (e.g. `coverage.yml` not yet registered with GitHub Actions API)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

The `cancel-on-pr-close.yml` workflow iterates over `targetWorkflows = ['ci.yml', 'coverage.yml']` and calls `listWorkflowRuns` for each. When a workflow file is not recognized by the GitHub Actions API (e.g. it has never run on the default branch), the API returns a 404 error. The script had no error handling around this call, causing the entire job to fail with an unhandled `HttpError: Not Found`.

This was observed in PR #82: https://github.com/kent8192/reinhardt-nuages/actions/runs/23201122942/job/67423414655

## How Was This Tested?

- Verified the fix logic by reviewing the error path: the `listWorkflowRuns` call is now wrapped in try-catch, logging a skip message and continuing to the next workflow on 404

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)