### PR TITLE
docs: add SECURITY.md vulnerability disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,69 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| --- | --- |
+| Latest on `feature/platform-basis` | :white_check_mark: |
+| Older releases | :x: |
+
+## Reporting a Vulnerability
+
+**Please do NOT report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them via [GitHub Security Advisories](https://github.com/kent8192/nuages/security/advisories/new).
+
+### What to Include
+
+When reporting a vulnerability, please include:
+
+- A description of the vulnerability
+- Steps to reproduce the issue
+- Potential impact of the vulnerability
+- Any suggested fixes (if available)
+
+### Response Timeline
+
+- **Acknowledgment**: Within 48 hours of report submission
+- **Triage**: Within 7 days, we will assess severity and impact
+- **Fix**: Critical vulnerabilities will be addressed within 30 days
+
+### Severity Classification
+
+| Severity | Description | Target Resolution |
+| --- | --- | --- |
+| Critical | Remote code execution, authentication bypass, data exposure | 30 days |
+| High | Privilege escalation, significant data leaks | 60 days |
+| Medium | Limited impact vulnerabilities | 90 days |
+| Low | Minor issues, hardening suggestions | Next release |
+
+## Scope
+
+The following are in scope for security reports:
+
+- The Nuages application and its dependencies
+- Authentication and authorization mechanisms
+- API endpoint security
+- Kubernetes operator security (CRD handling, RBAC)
+- CI/CD pipeline security
+
+The following are out of scope:
+
+- Third-party services not maintained by this project
+- Issues in upstream dependencies (report to the respective project)
+- Social engineering attacks
+
+## Safe Harbor
+
+We support safe harbor for security researchers who:
+
+- Make a good faith effort to avoid privacy violations, data destruction, and service disruption
+- Only interact with accounts you own or with explicit permission from the account holder
+- Do not exploit a security issue for purposes beyond what is necessary to demonstrate the vulnerability
+- Report vulnerabilities promptly and provide sufficient detail
+
+We will not pursue legal action against researchers who follow these guidelines.
+
+## Contact
+
+For security-related inquiries, use [GitHub Security Advisories](https://github.com/kent8192/nuages/security/advisories/new).


### PR DESCRIPTION
## Summary

- Add `SECURITY.md` with structured vulnerability disclosure policy

This PR addresses:

- Provide clear guidance for reporting security vulnerabilities via GitHub Security Advisories

## Type of Change

- [x] Documentation update

## Motivation and Context

The project needs a formal security policy to guide researchers and users on how to responsibly disclose vulnerabilities. This follows GitHub's recommended practice of including a `SECURITY.md` at the repository root.

Fixes #6

## How Was This Tested?

- Verified Markdown renders correctly
- Confirmed all GitHub Security Advisories links are valid

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings

## Related Issues

- Fixes #6

## Labels to Apply

### Type Label (select one)
- [x] `documentation` - Documentation update

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)