### PR TITLE
fix(ci): add settings setup to coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -80,6 +80,11 @@ jobs:
         with:
           tool: nextest
 
+      - name: Setup application settings
+        run: |
+          cp dashboard/settings/base.example.toml dashboard/settings/base.toml
+          cp dashboard/settings/ci.example.toml dashboard/settings/ci.toml
+
       - name: Clean coverage artifacts
         run: |
           cargo llvm-cov clean --workspace
@@ -93,6 +98,7 @@ jobs:
             --all-features \
             --no-fail-fast
         env:
+          REINHARDT_ENV: ci
           REINHARDT_CLOUD_JWT_SECRET: "ci-test-secret-minimum-32-bytes-long!!"
 
       - name: Generate coverage report


### PR DESCRIPTION
## Summary

- Add missing `Setup application settings` step to coverage.yml (copy example TOML files)
- Add `REINHARDT_ENV: ci` env var to coverage test execution

## Root cause

The coverage workflow was missing two things that the test workflow (`test.yml`) has:
1. **Settings file setup**: `base.toml` and `local.toml` are `.gitignored` (they contain environment-specific values). The test workflow copies from `*.example.toml`, but coverage didn't
2. **Environment profile**: Without `REINHARDT_ENV=ci`, the default `local` profile is used, which expects `local.toml` — also absent in clean CI checkouts

This caused `build_composed()` to panic with `MissingRequiredField { section: "core", field: "secret_key" }` for all 7 dashboard settings tests, which then prevented `cargo llvm-cov report` from generating `/tmp/codecov.json`.

## Test plan

- [ ] CI coverage job passes (settings tests no longer panic)
- [ ] Codecov report uploads successfully

Fixes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)