### PR TITLE
fix(auth): use JWT claims for is_staff/is_superuser instead of route-based inference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5438,7 +5438,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "reinhardt-admin"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5450,7 +5450,6 @@ dependencies = [
  "dashmap",
  "futures",
  "getrandom 0.3.4",
- "gloo-net",
  "hyper",
  "inventory",
  "js-sys",
@@ -5490,7 +5489,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-apps"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5520,7 +5519,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-auth"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5540,6 +5539,7 @@ dependencies = [
  "password-hash",
  "rand 0.9.2",
  "reinhardt-apps",
+ "reinhardt-auth-macros",
  "reinhardt-core",
  "reinhardt-db",
  "reinhardt-di",
@@ -5559,6 +5559,17 @@ dependencies = [
  "unicode-normalization",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "reinhardt-auth-macros"
+version = "0.1.0-rc.15"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "winnow",
 ]
 
 [[package]]
@@ -5689,7 +5700,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-commands"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5745,7 +5756,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-conf"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "chrono",
  "dotenv",
@@ -5754,6 +5765,7 @@ dependencies = [
  "percent-encoding",
  "regex",
  "reinhardt-core",
+ "reinhardt-macros",
  "reinhardt-utils",
  "secrecy",
  "serde",
@@ -5770,7 +5782,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-core"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -5817,7 +5829,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-db"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -5872,7 +5884,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-di"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -5894,7 +5906,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-forms"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -5911,7 +5923,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-http"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5932,7 +5944,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-macros"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "ctor",
  "inventory",
@@ -5946,7 +5958,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-mail"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5967,7 +5979,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-manouche"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "aquamarine",
  "convert_case",
@@ -5980,7 +5992,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-middleware"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6015,7 +6027,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-openapi"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "async-trait",
  "reinhardt-http",
@@ -6027,7 +6039,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-openapi-macros"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6038,13 +6050,12 @@ dependencies = [
 [[package]]
 name = "reinhardt-pages"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "aquamarine",
  "async-trait",
  "cfg_aliases",
  "getrandom 0.3.4",
- "gloo-net",
  "hyper",
  "js-sys",
  "proc-macro2",
@@ -6060,6 +6071,7 @@ dependencies = [
  "reinhardt-server",
  "reinhardt-urls",
  "reinhardt-utils",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -6077,7 +6089,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-pages-ast"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "aquamarine",
  "convert_case",
@@ -6091,14 +6103,13 @@ dependencies = [
 [[package]]
 name = "reinhardt-pages-macros"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "convert_case",
  "darling 0.20.11",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "reinhardt-core",
  "reinhardt-manouche",
  "syn 2.0.117",
 ]
@@ -6106,7 +6117,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-query"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -6120,7 +6131,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-query-macros"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -6131,7 +6142,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-rest"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6180,7 +6191,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-routers-macros"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6190,7 +6201,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-server"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6209,7 +6220,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-shortcuts"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "bytes",
  "hyper",
@@ -6227,10 +6238,11 @@ dependencies = [
 [[package]]
 name = "reinhardt-test"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "reinhardt-auth",
  "reinhardt-conf",
+ "reinhardt-core",
  "reinhardt-db",
  "reinhardt-pages",
  "reinhardt-query",
@@ -6245,7 +6257,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-testkit"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "async-dropper",
  "async-trait",
@@ -6296,7 +6308,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-throttling"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -6307,7 +6319,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-urls"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -6339,7 +6351,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-utils"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6375,7 +6387,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-views"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6411,7 +6423,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-web"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6450,7 +6462,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-websockets"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#7790c5ae7e85141cc7883564c00cfff551a6ab20"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/dashboard/src/apps/auth/services/session.rs
+++ b/dashboard/src/apps/auth/services/session.rs
@@ -15,8 +15,13 @@ const SESSION_COOKIE_NAME: &str = "reinhardt_cloud_session";
 /// functions that return the token in the response body.
 pub fn create_session_token(user: &User) -> Result<String, String> {
 	let auth = JwtAuth::new(jwt_secret().map_err(|e| e.to_string())?.as_bytes());
-	auth.generate_token(user.id().to_string(), user.get_username().to_string())
-		.map_err(|e| format!("Failed to generate session token: {e}"))
+	auth.generate_token(
+		user.id().to_string(),
+		user.get_username().to_string(),
+		user.is_staff,
+		user.is_superuser,
+	)
+	.map_err(|e| format!("Failed to generate session token: {e}"))
 }
 
 /// Session cookie max-age in seconds (24 hours, matches JWT expiry).

--- a/dashboard/src/config/middleware/jwt_auth.rs
+++ b/dashboard/src/config/middleware/jwt_auth.rs
@@ -43,16 +43,8 @@ impl Middleware for JwtAuthMiddleware {
 			if let Ok(claims) = auth.verify_token(token)
 				&& !claims.is_expired()
 			{
-				// Admin routes set is_staff=true and is_superuser=true because
-				// admin_login already verified staff status before issuing the
-				// JWT. API routes cannot infer staff status from the JWT sub
-				// claim alone.
-				let (staff, superuser) = if is_admin {
-					(true, true)
-				} else {
-					(false, true)
-				};
-				let auth_state = AuthState::authenticated(&claims.sub, staff, superuser);
+				let auth_state =
+					AuthState::authenticated(&claims.sub, claims.is_staff, claims.is_superuser);
 				request.extensions.insert(auth_state);
 			} else if !is_admin {
 				// Token present but invalid — reject for API routes only.


### PR DESCRIPTION
## Summary

- Remove hardcoded `is_staff`/`is_superuser` inference based on admin vs API route detection in `JwtAuthMiddleware`
- Read `claims.is_staff` and `claims.is_superuser` directly from JWT token, enabled by reinhardt-web#3298 and reinhardt-web#3300
- Update `create_session_token()` to pass `is_staff` and `is_superuser` to `generate_token()` per the new API signature
- Update `Cargo.lock` to latest reinhardt-web main (includes #3298, #3300, #3313, #3317-#3326)

## Test plan

- [x] `cargo check --workspace --all-features` passes
- [x] `cargo clippy --workspace --all-features -- -D warnings` passes
- [x] `cargo fmt -- --check` passes
- [x] Verified JWT token contains `is_staff`/`is_superuser` fields via curl (register endpoint)
- [x] Verified authenticated API requests work correctly with JWT claims-based auth (clusters endpoint)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)