### PR TITLE
fix(dashboard): update UnoCSS CDN and reinhardt-web for WASM admin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5404,7 +5404,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "reinhardt-admin"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5455,7 +5455,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-apps"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5485,7 +5485,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-auth"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5530,7 +5530,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-auth-macros"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5666,7 +5666,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-commands"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5722,7 +5722,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-conf"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "chrono",
  "dotenv",
@@ -5748,7 +5748,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-core"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -5795,7 +5795,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-db"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -5850,7 +5850,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-di"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -5872,7 +5872,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-forms"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -5889,7 +5889,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-http"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5910,7 +5910,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-macros"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "ctor",
  "inventory",
@@ -5924,7 +5924,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-mail"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5945,7 +5945,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-manouche"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "aquamarine",
  "convert_case",
@@ -5958,7 +5958,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-middleware"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5993,7 +5993,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-openapi"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "async-trait",
  "reinhardt-http",
@@ -6005,7 +6005,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-openapi-macros"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6016,7 +6016,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-pages"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "aquamarine",
  "async-trait",
@@ -6055,7 +6055,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-pages-ast"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "aquamarine",
  "convert_case",
@@ -6069,7 +6069,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-pages-macros"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "convert_case",
  "darling 0.20.11",
@@ -6083,7 +6083,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-query"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -6097,7 +6097,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-query-macros"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -6108,7 +6108,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-rest"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6157,7 +6157,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-routers-macros"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6167,7 +6167,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-server"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6186,7 +6186,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-shortcuts"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "bytes",
  "hyper",
@@ -6204,7 +6204,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-test"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "reinhardt-auth",
  "reinhardt-conf",
@@ -6223,7 +6223,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-testkit"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "async-dropper",
  "async-trait",
@@ -6274,7 +6274,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-throttling"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -6285,7 +6285,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-urls"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -6317,7 +6317,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-utils"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6353,7 +6353,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-views"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6389,7 +6389,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-web"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6428,7 +6428,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-websockets"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2e1f5d76e02c9da6392ad8816c22ca3ffd689a57"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#5764652abf52b1c1860a83113eedbbd9c9be4672"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -4,7 +4,7 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Reinhardt Cloud — Dashboard</title>
-	<script src="https://cdn.jsdelivr.net/npm/@unocss/runtime@0.65.5" integrity="sha384-TKS6hgIe4ZXMc6lVKEdgeIhmGzmiMJi72GKEh6GnQudXV2n+x6zUtb2e1RZvvaPF" crossorigin="anonymous"></script>
+	<script src="https://cdn.jsdelivr.net/npm/@unocss/runtime@66.6.7/uno.global.js" integrity="sha384-AO39wtQWix8ti0gjIXwhJ2rkQmmFJS5sUUSS6qmWUd/m/7PpY450fgUBBKUcXNvC" crossorigin="anonymous"></script>
 	<style>
 		[un-cloak] { display: none; }
 		body { margin: 0; font-family: system-ui, -apple-system, sans-serif; }


### PR DESCRIPTION
## Summary

- Update UnoCSS runtime CDN from `@0.65.5` (404) to `@66.6.7` with SRI integrity hash
- Update `Cargo.lock` to latest reinhardt-web main (5764652a) including:
  - #3329: `server_fn` reqwest re-export via `__private` module (removes need for direct reqwest dependency)
  - #3329: `page!` macro `#[allow(unused_variables)]` for event handler params

## Context

UnoCSS `@0.65.5` returns 404 from jsdelivr CDN, causing the `[un-cloak] { display: none }` CSS rule to hide the entire WASM SPA body. This made the admin panel appear blank despite WASM loading and rendering correctly.

## Test plan

- [x] `cargo check --workspace --all-features` passes
- [x] `cargo nextest run -p reinhardt-cloud-dashboard --all-features` — 62 tests passed
- [x] WASM build via `--with-pages` succeeds
- [x] Login page renders correctly in browser (Playwright verified)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)