### PR TITLE
test: add comprehensive test coverage for dashboard apps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,6 +826,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bit_field"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3061,7 +3076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
 dependencies = [
  "byteorder-lite",
- "quick-error",
+ "quick-error 2.0.1",
 ]
 
 [[package]]
@@ -4898,6 +4913,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.11.0",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax 0.8.10",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5030,6 +5064,12 @@ checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-error"
@@ -5213,6 +5253,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rav1e"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5256,7 +5305,7 @@ dependencies = [
  "avif-serialize",
  "imgref",
  "loop9",
- "quick-error",
+ "quick-error 2.0.1",
  "rav1e",
  "rayon",
  "rgb",
@@ -5676,6 +5725,7 @@ dependencies = [
  "gloo-timers",
  "inventory",
  "js-sys",
+ "proptest",
  "reinhardt-cloud-core",
  "reinhardt-cloud-k8s",
  "reinhardt-cloud-types",
@@ -6947,6 +6997,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8011,7 +8073,7 @@ dependencies = [
  "fax",
  "flate2",
  "half",
- "quick-error",
+ "quick-error 2.0.1",
  "weezl",
  "zune-jpeg",
 ]
@@ -8547,6 +8609,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8803,6 +8871,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/dashboard/Cargo.toml
+++ b/dashboard/Cargo.toml
@@ -53,6 +53,7 @@ cfg_aliases = "0.2"
 rstest = { workspace = true }
 serial_test = "3.2"
 anyhow = { workspace = true }
+proptest = "1.4"
 
 [lints]
 workspace = true

--- a/dashboard/src/apps/auth/tests.rs
+++ b/dashboard/src/apps/auth/tests.rs
@@ -1,8 +1,16 @@
 //! Tests for auth app.
 
 pub mod e2e {
+	pub mod test_auth_error_paths;
 	pub mod test_register_login;
 }
 pub mod unit {
+	pub mod test_auth_property;
 	pub mod test_jwt;
+	pub mod test_serializer_validation;
+	pub mod test_session_service;
+	pub mod test_user_model;
+}
+pub mod integration {
+	pub mod test_credential_service;
 }

--- a/dashboard/src/apps/auth/tests/e2e/test_auth_error_paths.rs
+++ b/dashboard/src/apps/auth/tests/e2e/test_auth_error_paths.rs
@@ -1,0 +1,351 @@
+//! End-to-end tests for auth error paths.
+
+#[cfg(test)]
+mod tests {
+	use reinhardt::db::orm::{FilterOperator, FilterValue, Model};
+	use reinhardt::prelude::DatabaseConnection;
+	use reinhardt::test::APIClient;
+	use reinhardt::test::fixtures::TestServerGuard;
+	use reinhardt::test::fixtures::{ContainerAsync, GenericImage, api_client_from_url};
+	use reinhardt::test::fixtures::{postgres_with_migrations_from_dir, test_server_guard};
+	use rstest::*;
+	use serde_json::json;
+	use serial_test::serial;
+	use std::sync::Arc;
+
+	use crate::apps::auth::models::User;
+	use crate::routes;
+
+	#[fixture]
+	async fn test_app() -> (
+		ContainerAsync<GenericImage>,
+		Arc<DatabaseConnection>,
+		TestServerGuard,
+		APIClient,
+	) {
+		// Arrange — set required environment variable for JWT secret
+		unsafe {
+			std::env::set_var(
+				"REINHARDT_CLOUD_JWT_SECRET",
+				"test-secret-minimum-32-bytes-long!!",
+			);
+		}
+		let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
+		let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
+			.await
+			.expect("Failed to start PostgreSQL with migrations");
+		let router = routes().into_server();
+		let server = test_server_guard(router).await;
+		let client = api_client_from_url(&server.url);
+		(container, conn, server, client)
+	}
+
+	/// Login with a non-existent user should not return 200.
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_login_nonexistent_user_returns_401(
+		#[future] test_app: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			TestServerGuard,
+			APIClient,
+		),
+	) {
+		// Arrange
+		let (_container, _conn, _server, client) = test_app.await;
+		let login_data = json!({
+			"username": "ghost_user",
+			"password": "doesnotmatter"
+		});
+
+		// Act
+		let response = client
+			.post("/api/auth/login/", &login_data, "json")
+			.await
+			.expect("Login request failed");
+
+		// Assert
+		assert_ne!(response.status_code(), 200);
+		let body: serde_json::Value = response.json().expect("Failed to parse JSON response");
+		assert!(
+			body.get("error").is_some() || body.get("detail").is_some(),
+			"Error response should contain 'error' or 'detail' field, got: {body}"
+		);
+	}
+
+	/// Login with empty JSON body should return 422 (validation error).
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_login_empty_body_returns_422(
+		#[future] test_app: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			TestServerGuard,
+			APIClient,
+		),
+	) {
+		// Arrange
+		let (_container, _conn, _server, client) = test_app.await;
+		let empty_body = json!({});
+
+		// Act
+		let response = client
+			.post("/api/auth/login/", &empty_body, "json")
+			.await
+			.expect("Login request failed");
+
+		// Assert
+		assert_eq!(response.status_code(), 400);
+	}
+
+	/// Register with empty JSON body should return 400 (validation error).
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_register_empty_body_returns_422(
+		#[future] test_app: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			TestServerGuard,
+			APIClient,
+		),
+	) {
+		// Arrange
+		let (_container, _conn, _server, client) = test_app.await;
+		let empty_body = json!({});
+
+		// Act
+		let response = client
+			.post("/api/auth/register/", &empty_body, "json")
+			.await
+			.expect("Register request failed");
+
+		// Assert
+		assert_eq!(response.status_code(), 400);
+	}
+
+	/// Registering with a duplicate username (different email) should return 409.
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_register_duplicate_username_returns_conflict(
+		#[future] test_app: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			TestServerGuard,
+			APIClient,
+		),
+	) {
+		// Arrange — register first user
+		let (_container, _conn, _server, client) = test_app.await;
+		let first_user = json!({
+			"username": "dupeuser",
+			"email": "dupe1@example.com",
+			"password": "securepassword"
+		});
+		let first_response = client
+			.post("/api/auth/register/", &first_user, "json")
+			.await
+			.expect("First register request failed");
+		assert_eq!(first_response.status_code(), 201);
+
+		// Act — register second user with same username but different email
+		let second_user = json!({
+			"username": "dupeuser",
+			"email": "dupe2@example.com",
+			"password": "securepassword"
+		});
+		let response = client
+			.post("/api/auth/register/", &second_user, "json")
+			.await
+			.expect("Second register request failed");
+
+		// Assert
+		assert_eq!(response.status_code(), 409);
+		let body: serde_json::Value = response.json().expect("Failed to parse JSON response");
+		assert_eq!(body["detail"], "Username already exists");
+	}
+
+	/// Login with an inactive user should not return 200.
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_login_inactive_user_returns_401(
+		#[future] test_app: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			TestServerGuard,
+			APIClient,
+		),
+	) {
+		// Arrange — register a user
+		let (_container, conn, _server, client) = test_app.await;
+		let register_data = json!({
+			"username": "inactiveuser",
+			"email": "inactive@example.com",
+			"password": "securepassword"
+		});
+		let reg_response = client
+			.post("/api/auth/register/", &register_data, "json")
+			.await
+			.expect("Register request failed");
+		assert_eq!(reg_response.status_code(), 201);
+
+		// Deactivate the user via ORM
+		let mut user = User::objects()
+			.filter(
+				User::field_username(),
+				FilterOperator::Eq,
+				FilterValue::String("inactiveuser".to_string()),
+			)
+			.first_with_db(&conn)
+			.await
+			.expect("Failed to query user")
+			.expect("User should exist after registration");
+		user.is_active = false;
+		User::objects()
+			.update_with_conn(&conn, &user)
+			.await
+			.expect("Failed to deactivate user");
+
+		// Act — login with deactivated user
+		let login_data = json!({
+			"username": "inactiveuser",
+			"password": "securepassword"
+		});
+		let response = client
+			.post("/api/auth/login/", &login_data, "json")
+			.await
+			.expect("Login request failed");
+
+		// Assert
+		assert_ne!(
+			response.status_code(),
+			200,
+			"Inactive user login should not return 200"
+		);
+	}
+
+	/// Register response token should be a non-empty JWT (has 2 dots, length > 20).
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_register_response_token_is_nonempty_jwt(
+		#[future] test_app: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			TestServerGuard,
+			APIClient,
+		),
+	) {
+		// Arrange
+		let (_container, _conn, _server, client) = test_app.await;
+		let register_data = json!({
+			"username": "jwtcheckuser",
+			"email": "jwtcheck@example.com",
+			"password": "securepassword"
+		});
+
+		// Act
+		let response = client
+			.post("/api/auth/register/", &register_data, "json")
+			.await
+			.expect("Register request failed");
+
+		// Assert
+		assert_eq!(response.status_code(), 201);
+		let body: serde_json::Value = response.json().expect("Failed to parse JSON response");
+		let token = body["token"].as_str().expect("token should be a string");
+		let dot_count = token.chars().filter(|&c| c == '.').count();
+		assert_eq!(dot_count, 2, "JWT should have exactly 2 dots");
+		assert!(token.len() > 20, "JWT should be longer than 20 chars");
+	}
+
+	/// Login response token should be a non-empty JWT (has 2 dots, length > 20).
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_login_response_token_is_nonempty_jwt(
+		#[future] test_app: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			TestServerGuard,
+			APIClient,
+		),
+	) {
+		// Arrange — register user first
+		let (_container, _conn, _server, client) = test_app.await;
+		let register_data = json!({
+			"username": "loginjwtuser",
+			"email": "loginjwt@example.com",
+			"password": "securepassword"
+		});
+		client
+			.post("/api/auth/register/", &register_data, "json")
+			.await
+			.expect("Register request failed");
+
+		// Act — login
+		let login_data = json!({
+			"username": "loginjwtuser",
+			"password": "securepassword"
+		});
+		let response = client
+			.post("/api/auth/login/", &login_data, "json")
+			.await
+			.expect("Login request failed");
+
+		// Assert
+		assert_eq!(response.status_code(), 200);
+		let body: serde_json::Value = response.json().expect("Failed to parse JSON response");
+		let token = body["token"].as_str().expect("token should be a string");
+		let dot_count = token.chars().filter(|&c| c == '.').count();
+		assert_eq!(dot_count, 2, "JWT should have exactly 2 dots");
+		assert!(token.len() > 20, "JWT should be longer than 20 chars");
+	}
+
+	/// Register with whitespace-padded username should be trimmed; login with trimmed name succeeds.
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_register_whitespace_username_trimmed(
+		#[future] test_app: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			TestServerGuard,
+			APIClient,
+		),
+	) {
+		// Arrange
+		let (_container, _conn, _server, client) = test_app.await;
+		let register_data = json!({
+			"username": "  trimuser  ",
+			"email": "trim@example.com",
+			"password": "securepassword"
+		});
+		let reg_response = client
+			.post("/api/auth/register/", &register_data, "json")
+			.await
+			.expect("Register request failed");
+		assert_eq!(reg_response.status_code(), 201);
+
+		// Act — login with trimmed username
+		let login_data = json!({
+			"username": "trimuser",
+			"password": "securepassword"
+		});
+		let response = client
+			.post("/api/auth/login/", &login_data, "json")
+			.await
+			.expect("Login request failed");
+
+		// Assert
+		assert_eq!(
+			response.status_code(),
+			200,
+			"Login with trimmed username should succeed"
+		);
+	}
+}

--- a/dashboard/src/apps/auth/tests/integration/test_credential_service.rs
+++ b/dashboard/src/apps/auth/tests/integration/test_credential_service.rs
@@ -1,0 +1,216 @@
+//! Integration tests for credential verification service.
+
+#[cfg(test)]
+mod tests {
+	use reinhardt::db::orm::{FilterOperator, FilterValue, Model};
+	use reinhardt::prelude::DatabaseConnection;
+	use reinhardt::test::APIClient;
+	use reinhardt::test::fixtures::TestServerGuard;
+	use reinhardt::test::fixtures::{ContainerAsync, GenericImage, api_client_from_url};
+	use reinhardt::test::fixtures::{postgres_with_migrations_from_dir, test_server_guard};
+	use rstest::*;
+	use serde_json::json;
+	use serial_test::serial;
+	use std::sync::Arc;
+
+	use crate::apps::auth::models::User;
+	use crate::apps::auth::services::credentials::verify_credentials;
+	use crate::routes;
+
+	#[fixture]
+	async fn test_app() -> (
+		ContainerAsync<GenericImage>,
+		Arc<DatabaseConnection>,
+		TestServerGuard,
+		APIClient,
+	) {
+		// Arrange — set required environment variable for JWT secret
+		unsafe {
+			std::env::set_var(
+				"REINHARDT_CLOUD_JWT_SECRET",
+				"test-secret-minimum-32-bytes-long!!",
+			);
+		}
+		let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
+		let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
+			.await
+			.expect("Failed to start PostgreSQL with migrations");
+		let router = routes().into_server();
+		let server = test_server_guard(router).await;
+		let client = api_client_from_url(&server.url);
+		(container, conn, server, client)
+	}
+
+	/// Helper: register a user via the API.
+	async fn register_user(client: &APIClient, username: &str, email: &str, password: &str) {
+		let data = json!({
+			"username": username,
+			"email": email,
+			"password": password,
+		});
+		let response = client
+			.post("/api/auth/register/", &data, "json")
+			.await
+			.expect("Register request failed");
+		assert_eq!(response.status_code(), 201, "Registration should succeed");
+	}
+
+	/// verify_credentials with correct password returns Ok with matching username.
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_verify_credentials_valid_user(
+		#[future] test_app: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			TestServerGuard,
+			APIClient,
+		),
+	) {
+		// Arrange
+		let (_container, _conn, _server, client) = test_app.await;
+		register_user(&client, "creduser", "cred@example.com", "securepassword").await;
+
+		// Act
+		let result = verify_credentials("creduser", "securepassword").await;
+
+		// Assert
+		let user = result.expect("verify_credentials should succeed for valid user");
+		assert_eq!(user.username, "creduser");
+	}
+
+	/// verify_credentials with wrong password returns Err.
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_verify_credentials_wrong_password(
+		#[future] test_app: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			TestServerGuard,
+			APIClient,
+		),
+	) {
+		// Arrange
+		let (_container, _conn, _server, client) = test_app.await;
+		register_user(
+			&client,
+			"wrongpwuser",
+			"wrongpw@example.com",
+			"correctpassword",
+		)
+		.await;
+
+		// Act
+		let result = verify_credentials("wrongpwuser", "incorrectpassword").await;
+
+		// Assert
+		assert!(
+			result.is_err(),
+			"verify_credentials should fail with wrong password"
+		);
+	}
+
+	/// verify_credentials for non-existent user returns Err.
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_verify_credentials_nonexistent_user(
+		#[future] test_app: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			TestServerGuard,
+			APIClient,
+		),
+	) {
+		// Arrange
+		let (_container, _conn, _server, _client) = test_app.await;
+
+		// Act
+		let result = verify_credentials("ghost", "pw").await;
+
+		// Assert
+		assert!(
+			result.is_err(),
+			"verify_credentials should fail for non-existent user"
+		);
+	}
+
+	/// verify_credentials for inactive user returns Err.
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_verify_credentials_inactive_user(
+		#[future] test_app: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			TestServerGuard,
+			APIClient,
+		),
+	) {
+		// Arrange — register user then deactivate via ORM
+		let (_container, conn, _server, client) = test_app.await;
+		register_user(
+			&client,
+			"inactivecred",
+			"inactivecred@example.com",
+			"securepassword",
+		)
+		.await;
+
+		let mut user = User::objects()
+			.filter(
+				User::field_username(),
+				FilterOperator::Eq,
+				FilterValue::String("inactivecred".to_string()),
+			)
+			.first_with_db(&conn)
+			.await
+			.expect("Failed to query user")
+			.expect("User should exist after registration");
+		user.is_active = false;
+		User::objects()
+			.update_with_conn(&conn, &user)
+			.await
+			.expect("Failed to deactivate user");
+
+		// Act
+		let result = verify_credentials("inactivecred", "securepassword").await;
+
+		// Assert
+		assert!(
+			result.is_err(),
+			"verify_credentials should fail for inactive user"
+		);
+	}
+
+	/// verify_credentials should trim whitespace from username.
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_verify_credentials_whitespace_trimmed(
+		#[future] test_app: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			TestServerGuard,
+			APIClient,
+		),
+	) {
+		// Arrange
+		let (_container, _conn, _server, client) = test_app.await;
+		register_user(
+			&client,
+			"trimcreduser",
+			"trimcred@example.com",
+			"securepassword",
+		)
+		.await;
+
+		// Act — pass username with surrounding whitespace
+		let result = verify_credentials(" trimcreduser ", "securepassword").await;
+
+		// Assert
+		let user = result.expect("verify_credentials should trim whitespace from username");
+		assert_eq!(user.username, "trimcreduser");
+	}
+}

--- a/dashboard/src/apps/auth/tests/unit/test_auth_property.rs
+++ b/dashboard/src/apps/auth/tests/unit/test_auth_property.rs
@@ -1,0 +1,105 @@
+//! Property-based tests for auth components.
+
+#[cfg(test)]
+mod tests {
+	use proptest::prelude::*;
+	use reinhardt::{BaseUser, JwtAuth};
+	use uuid::Uuid;
+
+	use crate::apps::auth::models::User;
+	use crate::apps::auth::serializers::TokenResponse;
+	use crate::apps::auth::services::session::validate_raw_token;
+
+	proptest! {
+		/// Any valid UUID + alphanumeric username should roundtrip through JWT.
+		#[test]
+		fn test_jwt_roundtrip_any_uuid_username(
+			username in "[a-zA-Z0-9]{1,32}"
+		) {
+			// Arrange
+			let secret = b"proptest-secret-minimum-32-bytes!!";
+			let auth = JwtAuth::new(secret);
+			let user_id = Uuid::new_v4().to_string();
+
+			// Act
+			let token = auth
+				.generate_token(user_id.clone(), username.clone(), false, false)
+				.unwrap();
+			let claims = auth.verify_token(&token).unwrap();
+
+			// Assert
+			prop_assert_eq!(&claims.sub, &user_id);
+			prop_assert_eq!(&claims.username, &username);
+			prop_assert!(!claims.is_expired());
+		}
+
+		/// Any non-empty password should hash and verify correctly.
+		#[test]
+		fn test_password_hash_verify_roundtrip(
+			password in ".{1,64}"
+		) {
+			// Arrange
+			let mut user = User::new(
+				"propuser".to_string(),
+				"prop@example.com".to_string(),
+				String::new(),
+				String::new(),
+				None,
+				true,
+				false,
+				false,
+			);
+
+			// Act
+			user.set_password(&password).unwrap();
+
+			// Assert
+			prop_assert!(user.check_password(&password).unwrap());
+		}
+
+		/// Random strings should never validate as a JWT.
+		#[test]
+		fn test_random_string_never_validates_as_jwt(
+			input in ".*"
+		) {
+			// Arrange
+			unsafe {
+				std::env::set_var(
+					"REINHARDT_CLOUD_JWT_SECRET",
+					"proptest-secret-minimum-32-bytes!!",
+				);
+			}
+
+			// Act
+			let result = validate_raw_token(&input);
+
+			// Assert — random strings should not produce valid claims
+			// (technically a valid JWT could be generated, but the probability is negligible)
+			if let Some((sub, _username)) = result {
+				// If somehow it parses, the sub must be a valid UUID
+				// (our JWT always stores UUID as sub)
+				prop_assert!(
+					Uuid::parse_str(&sub).is_ok(),
+					"If token validates, sub must be a valid UUID"
+				);
+			}
+		}
+
+		/// TokenResponse::bearer should roundtrip through serde.
+		#[test]
+		fn test_token_response_serialization_roundtrip(
+			token_str in "[a-zA-Z0-9._-]{1,200}"
+		) {
+			// Arrange
+			let resp = TokenResponse::bearer(token_str.clone());
+
+			// Act
+			let json = serde_json::to_string(&resp).unwrap();
+			let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+			// Assert
+			prop_assert_eq!(parsed["token"].as_str().unwrap(), token_str.as_str());
+			prop_assert_eq!(parsed["token_type"].as_str().unwrap(), "Bearer");
+		}
+	}
+}

--- a/dashboard/src/apps/auth/tests/unit/test_serializer_validation.rs
+++ b/dashboard/src/apps/auth/tests/unit/test_serializer_validation.rs
@@ -1,0 +1,232 @@
+//! Boundary value analysis and equivalence partitioning tests for auth serializers.
+
+#[cfg(test)]
+mod tests {
+	use reinhardt::Validate;
+	use rstest::rstest;
+
+	use crate::apps::auth::serializers::{LoginRequest, RegisterRequest};
+
+	// --- LoginRequest username boundary ---
+
+	#[rstest]
+	#[case::min_valid("a", true)]
+	#[case::max_valid(&"a".repeat(150), true)]
+	#[case::below_min("", false)]
+	#[case::above_max(&"a".repeat(151), false)]
+	fn test_login_request_username_boundary(#[case] username: &str, #[case] valid: bool) {
+		// Arrange
+		let req: LoginRequest = serde_json::from_value(serde_json::json!({
+			"username": username,
+			"password": "validpass"
+		}))
+		.expect("Failed to deserialize LoginRequest");
+
+		// Act
+		let result = req.validate();
+
+		// Assert
+		assert_eq!(
+			result.is_ok(),
+			valid,
+			"username len={} expected valid={valid}",
+			username.len()
+		);
+	}
+
+	// --- LoginRequest password boundary ---
+
+	#[rstest]
+	#[case::min_valid("p", true)]
+	#[case::max_valid(&"p".repeat(128), true)]
+	#[case::below_min("", false)]
+	#[case::above_max(&"p".repeat(129), false)]
+	fn test_login_request_password_boundary(#[case] password: &str, #[case] valid: bool) {
+		// Arrange
+		let req: LoginRequest = serde_json::from_value(serde_json::json!({
+			"username": "validuser",
+			"password": password
+		}))
+		.expect("Failed to deserialize LoginRequest");
+
+		// Act
+		let result = req.validate();
+
+		// Assert
+		assert_eq!(
+			result.is_ok(),
+			valid,
+			"password len={} expected valid={valid}",
+			password.len()
+		);
+	}
+
+	// --- RegisterRequest username boundary ---
+
+	#[rstest]
+	#[case::min_valid("abc", true)]
+	#[case::max_valid(&"u".repeat(32), true)]
+	#[case::below_min("ab", false)]
+	#[case::above_max(&"u".repeat(33), false)]
+	fn test_register_request_username_boundary(#[case] username: &str, #[case] valid: bool) {
+		// Arrange
+		let req: RegisterRequest = serde_json::from_value(serde_json::json!({
+			"username": username,
+			"email": "test@example.com",
+			"password": "securepassword"
+		}))
+		.expect("Failed to deserialize RegisterRequest");
+
+		// Act
+		let result = req.validate();
+
+		// Assert
+		assert_eq!(
+			result.is_ok(),
+			valid,
+			"username len={} expected valid={valid}",
+			username.len()
+		);
+	}
+
+	// --- RegisterRequest password boundary ---
+
+	#[rstest]
+	#[case::min_valid(&"p".repeat(8), true)]
+	#[case::max_valid(&"p".repeat(128), true)]
+	#[case::below_min(&"p".repeat(7), false)]
+	#[case::above_max(&"p".repeat(129), false)]
+	fn test_register_request_password_boundary(#[case] password: &str, #[case] valid: bool) {
+		// Arrange
+		let req: RegisterRequest = serde_json::from_value(serde_json::json!({
+			"username": "validuser",
+			"email": "test@example.com",
+			"password": password
+		}))
+		.expect("Failed to deserialize RegisterRequest");
+
+		// Act
+		let result = req.validate();
+
+		// Assert
+		assert_eq!(
+			result.is_ok(),
+			valid,
+			"password len={} expected valid={valid}",
+			password.len()
+		);
+	}
+
+	// --- RegisterRequest email max length ---
+
+	#[rstest]
+	#[case::max_valid(254, true)]
+	#[case::above_max(255, false)]
+	fn test_register_request_email_max_length(#[case] length: usize, #[case] valid: bool) {
+		// Arrange — construct email of exact length with valid RFC 5321 format.
+		// Local part max 64 chars, domain labels max 63 chars each.
+		// Format: "user@" + domain padded to fill remaining length
+		let local = "user"; // 4 chars
+		let at = "@"; // 1 char
+		let suffix = ".com"; // 4 chars
+		let domain_body_len = length - local.len() - at.len() - suffix.len();
+		// Build domain body as "aaa...a.bbb...b" with labels <= 63 chars
+		let mut domain_body = String::new();
+		let mut remaining = domain_body_len;
+		while remaining > 0 {
+			if !domain_body.is_empty() {
+				domain_body.push('.');
+				remaining -= 1;
+			}
+			let label_len = remaining.min(63);
+			domain_body.push_str(&"a".repeat(label_len));
+			remaining -= label_len;
+		}
+		let email = format!("{local}{at}{domain_body}{suffix}");
+		assert_eq!(email.len(), length, "constructed email length mismatch");
+
+		let req: RegisterRequest = serde_json::from_value(serde_json::json!({
+			"username": "validuser",
+			"email": email,
+			"password": "securepassword"
+		}))
+		.expect("Failed to deserialize RegisterRequest");
+
+		// Act
+		let result = req.validate();
+
+		// Assert
+		assert_eq!(
+			result.is_ok(),
+			valid,
+			"email len={length} expected valid={valid}"
+		);
+	}
+
+	// --- RegisterRequest email validation ---
+
+	#[rstest]
+	#[case::valid_simple("user@example.com", true)]
+	#[case::valid_subdomain("user@sub.example.com", true)]
+	#[case::valid_plus("user+tag@example.com", true)]
+	#[case::invalid_no_at("userexample.com", false)]
+	#[case::invalid_no_domain("user@", false)]
+	#[case::invalid_double_at("user@@example.com", false)]
+	#[case::invalid_empty("", false)]
+	fn test_register_request_email_validation(#[case] email: &str, #[case] valid: bool) {
+		// Arrange
+		let req: RegisterRequest = serde_json::from_value(serde_json::json!({
+			"username": "validuser",
+			"email": email,
+			"password": "securepassword"
+		}))
+		.expect("Failed to deserialize RegisterRequest");
+
+		// Act
+		let result = req.validate();
+
+		// Assert
+		assert_eq!(
+			result.is_ok(),
+			valid,
+			"email={email:?} expected valid={valid}"
+		);
+	}
+
+	// --- LoginRequest missing fields ---
+
+	#[rstest]
+	#[case::missing_username(serde_json::json!({"password": "pass"}), "username")]
+	#[case::missing_password(serde_json::json!({"username": "user"}), "password")]
+	fn test_login_request_missing_field(#[case] json: serde_json::Value, #[case] field: &str) {
+		// Arrange & Act
+		let result = serde_json::from_value::<LoginRequest>(json);
+
+		// Assert
+		let err = result.expect_err("Should fail to deserialize without required field");
+		let err_msg = err.to_string();
+		assert!(
+			err_msg.contains(field) || err_msg.contains("missing field"),
+			"Error should mention missing field {field:?}, got: {err_msg}"
+		);
+	}
+
+	// --- RegisterRequest missing fields ---
+
+	#[rstest]
+	#[case::missing_username(serde_json::json!({"email": "a@b.com", "password": "securepassword"}), "username")]
+	#[case::missing_email(serde_json::json!({"username": "user", "password": "securepassword"}), "email")]
+	#[case::missing_password(serde_json::json!({"username": "user", "email": "a@b.com"}), "password")]
+	fn test_register_request_missing_field(#[case] json: serde_json::Value, #[case] field: &str) {
+		// Arrange & Act
+		let result = serde_json::from_value::<RegisterRequest>(json);
+
+		// Assert
+		let err = result.expect_err("Should fail to deserialize without required field");
+		let err_msg = err.to_string();
+		assert!(
+			err_msg.contains(field) || err_msg.contains("missing field"),
+			"Error should mention missing field {field:?}, got: {err_msg}"
+		);
+	}
+}

--- a/dashboard/src/apps/auth/tests/unit/test_session_service.rs
+++ b/dashboard/src/apps/auth/tests/unit/test_session_service.rs
@@ -1,0 +1,155 @@
+//! Tests for session token creation and validation.
+
+#[cfg(test)]
+mod tests {
+	use reinhardt::{BaseUser, JwtAuth};
+	use rstest::rstest;
+	use serial_test::serial;
+	use uuid::Uuid;
+
+	use crate::apps::auth::models::User;
+	use crate::apps::auth::services::session::{create_session_token, validate_raw_token};
+
+	/// Retrieve the effective JWT secret used by the session service.
+	///
+	/// The service reads from TOML settings first, then falls back to env var.
+	/// Tests must use the same secret the service will use.
+	fn effective_jwt_secret() -> String {
+		crate::config::settings::get_jwt_secret()
+			.unwrap_or_else(|| "test-secret-minimum-32-bytes-long!!".to_string())
+	}
+
+	/// Helper: set the JWT secret env var used by session service.
+	fn set_jwt_secret(secret: &str) {
+		unsafe {
+			std::env::set_var("REINHARDT_CLOUD_JWT_SECRET", secret);
+		}
+	}
+
+	#[rstest]
+	#[serial(jwt)]
+	fn test_create_session_token_returns_valid_jwt() {
+		// Arrange — ensure env var is set (TOML takes priority if present)
+		set_jwt_secret(&effective_jwt_secret());
+		let mut user = User::new(
+			"sessionuser".to_string(),
+			"session@example.com".to_string(),
+			String::new(),
+			String::new(),
+			None,
+			true,
+			false,
+			false,
+		);
+		user.set_password("password123").unwrap();
+
+		// Act
+		let token = create_session_token(&user).expect("create_session_token should succeed");
+
+		// Assert — validate_raw_token should return matching user info
+		let (user_id, username) = validate_raw_token(&token).expect("Token should be valid");
+		assert_eq!(user_id, user.id().to_string());
+		assert_eq!(username, "sessionuser");
+	}
+
+	#[rstest]
+	#[serial(jwt)]
+	fn test_validate_raw_token_with_valid_token() {
+		// Arrange — use the effective secret (TOML takes priority over env var)
+		let secret = effective_jwt_secret();
+		let user_id = Uuid::new_v4().to_string();
+		let auth = JwtAuth::new(secret.as_bytes());
+		let token = auth
+			.generate_token(user_id.clone(), "manualuser".to_string(), false, false)
+			.expect("Token generation should succeed");
+
+		// Act
+		let result = validate_raw_token(&token);
+
+		// Assert
+		let (sub, username) = result.expect("Valid token should be accepted");
+		assert_eq!(sub, user_id);
+		assert_eq!(username, "manualuser");
+	}
+
+	#[rstest]
+	#[serial(jwt)]
+	fn test_validate_raw_token_empty_string() {
+		// Arrange
+		set_jwt_secret(&effective_jwt_secret());
+
+		// Act
+		let result = validate_raw_token("");
+
+		// Assert
+		assert!(result.is_none(), "Empty string should return None");
+	}
+
+	#[rstest]
+	#[serial(jwt)]
+	fn test_validate_raw_token_garbage() {
+		// Arrange
+		set_jwt_secret(&effective_jwt_secret());
+
+		// Act
+		let result = validate_raw_token("not-a-jwt");
+
+		// Assert
+		assert!(result.is_none(), "Garbage string should return None");
+	}
+
+	#[rstest]
+	#[serial(jwt)]
+	fn test_validate_raw_token_wrong_secret() {
+		// Arrange — generate token with one secret
+		let auth = JwtAuth::new(b"original-secret-at-least-32-bytes!!");
+		let token = auth
+			.generate_token(
+				Uuid::new_v4().to_string(),
+				"wrongsecret".to_string(),
+				false,
+				false,
+			)
+			.expect("Token generation should succeed");
+
+		// Set a different secret in the environment
+		set_jwt_secret("different-secret-at-least-32-bytes!");
+
+		// Act
+		let result = validate_raw_token(&token);
+
+		// Assert
+		assert!(
+			result.is_none(),
+			"Token signed with wrong secret should return None"
+		);
+	}
+
+	#[rstest]
+	#[serial(jwt)]
+	fn test_validate_raw_token_tampered_payload() {
+		// Arrange — generate a valid token, then tamper with the payload segment
+		let secret = effective_jwt_secret();
+		set_jwt_secret(&secret);
+		let auth = JwtAuth::new(secret.as_bytes());
+		let token = auth
+			.generate_token(
+				Uuid::new_v4().to_string(),
+				"tampered".to_string(),
+				false,
+				false,
+			)
+			.expect("Token generation should succeed");
+
+		// Tamper: replace the middle (payload) segment
+		let parts: Vec<&str> = token.split('.').collect();
+		assert_eq!(parts.len(), 3, "JWT should have 3 parts");
+		let tampered = format!("{}.dGFtcGVyZWQ.{}", parts[0], parts[2]);
+
+		// Act
+		let result = validate_raw_token(&tampered);
+
+		// Assert
+		assert!(result.is_none(), "Tampered token should return None");
+	}
+}

--- a/dashboard/src/apps/auth/tests/unit/test_user_model.rs
+++ b/dashboard/src/apps/auth/tests/unit/test_user_model.rs
@@ -1,0 +1,140 @@
+//! Tests for User model construction and behavior.
+
+#[cfg(test)]
+mod tests {
+	use reinhardt::BaseUser;
+	use rstest::rstest;
+
+	use crate::apps::auth::models::User;
+
+	#[rstest]
+	fn test_user_new_sets_all_fields() {
+		// Arrange
+		let username = "testuser".to_string();
+		let email = "test@example.com".to_string();
+		let first_name = "Test".to_string();
+		let last_name = "User".to_string();
+
+		// Act
+		let user = User::new(
+			username.clone(),
+			email.clone(),
+			first_name.clone(),
+			last_name.clone(),
+			None,
+			true,
+			false,
+			false,
+		);
+
+		// Assert
+		assert_eq!(user.get_username(), username);
+		assert_eq!(user.email, email);
+		assert_eq!(user.first_name, first_name);
+		assert_eq!(user.last_name, last_name);
+		assert!(user.password_hash().is_none());
+		assert!(user.is_active());
+		assert!(!user.is_staff);
+		assert!(!user.is_superuser);
+	}
+
+	#[rstest]
+	fn test_user_default_is_active_true() {
+		// Arrange & Act
+		let user = User::new(
+			"activeuser".to_string(),
+			"active@example.com".to_string(),
+			String::new(),
+			String::new(),
+			None,
+			true,
+			false,
+			false,
+		);
+
+		// Assert
+		assert!(
+			user.is_active(),
+			"User created with is_active=true should be active"
+		);
+	}
+
+	#[rstest]
+	fn test_user_password_hash_starts_with_argon2() {
+		// Arrange
+		let mut user = User::new(
+			"hashuser".to_string(),
+			"hash@example.com".to_string(),
+			String::new(),
+			String::new(),
+			None,
+			true,
+			false,
+			false,
+		);
+
+		// Act
+		user.set_password("my-secure-password").unwrap();
+
+		// Assert
+		let hash = user
+			.password_hash()
+			.expect("Password hash should be set after set_password");
+		assert!(
+			hash.starts_with("$argon2"),
+			"Password hash should start with $argon2, got: {}",
+			&hash[..hash.len().min(20)]
+		);
+	}
+
+	#[rstest]
+	fn test_user_check_password_no_hash() {
+		// Arrange
+		let user = User::new(
+			"nohash".to_string(),
+			"nohash@example.com".to_string(),
+			String::new(),
+			String::new(),
+			None,
+			true,
+			false,
+			false,
+		);
+
+		// Act
+		let result = user.check_password("anypassword");
+
+		// Assert — with no hash, check_password should return Ok(false) or Err
+		match result {
+			Ok(valid) => assert!(!valid, "check_password with no hash should return false"),
+			Err(_) => {} // Also acceptable: error when no hash is set
+		}
+	}
+
+	#[rstest]
+	fn test_user_serialization_roundtrip() {
+		// Arrange
+		let user = User::new(
+			"serdeuser".to_string(),
+			"serde@example.com".to_string(),
+			"Serde".to_string(),
+			"Test".to_string(),
+			Some("$argon2id$fakehash".to_string()),
+			true,
+			true,
+			false,
+		);
+
+		// Act
+		let json = serde_json::to_string(&user).expect("Failed to serialize User");
+		let deserialized: User = serde_json::from_str(&json).expect("Failed to deserialize User");
+
+		// Assert
+		assert_eq!(deserialized.get_username(), user.get_username());
+		assert_eq!(deserialized.email, user.email);
+		assert_eq!(deserialized.first_name, user.first_name);
+		assert_eq!(deserialized.last_name, user.last_name);
+		assert_eq!(deserialized.is_staff, user.is_staff);
+		assert_eq!(deserialized.is_superuser, user.is_superuser);
+	}
+}

--- a/dashboard/src/apps/clusters/tests.rs
+++ b/dashboard/src/apps/clusters/tests.rs
@@ -2,7 +2,12 @@
 
 pub mod e2e {
 	pub mod test_cluster_crud;
+	pub mod test_cluster_ownership;
+	pub mod test_cluster_pagination;
 }
 pub mod unit {
+	pub mod test_cluster_model;
+	pub mod test_cluster_property;
+	pub mod test_request_validation;
 	pub mod test_serializer;
 }

--- a/dashboard/src/apps/clusters/tests/e2e/test_cluster_ownership.rs
+++ b/dashboard/src/apps/clusters/tests/e2e/test_cluster_ownership.rs
@@ -1,0 +1,262 @@
+//! Cross-user isolation tests for clusters API.
+
+#[cfg(test)]
+mod tests {
+	use reinhardt::JwtAuth;
+	use reinhardt::prelude::DatabaseConnection;
+	use reinhardt::test::APIClient;
+	use reinhardt::test::fixtures::TestServerGuard;
+	use reinhardt::test::fixtures::{ContainerAsync, GenericImage, api_client_from_url};
+	use reinhardt::test::fixtures::{postgres_with_migrations_from_dir, test_server_guard};
+	use rstest::*;
+	use serde_json::json;
+	use serial_test::serial;
+	use std::sync::Arc;
+	use uuid::Uuid;
+
+	use crate::routes;
+
+	#[fixture]
+	async fn test_app() -> (
+		ContainerAsync<GenericImage>,
+		Arc<DatabaseConnection>,
+		TestServerGuard,
+		APIClient,
+	) {
+		unsafe {
+			std::env::set_var(
+				"REINHARDT_CLOUD_JWT_SECRET",
+				"test-secret-minimum-32-bytes-long!!",
+			);
+		}
+		let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
+		let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
+			.await
+			.expect("Failed to start PostgreSQL with migrations");
+		let router = routes().into_server();
+		let server = test_server_guard(router).await;
+		let client = api_client_from_url(&server.url);
+		(container, conn, server, client)
+	}
+
+	/// Helper: register a user and return the JWT token.
+	async fn register_user(client: &APIClient, username: &str, email: &str) -> String {
+		let data = json!({
+			"username": username,
+			"email": email,
+			"password": "securepassword123"
+		});
+		let resp = client
+			.post("/api/auth/register/", &data, "json")
+			.await
+			.expect("Register request failed");
+		assert_eq!(resp.status_code(), 201);
+		let body: serde_json::Value = resp.json().expect("Failed to parse JSON response");
+		body["token"].as_str().unwrap().to_string()
+	}
+
+	/// Helper: set Authorization header on client.
+	async fn authenticate_client(client: &APIClient, token: &str) {
+		client
+			.set_header("Authorization", format!("Bearer {token}"))
+			.await
+			.expect("Failed to set Authorization header");
+	}
+
+	/// Helper: create a cluster and return its response body.
+	async fn create_cluster(client: &APIClient, name: &str) -> serde_json::Value {
+		let data = json!({
+			"name": name,
+			"api_url": "https://k8s.example.com:6443"
+		});
+		let resp = client
+			.post("/api/clusters/", &data, "json")
+			.await
+			.expect("Create cluster request failed");
+		assert_eq!(resp.status_code(), 201);
+		resp.json().expect("Failed to parse create response")
+	}
+
+	/// UserA creates a cluster; UserB lists clusters and sees nothing.
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_user_cannot_see_other_users_clusters(
+		#[future] test_app: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			TestServerGuard,
+			APIClient,
+		),
+	) {
+		// Arrange
+		let (_container, _conn, _server, client) = test_app.await;
+
+		let token_a = register_user(&client, "user_a", "a@example.com").await;
+		authenticate_client(&client, &token_a).await;
+		create_cluster(&client, "cluster-a").await;
+
+		let token_b = register_user(&client, "user_b", "b@example.com").await;
+		authenticate_client(&client, &token_b).await;
+
+		// Act
+		let response = client
+			.get("/api/clusters/")
+			.await
+			.expect("List clusters request failed");
+
+		// Assert
+		assert_eq!(response.status_code(), 200);
+		let body: serde_json::Value = response.json().expect("Failed to parse JSON response");
+		assert_eq!(body["items"], json!([]));
+		assert_eq!(body["total"], 0);
+	}
+
+	/// UserA creates 2 clusters, UserB creates 1 — each sees only their own.
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_user_sees_only_own_clusters(
+		#[future] test_app: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			TestServerGuard,
+			APIClient,
+		),
+	) {
+		// Arrange
+		let (_container, _conn, _server, client) = test_app.await;
+
+		let token_a = register_user(&client, "user_a", "a@example.com").await;
+		authenticate_client(&client, &token_a).await;
+		create_cluster(&client, "cluster-a1").await;
+		create_cluster(&client, "cluster-a2").await;
+
+		let token_b = register_user(&client, "user_b", "b@example.com").await;
+		authenticate_client(&client, &token_b).await;
+		create_cluster(&client, "cluster-b1").await;
+
+		// Act — UserB lists clusters
+		let resp_b = client
+			.get("/api/clusters/")
+			.await
+			.expect("List clusters request failed");
+
+		// Assert — UserB sees only 1
+		assert_eq!(resp_b.status_code(), 200);
+		let body_b: serde_json::Value = resp_b.json().expect("Failed to parse JSON");
+		assert_eq!(body_b["total"], 1);
+		let items_b = body_b["items"]
+			.as_array()
+			.expect("items should be an array");
+		assert_eq!(items_b.len(), 1);
+		assert_eq!(items_b[0]["name"], "cluster-b1");
+
+		// Act — switch to UserA
+		authenticate_client(&client, &token_a).await;
+		let resp_a = client
+			.get("/api/clusters/")
+			.await
+			.expect("List clusters request failed");
+
+		// Assert — UserA sees 2
+		assert_eq!(resp_a.status_code(), 200);
+		let body_a: serde_json::Value = resp_a.json().expect("Failed to parse JSON");
+		assert_eq!(body_a["total"], 2);
+		let items_a = body_a["items"]
+			.as_array()
+			.expect("items should be an array");
+		assert_eq!(items_a.len(), 2);
+	}
+
+	/// A token signed with the wrong secret should return 401.
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_wrong_secret_token_returns_401(
+		#[future] test_app: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			TestServerGuard,
+			APIClient,
+		),
+	) {
+		// Arrange
+		let (_container, _conn, _server, client) = test_app.await;
+		let wrong_auth = JwtAuth::new(b"wrong-secret-that-is-32-bytes-long!");
+		let token = wrong_auth
+			.generate_token(
+				Uuid::new_v4().to_string(),
+				"wrong-secret-user".to_string(),
+				false,
+				false,
+			)
+			.expect("Failed to generate token");
+
+		authenticate_client(&client, &token).await;
+
+		// Act
+		let response = client
+			.get("/api/clusters/")
+			.await
+			.expect("List clusters request failed");
+
+		// Assert
+		assert_eq!(response.status_code(), 401);
+	}
+
+	/// A malformed bearer token should return 401.
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_malformed_bearer_token_returns_401(
+		#[future] test_app: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			TestServerGuard,
+			APIClient,
+		),
+	) {
+		// Arrange
+		let (_container, _conn, _server, client) = test_app.await;
+		authenticate_client(&client, "invalid-jwt-gibberish").await;
+
+		// Act
+		let response = client
+			.get("/api/clusters/")
+			.await
+			.expect("List clusters request failed");
+
+		// Assert
+		assert_eq!(response.status_code(), 401);
+	}
+
+	/// Authorization header without "Bearer " prefix should return 401.
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_missing_bearer_prefix_returns_401(
+		#[future] test_app: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			TestServerGuard,
+			APIClient,
+		),
+	) {
+		// Arrange
+		let (_container, _conn, _server, client) = test_app.await;
+		client
+			.set_header("Authorization", "just-a-token-no-bearer".to_string())
+			.await
+			.expect("Failed to set Authorization header");
+
+		// Act
+		let response = client
+			.get("/api/clusters/")
+			.await
+			.expect("List clusters request failed");
+
+		// Assert
+		assert_eq!(response.status_code(), 401);
+	}
+}

--- a/dashboard/src/apps/clusters/tests/e2e/test_cluster_pagination.rs
+++ b/dashboard/src/apps/clusters/tests/e2e/test_cluster_pagination.rs
@@ -1,0 +1,210 @@
+//! Pagination tests for clusters API.
+
+#[cfg(test)]
+mod tests {
+	use reinhardt::prelude::DatabaseConnection;
+	use reinhardt::test::APIClient;
+	use reinhardt::test::fixtures::TestServerGuard;
+	use reinhardt::test::fixtures::{ContainerAsync, GenericImage, api_client_from_url};
+	use reinhardt::test::fixtures::{postgres_with_migrations_from_dir, test_server_guard};
+	use rstest::*;
+	use serde_json::json;
+	use serial_test::serial;
+	use std::sync::Arc;
+
+	use crate::routes;
+
+	#[fixture]
+	async fn test_app() -> (
+		ContainerAsync<GenericImage>,
+		Arc<DatabaseConnection>,
+		TestServerGuard,
+		APIClient,
+	) {
+		unsafe {
+			std::env::set_var(
+				"REINHARDT_CLOUD_JWT_SECRET",
+				"test-secret-minimum-32-bytes-long!!",
+			);
+		}
+		let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
+		let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
+			.await
+			.expect("Failed to start PostgreSQL with migrations");
+		let router = routes().into_server();
+		let server = test_server_guard(router).await;
+		let client = api_client_from_url(&server.url);
+		(container, conn, server, client)
+	}
+
+	/// Helper: register a test user and return the JWT token.
+	async fn register_and_get_token(client: &APIClient) -> String {
+		let register_data = json!({
+			"username": "testuser",
+			"email": "test@example.com",
+			"password": "securepassword123"
+		});
+		let resp = client
+			.post("/api/auth/register/", &register_data, "json")
+			.await
+			.expect("Register request failed");
+		assert_eq!(resp.status_code(), 201);
+		let body: serde_json::Value = resp.json().expect("Failed to parse JSON response");
+		body["token"].as_str().unwrap().to_string()
+	}
+
+	/// Helper: set Authorization header on client.
+	async fn authenticate_client(client: &APIClient, token: &str) {
+		client
+			.set_header("Authorization", format!("Bearer {token}"))
+			.await
+			.expect("Failed to set Authorization header");
+	}
+
+	/// Helper: create N clusters with sequential names.
+	async fn create_clusters(client: &APIClient, count: usize) {
+		for i in 0..count {
+			let data = json!({
+				"name": format!("cluster-{}", i),
+				"api_url": "https://k8s.example.com:6443"
+			});
+			let resp = client
+				.post("/api/clusters/", &data, "json")
+				.await
+				.expect("Create cluster request failed");
+			assert_eq!(resp.status_code(), 201);
+		}
+	}
+
+	/// Default pagination returns all items when count is small.
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_clusters_default_pagination(
+		#[future] test_app: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			TestServerGuard,
+			APIClient,
+		),
+	) {
+		// Arrange
+		let (_container, _conn, _server, client) = test_app.await;
+		let token = register_and_get_token(&client).await;
+		authenticate_client(&client, &token).await;
+		create_clusters(&client, 3).await;
+
+		// Act
+		let response = client
+			.get("/api/clusters/")
+			.await
+			.expect("List clusters request failed");
+
+		// Assert
+		assert_eq!(response.status_code(), 200);
+		let body: serde_json::Value = response.json().expect("Failed to parse JSON");
+		assert_eq!(body["total"], 3);
+		let items = body["items"].as_array().expect("items should be an array");
+		assert_eq!(items.len(), 3);
+		assert_eq!(body["page"], 1);
+	}
+
+	/// Custom page_size limits the number of returned items.
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_clusters_custom_page_size(
+		#[future] test_app: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			TestServerGuard,
+			APIClient,
+		),
+	) {
+		// Arrange
+		let (_container, _conn, _server, client) = test_app.await;
+		let token = register_and_get_token(&client).await;
+		authenticate_client(&client, &token).await;
+		create_clusters(&client, 5).await;
+
+		// Act
+		let response = client
+			.get("/api/clusters/?page_size=2")
+			.await
+			.expect("List clusters request failed");
+
+		// Assert
+		assert_eq!(response.status_code(), 200);
+		let body: serde_json::Value = response.json().expect("Failed to parse JSON");
+		assert_eq!(body["total"], 5);
+		let items = body["items"].as_array().expect("items should be an array");
+		assert_eq!(items.len(), 2);
+	}
+
+	/// Requesting a page beyond total results returns empty items.
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_clusters_page_beyond_total(
+		#[future] test_app: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			TestServerGuard,
+			APIClient,
+		),
+	) {
+		// Arrange
+		let (_container, _conn, _server, client) = test_app.await;
+		let token = register_and_get_token(&client).await;
+		authenticate_client(&client, &token).await;
+		create_clusters(&client, 2).await;
+
+		// Act
+		let response = client
+			.get("/api/clusters/?page=5&page_size=2")
+			.await
+			.expect("List clusters request failed");
+
+		// Assert
+		assert_eq!(response.status_code(), 200);
+		let body: serde_json::Value = response.json().expect("Failed to parse JSON");
+		let items = body["items"].as_array().expect("items should be an array");
+		assert_eq!(items.len(), 0);
+	}
+
+	/// page_size is capped at 100 even if a larger value is requested.
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_clusters_page_size_capped_at_100(
+		#[future] test_app: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			TestServerGuard,
+			APIClient,
+		),
+	) {
+		// Arrange
+		let (_container, _conn, _server, client) = test_app.await;
+		let token = register_and_get_token(&client).await;
+		authenticate_client(&client, &token).await;
+
+		// Act
+		let response = client
+			.get("/api/clusters/?page_size=500")
+			.await
+			.expect("List clusters request failed");
+
+		// Assert
+		assert_eq!(response.status_code(), 200);
+		let body: serde_json::Value = response.json().expect("Failed to parse JSON");
+		let page_size = body["page_size"]
+			.as_i64()
+			.expect("page_size should be a number");
+		assert!(
+			page_size <= 100,
+			"page_size should be capped at 100 but got {}",
+			page_size
+		);
+	}
+}

--- a/dashboard/src/apps/clusters/tests/unit/test_cluster_model.rs
+++ b/dashboard/src/apps/clusters/tests/unit/test_cluster_model.rs
@@ -1,0 +1,85 @@
+//! Unit tests for Cluster model construction and field behaviour.
+
+#[cfg(test)]
+mod tests {
+	use rstest::rstest;
+	use uuid::Uuid;
+
+	use crate::apps::clusters::models::Cluster;
+
+	#[rstest]
+	fn test_cluster_new_sets_fields() {
+		// Arrange
+		let user_id = Uuid::new_v4();
+		let name = "production".to_string();
+		let api_url = "https://k8s.example.com:6443".to_string();
+
+		// Act
+		let cluster = Cluster::new(user_id, name.clone(), api_url.clone(), true);
+
+		// Assert
+		assert_eq!(cluster.user_id, user_id);
+		assert_eq!(cluster.name, name);
+		assert_eq!(cluster.api_url, api_url);
+		assert!(cluster.is_active);
+	}
+
+	#[rstest]
+	fn test_cluster_new_id_is_none() {
+		// Arrange
+		let user_id = Uuid::new_v4();
+
+		// Act
+		let cluster = Cluster::new(
+			user_id,
+			"test-cluster".to_string(),
+			"https://k8s.example.com:6443".to_string(),
+			true,
+		);
+
+		// Assert
+		assert_eq!(cluster.id, None);
+	}
+
+	#[rstest]
+	#[case(true)]
+	#[case(false)]
+	fn test_cluster_is_active_flag(#[case] active: bool) {
+		// Arrange
+		let user_id = Uuid::new_v4();
+
+		// Act
+		let cluster = Cluster::new(
+			user_id,
+			"flag-test".to_string(),
+			"https://k8s.example.com:6443".to_string(),
+			active,
+		);
+
+		// Assert
+		assert_eq!(cluster.is_active, active);
+	}
+
+	#[rstest]
+	fn test_cluster_serialization_roundtrip() {
+		// Arrange
+		let cluster = Cluster::new(
+			Uuid::new_v4(),
+			"roundtrip".to_string(),
+			"https://k8s.example.com:6443".to_string(),
+			true,
+		);
+
+		// Act
+		let json = serde_json::to_string(&cluster).expect("serialize should succeed");
+		let deserialized: Cluster =
+			serde_json::from_str(&json).expect("deserialize should succeed");
+
+		// Assert
+		assert_eq!(deserialized.name, cluster.name);
+		assert_eq!(deserialized.api_url, cluster.api_url);
+		assert_eq!(deserialized.user_id, cluster.user_id);
+		assert_eq!(deserialized.is_active, cluster.is_active);
+		assert_eq!(deserialized.id, cluster.id);
+	}
+}

--- a/dashboard/src/apps/clusters/tests/unit/test_cluster_property.rs
+++ b/dashboard/src/apps/clusters/tests/unit/test_cluster_property.rs
@@ -1,0 +1,67 @@
+//! Property-based tests for Cluster model and serializers.
+
+#[cfg(test)]
+mod tests {
+	use proptest::prelude::*;
+	use uuid::Uuid;
+
+	use crate::apps::clusters::models::Cluster;
+	use crate::apps::clusters::serializers::{ClusterResponse, CreateClusterRequest};
+
+	proptest! {
+		/// ClusterResponse::from preserves all fields from the Cluster model.
+		#[test]
+		fn test_cluster_response_from_model_preserves_fields(
+			name in "[a-zA-Z0-9_-]{1,63}",
+			api_url in "https://[a-z]{1,20}\\.example\\.com(:[0-9]{1,5})?",
+			is_active in proptest::bool::ANY,
+		) {
+			// Arrange
+			let cluster = Cluster::new(
+				Uuid::new_v4(),
+				name.clone(),
+				api_url.clone(),
+				is_active,
+			);
+
+			// Act
+			let resp = ClusterResponse::from(cluster);
+
+			// Assert
+			prop_assert_eq!(&resp.name, &name);
+			prop_assert_eq!(&resp.api_url, &api_url);
+			prop_assert_eq!(resp.is_active, is_active);
+			prop_assert_eq!(resp.id, None);
+		}
+
+		/// CreateClusterRequest deserializes correctly from well-formed JSON.
+		#[test]
+		fn test_create_cluster_request_roundtrip(
+			name in "[a-zA-Z0-9_-]{1,63}",
+			api_url in "https://[a-z]{1,20}\\.example\\.com(:[0-9]{1,5})?",
+		) {
+			// Arrange
+			let json = serde_json::json!({
+				"name": name,
+				"api_url": api_url,
+			});
+
+			// Act
+			let deserialized: CreateClusterRequest =
+				serde_json::from_value(json).expect("deserialize should succeed");
+
+			// Assert
+			prop_assert_eq!(&deserialized.name, &name);
+			prop_assert_eq!(&deserialized.api_url, &api_url);
+		}
+
+		/// Deserializing arbitrary JSON into CreateClusterRequest must never panic.
+		#[test]
+		fn test_arbitrary_json_cluster_no_panic(json_str in "\\PC{0,256}") {
+			// Arrange / Act
+			let _ = serde_json::from_str::<CreateClusterRequest>(&json_str);
+
+			// Assert — no panic is the success condition
+		}
+	}
+}

--- a/dashboard/src/apps/clusters/tests/unit/test_request_validation.rs
+++ b/dashboard/src/apps/clusters/tests/unit/test_request_validation.rs
@@ -1,0 +1,112 @@
+//! Boundary value analysis and equivalence partitioning for CreateClusterRequest.
+
+#[cfg(test)]
+mod tests {
+	use reinhardt::Validate;
+	use rstest::rstest;
+
+	use crate::apps::clusters::serializers::CreateClusterRequest;
+
+	// -- Name boundary tests --
+
+	#[rstest]
+	#[case("a", true)] // min valid (1 char)
+	#[case("", false)] // below min (0 chars)
+	#[case(&"a".repeat(63), true)] // max valid (63 chars)
+	#[case(&"a".repeat(64), false)] // above max (64 chars)
+	fn test_cluster_name_boundary(#[case] name: &str, #[case] expected_valid: bool) {
+		// Arrange
+		let req = CreateClusterRequest {
+			name: name.to_string(),
+			api_url: "https://k8s.example.com:6443".to_string(),
+		};
+
+		// Act
+		let result = req.validate();
+
+		// Assert
+		assert_eq!(
+			result.is_ok(),
+			expected_valid,
+			"name='{}' (len={}) should be valid={}",
+			name,
+			name.len(),
+			expected_valid
+		);
+	}
+
+	// -- URL validation tests --
+
+	#[rstest]
+	#[case("https://k8s.example.com:6443", true)] // valid HTTPS URL
+	#[case("http://10.0.0.1:6443", true)] // valid HTTP URL with IP
+	#[case("not-a-url", false)] // invalid: no scheme
+	#[case("", false)] // invalid: empty string
+	fn test_cluster_api_url_validation(#[case] url: &str, #[case] expected_valid: bool) {
+		// Arrange
+		let req = CreateClusterRequest {
+			name: "valid-cluster".to_string(),
+			api_url: url.to_string(),
+		};
+
+		// Act
+		let result = req.validate();
+
+		// Assert
+		assert_eq!(
+			result.is_ok(),
+			expected_valid,
+			"api_url='{}' should be valid={}",
+			url,
+			expected_valid
+		);
+	}
+
+	// -- URL max length tests --
+
+	#[rstest]
+	#[case(2048, true)] // max valid length
+	#[case(2049, false)] // above max length
+	fn test_cluster_api_url_max_length(#[case] len: usize, #[case] expected_valid: bool) {
+		// Arrange
+		let base = "https://k8s.example.com/";
+		let padding = "a".repeat(len - base.len());
+		let url = format!("{}{}", base, padding);
+		assert_eq!(url.len(), len);
+
+		let req = CreateClusterRequest {
+			name: "valid-cluster".to_string(),
+			api_url: url.clone(),
+		};
+
+		// Act
+		let result = req.validate();
+
+		// Assert
+		assert_eq!(
+			result.is_ok(),
+			expected_valid,
+			"api_url with len={} should be valid={}",
+			len,
+			expected_valid
+		);
+	}
+
+	// -- Missing fields deserialization test --
+
+	#[rstest]
+	#[case(r#"{"api_url": "https://k8s.example.com:6443"}"#, "missing name")]
+	#[case(r#"{"name": "prod"}"#, "missing api_url")]
+	#[case(r#"{}"#, "missing both fields")]
+	fn test_create_cluster_request_missing_fields(#[case] json: &str, #[case] description: &str) {
+		// Arrange / Act
+		let result = serde_json::from_str::<CreateClusterRequest>(json);
+
+		// Assert
+		assert!(
+			result.is_err(),
+			"deserialization should fail for: {}",
+			description
+		);
+	}
+}

--- a/dashboard/src/apps/deployments/tests.rs
+++ b/dashboard/src/apps/deployments/tests.rs
@@ -2,7 +2,12 @@
 
 pub mod e2e {
 	pub mod test_deployment_crud;
+	pub mod test_deployment_ownership;
+	pub mod test_deployment_pagination;
 }
 pub mod unit {
+	pub mod test_deployment_model;
+	pub mod test_deployment_property;
+	pub mod test_request_validation;
 	pub mod test_serializer;
 }

--- a/dashboard/src/apps/deployments/tests/e2e/test_deployment_ownership.rs
+++ b/dashboard/src/apps/deployments/tests/e2e/test_deployment_ownership.rs
@@ -1,0 +1,279 @@
+//! Cross-user isolation and cluster ownership tests for deployments API.
+
+#[cfg(test)]
+mod tests {
+	use reinhardt::prelude::DatabaseConnection;
+	use reinhardt::test::APIClient;
+	use reinhardt::test::fixtures::TestServerGuard;
+	use reinhardt::test::fixtures::{ContainerAsync, GenericImage, api_client_from_url};
+	use reinhardt::test::fixtures::{postgres_with_migrations_from_dir, test_server_guard};
+	use rstest::*;
+	use serde_json::json;
+	use serial_test::serial;
+	use std::sync::Arc;
+
+	use crate::routes;
+
+	#[fixture]
+	async fn test_app() -> (
+		ContainerAsync<GenericImage>,
+		Arc<DatabaseConnection>,
+		TestServerGuard,
+		APIClient,
+	) {
+		unsafe {
+			std::env::set_var(
+				"REINHARDT_CLOUD_JWT_SECRET",
+				"test-secret-minimum-32-bytes-long!!",
+			);
+		}
+		let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
+		let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
+			.await
+			.expect("Failed to start PostgreSQL with migrations");
+		let router = routes().into_server();
+		let server = test_server_guard(router).await;
+		let client = api_client_from_url(&server.url);
+		(container, conn, server, client)
+	}
+
+	/// Helper: register a user and return the JWT token.
+	async fn register_user(client: &APIClient, username: &str, email: &str) -> String {
+		let data = json!({
+			"username": username,
+			"email": email,
+			"password": "securepassword123"
+		});
+		let resp = client
+			.post("/api/auth/register/", &data, "json")
+			.await
+			.expect("Register request failed");
+		assert_eq!(resp.status_code(), 201);
+		let body: serde_json::Value = resp.json().expect("Failed to parse register response");
+		body["token"].as_str().unwrap().to_string()
+	}
+
+	/// Helper: set Authorization header on client.
+	async fn authenticate_client(client: &APIClient, token: &str) {
+		client
+			.set_header("Authorization", format!("Bearer {token}"))
+			.await
+			.expect("Failed to set Authorization header");
+	}
+
+	/// Helper: create a cluster and return its id.
+	async fn create_cluster(client: &APIClient) -> i64 {
+		let data = json!({
+			"name": "test-cluster",
+			"api_url": "https://k8s.example.com:6443"
+		});
+		let resp = client
+			.post("/api/clusters/", &data, "json")
+			.await
+			.expect("Create cluster failed");
+		assert_eq!(resp.status_code(), 201);
+		let body: serde_json::Value = resp.json().expect("Failed to parse cluster response");
+		body["id"].as_i64().expect("cluster id")
+	}
+
+	/// Helper: create a deployment and return the response body.
+	async fn create_deployment(client: &APIClient, cluster_id: i64) -> serde_json::Value {
+		let data = json!({
+			"app_name": "test-app",
+			"cluster_id": cluster_id,
+			"image": "nginx:latest"
+		});
+		let resp = client
+			.post("/api/deployments/", &data, "json")
+			.await
+			.expect("Create deployment failed");
+		assert_eq!(resp.status_code(), 201);
+		resp.json().expect("Failed to parse deployment response")
+	}
+
+	/// UserA creates a deployment; UserB should not see it.
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_user_cannot_see_other_users_deployments(
+		#[future] test_app: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			TestServerGuard,
+			APIClient,
+		),
+	) {
+		// Arrange
+		let (_container, _conn, _server, client) = test_app.await;
+
+		let token_a = register_user(&client, "user_a", "a@example.com").await;
+		authenticate_client(&client, &token_a).await;
+		let cluster_id = create_cluster(&client).await;
+		create_deployment(&client, cluster_id).await;
+
+		let token_b = register_user(&client, "user_b", "b@example.com").await;
+		authenticate_client(&client, &token_b).await;
+
+		// Act
+		let response = client
+			.get("/api/deployments/")
+			.await
+			.expect("List deployments failed");
+
+		// Assert
+		assert_eq!(response.status_code(), 200);
+		let body: serde_json::Value = response.json().expect("Failed to parse response");
+		assert_eq!(body["items"], json!([]));
+		assert_eq!(body["total"], 0);
+	}
+
+	/// Creating a deployment with a nonexistent cluster returns 404.
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_create_deployment_nonexistent_cluster_404(
+		#[future] test_app: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			TestServerGuard,
+			APIClient,
+		),
+	) {
+		// Arrange
+		let (_container, _conn, _server, client) = test_app.await;
+		let token = register_user(&client, "testuser", "test@example.com").await;
+		authenticate_client(&client, &token).await;
+
+		let data = json!({
+			"app_name": "my-app",
+			"cluster_id": 99999,
+			"image": "nginx:latest"
+		});
+
+		// Act
+		let response = client
+			.post("/api/deployments/", &data, "json")
+			.await
+			.expect("Create deployment request failed");
+
+		// Assert
+		assert_eq!(response.status_code(), 404);
+		let body_text = response.text();
+		assert!(
+			body_text.contains("Cluster with id 99999 not found")
+				|| body_text.contains("not found")
+				|| body_text.contains("Not Found"),
+			"Expected cluster-not-found message, got: {body_text}"
+		);
+	}
+
+	/// UserB cannot deploy to UserA's cluster — returns 404.
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_create_deployment_other_users_cluster_404(
+		#[future] test_app: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			TestServerGuard,
+			APIClient,
+		),
+	) {
+		// Arrange
+		let (_container, _conn, _server, client) = test_app.await;
+
+		// UserA creates a cluster
+		let token_a = register_user(&client, "owner", "owner@example.com").await;
+		authenticate_client(&client, &token_a).await;
+		let cluster_id = create_cluster(&client).await;
+
+		// UserB tries to deploy to it
+		let token_b = register_user(&client, "intruder", "intruder@example.com").await;
+		authenticate_client(&client, &token_b).await;
+
+		let data = json!({
+			"app_name": "evil-app",
+			"cluster_id": cluster_id,
+			"image": "malicious:latest"
+		});
+
+		// Act
+		let response = client
+			.post("/api/deployments/", &data, "json")
+			.await
+			.expect("Create deployment request failed");
+
+		// Assert
+		assert_eq!(response.status_code(), 404);
+		let body_text = response.text();
+		assert!(
+			body_text.contains(&format!("Cluster with id {cluster_id} not found"))
+				|| body_text.contains("not found")
+				|| body_text.contains("Not Found"),
+			"Expected cluster-not-found for other user's cluster, got: {body_text}"
+		);
+	}
+
+	/// Decision table: deployment ownership scenarios.
+	#[rstest]
+	#[case::own_cluster(true, true, 201)]
+	#[case::other_users_cluster(true, false, 404)]
+	#[case::nonexistent_cluster(false, false, 404)]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_deployment_ownership_decision_table(
+		#[future] test_app: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			TestServerGuard,
+			APIClient,
+		),
+		#[case] cluster_exists: bool,
+		#[case] is_owner: bool,
+		#[case] expected_status: u16,
+	) {
+		// Arrange
+		let (_container, _conn, _server, client) = test_app.await;
+
+		let cluster_id = if cluster_exists {
+			// Create a cluster owned by user_a
+			let token_a = register_user(&client, "cluster_owner", "cowner@example.com").await;
+			authenticate_client(&client, &token_a).await;
+			let cid = create_cluster(&client).await;
+
+			if is_owner {
+				// Deploy as the same user who owns the cluster
+				// (already authenticated as cluster_owner)
+			} else {
+				// Deploy as a different user
+				let token_b = register_user(&client, "deployer", "deployer@example.com").await;
+				authenticate_client(&client, &token_b).await;
+			}
+			cid
+		} else {
+			// Use a nonexistent cluster id
+			let token = register_user(&client, "solo_user", "solo@example.com").await;
+			authenticate_client(&client, &token).await;
+			99999i64
+		};
+
+		let data = json!({
+			"app_name": "decision-app",
+			"cluster_id": cluster_id,
+			"image": "nginx:latest"
+		});
+
+		// Act
+		let response = client
+			.post("/api/deployments/", &data, "json")
+			.await
+			.expect("Create deployment request failed");
+
+		// Assert
+		assert_eq!(
+			response.status_code(),
+			expected_status,
+			"cluster_exists={cluster_exists}, is_owner={is_owner}"
+		);
+	}
+}

--- a/dashboard/src/apps/deployments/tests/e2e/test_deployment_pagination.rs
+++ b/dashboard/src/apps/deployments/tests/e2e/test_deployment_pagination.rs
@@ -1,0 +1,196 @@
+//! Pagination tests for deployments API.
+
+#[cfg(test)]
+mod tests {
+	use reinhardt::prelude::DatabaseConnection;
+	use reinhardt::test::APIClient;
+	use reinhardt::test::fixtures::TestServerGuard;
+	use reinhardt::test::fixtures::{ContainerAsync, GenericImage, api_client_from_url};
+	use reinhardt::test::fixtures::{postgres_with_migrations_from_dir, test_server_guard};
+	use rstest::*;
+	use serde_json::json;
+	use serial_test::serial;
+	use std::sync::Arc;
+
+	use crate::routes;
+
+	#[fixture]
+	async fn test_app() -> (
+		ContainerAsync<GenericImage>,
+		Arc<DatabaseConnection>,
+		TestServerGuard,
+		APIClient,
+	) {
+		unsafe {
+			std::env::set_var(
+				"REINHARDT_CLOUD_JWT_SECRET",
+				"test-secret-minimum-32-bytes-long!!",
+			);
+		}
+		let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
+		let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
+			.await
+			.expect("Failed to start PostgreSQL with migrations");
+		let router = routes().into_server();
+		let server = test_server_guard(router).await;
+		let client = api_client_from_url(&server.url);
+		(container, conn, server, client)
+	}
+
+	/// Helper: register a user and return the JWT token.
+	async fn register_and_get_token(client: &APIClient) -> String {
+		let data = json!({
+			"username": "testuser",
+			"email": "test@example.com",
+			"password": "securepassword123"
+		});
+		let resp = client
+			.post("/api/auth/register/", &data, "json")
+			.await
+			.expect("Register request failed");
+		assert_eq!(resp.status_code(), 201);
+		let body: serde_json::Value = resp.json().expect("Failed to parse register response");
+		body["token"].as_str().unwrap().to_string()
+	}
+
+	/// Helper: set Authorization header on client.
+	async fn authenticate_client(client: &APIClient, token: &str) {
+		client
+			.set_header("Authorization", format!("Bearer {token}"))
+			.await
+			.expect("Failed to set Authorization header");
+	}
+
+	/// Helper: create a cluster and return its id.
+	async fn create_cluster(client: &APIClient) -> i64 {
+		let data = json!({
+			"name": "test-cluster",
+			"api_url": "https://k8s.example.com:6443"
+		});
+		let resp = client
+			.post("/api/clusters/", &data, "json")
+			.await
+			.expect("Create cluster failed");
+		assert_eq!(resp.status_code(), 201);
+		let body: serde_json::Value = resp.json().expect("Failed to parse cluster response");
+		body["id"].as_i64().expect("cluster id")
+	}
+
+	/// Helper: create a deployment with a unique app_name.
+	async fn create_deployment(client: &APIClient, cluster_id: i64, suffix: &str) {
+		let data = json!({
+			"app_name": format!("app-{suffix}"),
+			"cluster_id": cluster_id,
+			"image": "nginx:latest"
+		});
+		let resp = client
+			.post("/api/deployments/", &data, "json")
+			.await
+			.expect("Create deployment failed");
+		assert_eq!(resp.status_code(), 201);
+	}
+
+	/// Default pagination returns all items when count is small.
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_deployments_default_pagination(
+		#[future] test_app: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			TestServerGuard,
+			APIClient,
+		),
+	) {
+		// Arrange
+		let (_container, _conn, _server, client) = test_app.await;
+		let token = register_and_get_token(&client).await;
+		authenticate_client(&client, &token).await;
+		let cluster_id = create_cluster(&client).await;
+		for i in 1..=3 {
+			create_deployment(&client, cluster_id, &i.to_string()).await;
+		}
+
+		// Act
+		let response = client
+			.get("/api/deployments/")
+			.await
+			.expect("List deployments failed");
+
+		// Assert
+		assert_eq!(response.status_code(), 200);
+		let body: serde_json::Value = response.json().expect("Failed to parse response");
+		assert_eq!(body["total"], 3);
+		let items = body["items"].as_array().expect("items should be array");
+		assert_eq!(items.len(), 3);
+	}
+
+	/// Page 2 with page_size=2 returns the remaining item.
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_deployments_page_2(
+		#[future] test_app: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			TestServerGuard,
+			APIClient,
+		),
+	) {
+		// Arrange
+		let (_container, _conn, _server, client) = test_app.await;
+		let token = register_and_get_token(&client).await;
+		authenticate_client(&client, &token).await;
+		let cluster_id = create_cluster(&client).await;
+		for i in 1..=3 {
+			create_deployment(&client, cluster_id, &i.to_string()).await;
+		}
+
+		// Act
+		let response = client
+			.get("/api/deployments/?page=2&page_size=2")
+			.await
+			.expect("List deployments page 2 failed");
+
+		// Assert
+		assert_eq!(response.status_code(), 200);
+		let body: serde_json::Value = response.json().expect("Failed to parse response");
+		let items = body["items"].as_array().expect("items should be array");
+		assert_eq!(items.len(), 1);
+		assert_eq!(body["total"], 3);
+	}
+
+	/// Requesting a page beyond available data returns empty items.
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_deployments_empty_page(
+		#[future] test_app: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			TestServerGuard,
+			APIClient,
+		),
+	) {
+		// Arrange
+		let (_container, _conn, _server, client) = test_app.await;
+		let token = register_and_get_token(&client).await;
+		authenticate_client(&client, &token).await;
+		let cluster_id = create_cluster(&client).await;
+		for i in 1..=3 {
+			create_deployment(&client, cluster_id, &i.to_string()).await;
+		}
+
+		// Act
+		let response = client
+			.get("/api/deployments/?page=99")
+			.await
+			.expect("List deployments page 99 failed");
+
+		// Assert
+		assert_eq!(response.status_code(), 200);
+		let body: serde_json::Value = response.json().expect("Failed to parse response");
+		let items = body["items"].as_array().expect("items should be array");
+		assert_eq!(items.len(), 0);
+	}
+}

--- a/dashboard/src/apps/deployments/tests/unit/test_deployment_model.rs
+++ b/dashboard/src/apps/deployments/tests/unit/test_deployment_model.rs
@@ -1,0 +1,98 @@
+//! Unit tests for the Deployment model.
+
+#[cfg(test)]
+mod tests {
+	use rstest::rstest;
+	use uuid::Uuid;
+
+	use crate::apps::deployments::models::Deployment;
+
+	/// All fields from Deployment::new match constructor arguments.
+	#[rstest]
+	fn test_deployment_new_sets_fields() {
+		// Arrange
+		let user_id = Uuid::new_v4();
+		let app_name = "my-app".to_string();
+		let cluster_id = 42i64;
+		let status = "pending".to_string();
+		let image = "ghcr.io/my-app:latest".to_string();
+
+		// Act
+		let deployment = Deployment::new(
+			user_id,
+			app_name.clone(),
+			cluster_id,
+			status.clone(),
+			image.clone(),
+		);
+
+		// Assert
+		assert_eq!(deployment.user_id, user_id);
+		assert_eq!(deployment.app_name, app_name);
+		assert_eq!(deployment.cluster_id, cluster_id);
+		assert_eq!(deployment.status, status);
+		assert_eq!(deployment.image, image);
+	}
+
+	/// Deployment::new sets id to None (auto-increment on insert).
+	#[rstest]
+	fn test_deployment_new_id_is_none() {
+		// Arrange & Act
+		let deployment = Deployment::new(
+			Uuid::new_v4(),
+			"app".to_string(),
+			1,
+			"pending".to_string(),
+			"nginx:latest".to_string(),
+		);
+
+		// Assert
+		assert_eq!(deployment.id, None);
+	}
+
+	/// Deployment accepts various status string values.
+	#[rstest]
+	#[case("pending")]
+	#[case("running")]
+	#[case("failed")]
+	#[case("succeeded")]
+	fn test_deployment_status_values(#[case] status: &str) {
+		// Arrange & Act
+		let deployment = Deployment::new(
+			Uuid::new_v4(),
+			"app".to_string(),
+			1,
+			status.to_string(),
+			"nginx:latest".to_string(),
+		);
+
+		// Assert
+		assert_eq!(deployment.status, status);
+	}
+
+	/// Deployment survives a serde_json roundtrip.
+	#[rstest]
+	fn test_deployment_serialization_roundtrip() {
+		// Arrange
+		let mut deployment = Deployment::new(
+			Uuid::new_v4(),
+			"roundtrip-app".to_string(),
+			99,
+			"running".to_string(),
+			"ghcr.io/roundtrip:v1".to_string(),
+		);
+		deployment.id = Some(7);
+
+		// Act
+		let json = serde_json::to_string(&deployment).expect("serialize");
+		let restored: Deployment = serde_json::from_str(&json).expect("deserialize");
+
+		// Assert
+		assert_eq!(restored.id, deployment.id);
+		assert_eq!(restored.user_id, deployment.user_id);
+		assert_eq!(restored.app_name, deployment.app_name);
+		assert_eq!(restored.cluster_id, deployment.cluster_id);
+		assert_eq!(restored.status, deployment.status);
+		assert_eq!(restored.image, deployment.image);
+	}
+}

--- a/dashboard/src/apps/deployments/tests/unit/test_deployment_property.rs
+++ b/dashboard/src/apps/deployments/tests/unit/test_deployment_property.rs
@@ -1,0 +1,92 @@
+//! Property-based tests for deployment serializers.
+
+#[cfg(test)]
+mod tests {
+	use proptest::prelude::*;
+	use uuid::Uuid;
+
+	use crate::apps::deployments::models::Deployment;
+	use crate::apps::deployments::serializers::{CreateDeploymentRequest, DeploymentResponse};
+
+	/// Strategy for generating arbitrary Deployment instances.
+	fn arb_deployment() -> impl Strategy<Value = Deployment> {
+		(
+			prop::array::uniform16(any::<u8>()),
+			"[a-z][a-z0-9\\-]{0,62}",
+			1i64..=i64::MAX,
+			prop::sample::select(vec![
+				"pending".to_string(),
+				"running".to_string(),
+				"failed".to_string(),
+				"succeeded".to_string(),
+			]),
+			"[a-z0-9./:\\-]{1,128}",
+		)
+			.prop_map(|(uuid_bytes, app_name, cluster_id, status, image)| {
+				let mut d = Deployment::new(
+					Uuid::from_bytes(uuid_bytes),
+					app_name,
+					cluster_id,
+					status,
+					image,
+				);
+				d.id = Some(cluster_id);
+				d
+			})
+	}
+
+	proptest! {
+		/// DeploymentResponse::from preserves all fields from the source Deployment.
+		#[test]
+		fn test_deployment_response_preserves_fields(
+			(expected_id, expected_app, expected_cluster, expected_status, expected_image, deployment)
+			in arb_deployment().prop_map(|d| {
+				let id = d.id;
+				let app = d.app_name.clone();
+				let cluster = d.cluster_id;
+				let status = d.status.clone();
+				let image = d.image.clone();
+				(id, app, cluster, status, image, d)
+			})
+		) {
+			// Act
+			let response = DeploymentResponse::from(deployment);
+
+			// Assert
+			prop_assert_eq!(response.id, expected_id);
+			prop_assert_eq!(&response.app_name, &expected_app);
+			prop_assert_eq!(response.cluster_id, expected_cluster);
+			prop_assert_eq!(&response.status, &expected_status);
+			prop_assert_eq!(&response.image, &expected_image);
+		}
+
+		/// CreateDeploymentRequest survives a JSON serialize/deserialize roundtrip.
+		#[test]
+		fn test_create_deployment_request_roundtrip(
+			app_name in "[a-z]{1,63}",
+			cluster_id in 1i64..=1_000_000,
+			image in "[a-z0-9]{1,128}",
+		) {
+			// Arrange — build JSON string manually (CreateDeploymentRequest has no Serialize)
+			let json = format!(
+				r#"{{"app_name":"{}","cluster_id":{},"image":"{}"}}"#,
+				app_name, cluster_id, image,
+			);
+
+			// Act
+			let restored: CreateDeploymentRequest = serde_json::from_str(&json).expect("deserialize");
+
+			// Assert
+			prop_assert_eq!(&restored.app_name, &app_name);
+			prop_assert_eq!(restored.cluster_id, cluster_id);
+			prop_assert_eq!(&restored.image, &image);
+		}
+
+		/// Arbitrary JSON never causes a panic in CreateDeploymentRequest deserialization.
+		#[test]
+		fn test_arbitrary_json_deployment_no_panic(s in "\\PC{0,256}") {
+			// Act & Assert — should never panic, only Ok or Err
+			let _ = serde_json::from_str::<CreateDeploymentRequest>(&s);
+		}
+	}
+}

--- a/dashboard/src/apps/deployments/tests/unit/test_request_validation.rs
+++ b/dashboard/src/apps/deployments/tests/unit/test_request_validation.rs
@@ -1,0 +1,106 @@
+//! Boundary validation tests for CreateDeploymentRequest.
+
+#[cfg(test)]
+mod tests {
+	use reinhardt::Validate;
+	use rstest::rstest;
+
+	use crate::apps::deployments::serializers::CreateDeploymentRequest;
+
+	/// Validate app_name length boundaries (min=1, max=63).
+	#[rstest]
+	#[case("a", true)]
+	#[case("", false)]
+	#[case(&"a".repeat(63), true)]
+	#[case(&"a".repeat(64), false)]
+	fn test_deployment_app_name_boundary(#[case] app_name: &str, #[case] valid: bool) {
+		// Arrange
+		let req = CreateDeploymentRequest {
+			app_name: app_name.to_string(),
+			cluster_id: 1,
+			image: "nginx:latest".to_string(),
+		};
+
+		// Act
+		let result = req.validate();
+
+		// Assert
+		assert_eq!(
+			result.is_ok(),
+			valid,
+			"app_name={app_name:?} expected valid={valid}"
+		);
+	}
+
+	/// Validate cluster_id range boundaries (min=1).
+	#[rstest]
+	#[case(1i64, true)]
+	#[case(0i64, false)]
+	#[case(-1i64, false)]
+	#[case(i64::MAX, true)]
+	fn test_deployment_cluster_id_boundary(#[case] cluster_id: i64, #[case] valid: bool) {
+		// Arrange
+		let req = CreateDeploymentRequest {
+			app_name: "my-app".to_string(),
+			cluster_id,
+			image: "nginx:latest".to_string(),
+		};
+
+		// Act
+		let result = req.validate();
+
+		// Assert
+		assert_eq!(
+			result.is_ok(),
+			valid,
+			"cluster_id={cluster_id} expected valid={valid}"
+		);
+	}
+
+	/// Validate image length boundaries (min=1, max=512).
+	#[rstest]
+	#[case("n", true)]
+	#[case("", false)]
+	#[case(&"n".repeat(512), true)]
+	#[case(&"n".repeat(513), false)]
+	fn test_deployment_image_boundary(#[case] image: &str, #[case] valid: bool) {
+		// Arrange
+		let req = CreateDeploymentRequest {
+			app_name: "my-app".to_string(),
+			cluster_id: 1,
+			image: image.to_string(),
+		};
+
+		// Act
+		let result = req.validate();
+
+		// Assert
+		assert_eq!(
+			result.is_ok(),
+			valid,
+			"image len={} expected valid={valid}",
+			image.len()
+		);
+	}
+
+	/// Missing required fields cause deserialization errors.
+	#[rstest]
+	#[case(r#"{"cluster_id": 1, "image": "nginx"}"#, "app_name")]
+	#[case(r#"{"app_name": "web", "image": "nginx"}"#, "cluster_id")]
+	#[case(r#"{"app_name": "web", "cluster_id": 1}"#, "image")]
+	fn test_deployment_request_missing_fields(#[case] json: &str, #[case] missing_field: &str) {
+		// Arrange & Act
+		let result = serde_json::from_str::<CreateDeploymentRequest>(json);
+
+		// Assert
+		assert!(
+			result.is_err(),
+			"Should fail when {missing_field} is missing"
+		);
+		let err_msg = result.unwrap_err().to_string();
+		assert!(
+			err_msg.contains(missing_field),
+			"Error should mention '{missing_field}', got: {err_msg}"
+		);
+	}
+}

--- a/dashboard/src/apps/realtime/broadcaster.rs
+++ b/dashboard/src/apps/realtime/broadcaster.rs
@@ -508,6 +508,156 @@ mod tests {
 
 	#[rstest]
 	#[tokio::test]
+	async fn test_multiple_connections_same_user() {
+		// Arrange
+		let broadcaster = WsBroadcaster::new();
+		let (conn1, mut rx1) = make_connection("conn-1");
+		let (conn2, mut rx2) = make_connection("conn-2");
+
+		// Act — register two connections for the same user
+		broadcaster
+			.register_connection("conn-1", "user-1", conn1)
+			.await;
+		broadcaster
+			.register_connection("conn-2", "user-1", conn2)
+			.await;
+
+		// Assert — connection_count counts users, not connections
+		assert_eq!(broadcaster.connection_count().await, 1);
+
+		// Act — broadcast system notification
+		let payload = SystemNotificationPayload {
+			id: "notif-1".to_string(),
+			level: NotificationLevel::Info,
+			title: "Test".to_string(),
+			message: "Broadcast test".to_string(),
+			timestamp: "2026-03-22T00:00:00Z".to_string(),
+		};
+		broadcaster.broadcast_system_notification(&payload).await;
+
+		// Assert — both connections receive the broadcast
+		assert!(rx1.try_recv().is_ok(), "conn-1 should receive the message");
+		assert!(rx2.try_recv().is_ok(), "conn-2 should receive the message");
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_remove_one_connection_keeps_subscriptions() {
+		// Arrange
+		let broadcaster = WsBroadcaster::new();
+		let (conn1, _rx1) = make_connection("conn-1");
+		let (conn2, _rx2) = make_connection("conn-2");
+		broadcaster
+			.register_connection("conn-1", "user-1", conn1)
+			.await;
+		broadcaster
+			.register_connection("conn-2", "user-1", conn2)
+			.await;
+		broadcaster.subscribe("conn-1", "user-1", "dep-a").await;
+		broadcaster.subscribe("conn-2", "user-1", "dep-a").await;
+
+		// Act — remove conn-1 only
+		broadcaster.remove_connection("conn-1").await;
+
+		// Assert — user still subscribed because conn-2 is alive
+		assert!(broadcaster.is_subscribed("user-1", "dep-a").await);
+		assert_eq!(broadcaster.connection_count().await, 1);
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_try_subscribe_idempotent() {
+		// Arrange
+		let broadcaster = WsBroadcaster::new();
+		let (conn, _rx) = make_connection("conn-1");
+		broadcaster
+			.register_connection("conn-1", "user-1", conn)
+			.await;
+
+		// Act — subscribe twice to the same deployment
+		let first = broadcaster.try_subscribe("conn-1", "user-1", "dep-a").await;
+		let second = broadcaster.try_subscribe("conn-1", "user-1", "dep-a").await;
+
+		// Assert — both return true
+		assert!(first);
+		assert!(second);
+		assert!(broadcaster.is_subscribed("user-1", "dep-a").await);
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_subscribe_unregistered_connection_noop() {
+		// Arrange
+		let broadcaster = WsBroadcaster::new();
+
+		// Act — subscribe an unknown connection (no panic expected)
+		broadcaster.subscribe("ghost-conn", "user-x", "dep-a").await;
+
+		// Assert — user is tracked in subscriptions but connection was a no-op
+		assert!(broadcaster.is_subscribed("user-x", "dep-a").await);
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_cleanup_nonexistent_user_noop() {
+		// Arrange
+		let broadcaster = WsBroadcaster::new();
+
+		// Act — cleanup a user that was never registered (no panic expected)
+		broadcaster.cleanup_user("ghost").await;
+
+		// Assert — still zero connections
+		assert_eq!(broadcaster.connection_count().await, 0);
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_broadcast_to_empty_room_noop() {
+		// Arrange
+		let broadcaster = WsBroadcaster::new();
+		let payload = DeploymentStatusPayload {
+			deployment_id: "dep-nonexistent".to_string(),
+			name: "ghost-app".to_string(),
+			namespace: "default".to_string(),
+			status: DeploymentState::Failed,
+			ready_replicas: 0,
+			desired_replicas: 1,
+			message: None,
+			timestamp: "2026-03-22T00:00:00Z".to_string(),
+		};
+
+		// Act — broadcast to a deployment with no subscribers (no panic expected)
+		broadcaster.broadcast_deployment_status(&payload).await;
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_connection_full_lifecycle() {
+		// Arrange
+		let broadcaster = WsBroadcaster::new();
+		let (conn, _rx) = make_connection("conn-1");
+
+		// Act & Assert — register
+		broadcaster
+			.register_connection("conn-1", "user-1", conn)
+			.await;
+		assert_eq!(broadcaster.connection_count().await, 1);
+
+		// Act & Assert — subscribe
+		broadcaster.subscribe("conn-1", "user-1", "dep-a").await;
+		assert!(broadcaster.is_subscribed("user-1", "dep-a").await);
+
+		// Act & Assert — unsubscribe
+		broadcaster.unsubscribe("conn-1", "dep-a").await;
+		assert!(!broadcaster.is_subscribed("user-1", "dep-a").await);
+
+		// Act & Assert — remove
+		broadcaster.remove_connection("conn-1").await;
+		assert_eq!(broadcaster.connection_count().await, 0);
+	}
+
+	#[rstest]
+	#[tokio::test]
 	async fn test_cleanup_user_removes_connections_and_subscriptions() {
 		// Arrange
 		let broadcaster = WsBroadcaster::new();

--- a/dashboard/src/apps/realtime/consumer.rs
+++ b/dashboard/src/apps/realtime/consumer.rs
@@ -283,6 +283,77 @@ mod tests {
 	}
 
 	#[rstest]
+	fn test_parse_unsubscribe_without_auth_works() {
+		// Arrange
+		let msg = WsClientMessage::Unsubscribe {
+			deployment_ids: vec!["dep-1".to_string()],
+		};
+
+		// Act — no user_id (unauthenticated), but Unsubscribe should still work
+		let action = NotificationConsumer::parse_client_message(None, msg);
+
+		// Assert
+		match action {
+			ParsedAction::Unsubscribe { deployment_ids } => {
+				assert_eq!(deployment_ids, vec!["dep-1"]);
+			}
+			_ => panic!("expected Unsubscribe action"),
+		}
+	}
+
+	#[rstest]
+	fn test_parse_subscribe_empty_deployment_ids() {
+		// Arrange
+		let msg = WsClientMessage::Subscribe {
+			deployment_ids: vec![],
+		};
+
+		// Act — authenticated user subscribes with empty list
+		let action = NotificationConsumer::parse_client_message(Some("user-1"), msg);
+
+		// Assert
+		match action {
+			ParsedAction::Subscribe { deployment_ids } => {
+				assert!(deployment_ids.is_empty());
+			}
+			_ => panic!("expected Subscribe action"),
+		}
+	}
+
+	#[rstest]
+	#[serial(jwt)]
+	fn test_parse_authenticate_empty_token() {
+		// Arrange
+		// SAFETY: Tests using this helper are serialized with #[serial(jwt)]
+		// to prevent concurrent environment variable mutation.
+		unsafe {
+			std::env::set_var(
+				"REINHARDT_CLOUD_JWT_SECRET",
+				"test-secret-key-for-unit-tests-minimum-length-32",
+			);
+		}
+
+		let msg = WsClientMessage::Authenticate {
+			token: "".to_string(),
+		};
+
+		// Act
+		let action = NotificationConsumer::parse_client_message(None, msg);
+
+		// Assert
+		match action {
+			ParsedAction::AuthFailure { response } => match &response {
+				WsMessage::AuthResult(payload) => {
+					assert!(!payload.success);
+					assert!(payload.message.is_some());
+				}
+				_ => panic!("expected AuthResult"),
+			},
+			_ => panic!("expected AuthFailure action"),
+		}
+	}
+
+	#[rstest]
 	#[tokio::test]
 	async fn test_on_disconnect_cleans_up_broadcaster() {
 		// Arrange

--- a/dashboard/src/apps/validators.rs
+++ b/dashboard/src/apps/validators.rs
@@ -33,3 +33,178 @@ pub fn validate_k8s_dns_label(value: &str) -> Result<(), String> {
 
 	Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use rstest::rstest;
+
+	#[rstest]
+	#[case("a", true)]
+	#[case("abc", true)]
+	#[case("a-b", true)]
+	#[case("a1", true)]
+	#[case("1a", true)]
+	#[case("abc-def-123", true)]
+	#[case("a1b2c3", true)]
+	fn test_valid_dns_labels(#[case] input: &str, #[case] expected_valid: bool) {
+		// Act
+		let result = validate_k8s_dns_label(input);
+
+		// Assert
+		assert_eq!(result.is_ok(), expected_valid);
+	}
+
+	#[rstest]
+	#[case("", false, "must be between 1 and 63")]
+	#[case("a", true, "")]
+	#[case(&"a".repeat(63), true, "")]
+	#[case(&"a".repeat(64), false, "must be between 1 and 63")]
+	fn test_dns_label_length_boundary(
+		#[case] input: &str,
+		#[case] expected_ok: bool,
+		#[case] expected_msg: &str,
+	) {
+		// Act
+		let result = validate_k8s_dns_label(input);
+
+		// Assert
+		assert_eq!(result.is_ok(), expected_ok);
+		if !expected_ok {
+			assert!(result.unwrap_err().contains(expected_msg));
+		}
+	}
+
+	#[rstest]
+	#[case("-abc", "must start")]
+	#[case("_abc", "must start")]
+	#[case("Abc", "must start")]
+	fn test_dns_label_invalid_start(#[case] input: &str, #[case] expected_msg: &str) {
+		// Act
+		let result = validate_k8s_dns_label(input);
+
+		// Assert
+		assert!(result.is_err());
+		assert!(
+			result.unwrap_err().contains(expected_msg),
+			"expected error containing '{expected_msg}'"
+		);
+	}
+
+	#[rstest]
+	#[case("abc-", "must end")]
+	fn test_dns_label_invalid_end(#[case] input: &str, #[case] expected_msg: &str) {
+		// Act
+		let result = validate_k8s_dns_label(input);
+
+		// Assert
+		assert!(result.is_err());
+		assert!(
+			result.unwrap_err().contains(expected_msg),
+			"expected error containing '{expected_msg}'"
+		);
+	}
+
+	#[rstest]
+	#[case("abc_def", "must contain only")]
+	#[case("abc.def", "must contain only")]
+	#[case("ab cd", "must contain only")]
+	#[case("ABC", "must start")]
+	fn test_dns_label_invalid_chars(#[case] input: &str, #[case] expected_msg: &str) {
+		// Act
+		let result = validate_k8s_dns_label(input);
+
+		// Assert
+		assert!(result.is_err());
+		assert!(
+			result.unwrap_err().contains(expected_msg),
+			"expected error containing '{expected_msg}'"
+		);
+	}
+
+	#[rstest]
+	#[case("Abc")]
+	#[case("aBc")]
+	#[case("abC")]
+	fn test_dns_label_uppercase_rejected(#[case] input: &str) {
+		// Act
+		let result = validate_k8s_dns_label(input);
+
+		// Assert
+		assert!(result.is_err());
+	}
+
+	#[rstest]
+	#[case("a", true)]
+	#[case("1", true)]
+	#[case("-", false)]
+	#[case("A", false)]
+	fn test_dns_label_single_char_boundary(#[case] input: &str, #[case] expected_ok: bool) {
+		// Act
+		let result = validate_k8s_dns_label(input);
+
+		// Assert
+		assert_eq!(result.is_ok(), expected_ok);
+	}
+
+	#[rstest]
+	fn test_dns_label_combinatorial() {
+		// Arrange
+		let valid_starts = ['a', 'z', '0', '9'];
+		let valid_ends = ['a', 'z', '0', '9'];
+		let invalid_starts = ['-', 'A', '_'];
+		let invalid_ends = ['-'];
+
+		// Act & Assert — valid start × valid end
+		for &start in &valid_starts {
+			for &end in &valid_ends {
+				let label = format!("{start}x{end}");
+				assert!(
+					validate_k8s_dns_label(&label).is_ok(),
+					"expected '{label}' to be valid"
+				);
+			}
+		}
+
+		// Act & Assert — invalid start
+		for &start in &invalid_starts {
+			let label = format!("{start}abc");
+			assert!(
+				validate_k8s_dns_label(&label).is_err(),
+				"expected '{label}' to be invalid"
+			);
+		}
+
+		// Act & Assert — invalid end
+		for &end in &invalid_ends {
+			let label = format!("abc{end}");
+			assert!(
+				validate_k8s_dns_label(&label).is_err(),
+				"expected 'abc{end}' to be invalid"
+			);
+		}
+	}
+
+	mod property_tests {
+		use super::super::*;
+		use proptest::prelude::*;
+
+		proptest! {
+			#[test]
+			fn test_dns_label_property_valid_always_pass(
+				s in "[a-z0-9][a-z0-9\\-]{0,61}[a-z0-9]"
+			) {
+				// Valid labels that match the regex should always pass
+				if s.len() <= 63 {
+					prop_assert!(validate_k8s_dns_label(&s).is_ok());
+				}
+			}
+
+			#[test]
+			fn test_dns_label_fuzz_never_panics(s in "\\PC{0,100}") {
+				// Any string should never panic, only return Ok or Err
+				let _ = validate_k8s_dns_label(&s);
+			}
+		}
+	}
+}

--- a/dashboard/src/shared/errors.rs
+++ b/dashboard/src/shared/errors.rs
@@ -51,3 +51,74 @@ impl std::fmt::Display for AppError {
 }
 
 impl std::error::Error for AppError {}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use rstest::rstest;
+
+	#[rstest]
+	#[case(AppError::InvalidCredentials, "Invalid credentials")]
+	#[case(AppError::SessionExpired, "Session expired")]
+	#[case(AppError::NotFound, "Not found")]
+	#[case(AppError::Conflict("dup".into()), "Conflict: dup")]
+	#[case(AppError::Internal("boom".into()), "Internal error: boom")]
+	fn test_app_error_display_variants(#[case] error: AppError, #[case] expected: &str) {
+		// Act
+		let display = error.to_string();
+
+		// Assert
+		assert_eq!(display, expected);
+	}
+
+	#[rstest]
+	fn test_app_error_validation_display() {
+		// Arrange
+		let error = AppError::ValidationError(vec![
+			FieldError {
+				field: "username".to_string(),
+				message: "too short".to_string(),
+			},
+			FieldError {
+				field: "email".to_string(),
+				message: "invalid format".to_string(),
+			},
+		]);
+
+		// Act
+		let display = error.to_string();
+
+		// Assert
+		assert!(display.contains("username: too short"));
+		assert!(display.contains("email: invalid format"));
+	}
+
+	#[rstest]
+	#[case(AppError::InvalidCredentials)]
+	#[case(AppError::SessionExpired)]
+	#[case(AppError::NotFound)]
+	#[case(AppError::Conflict("dup".into()))]
+	#[case(AppError::Internal("boom".into()))]
+	#[case(AppError::ValidationError(vec![FieldError { field: "f".into(), message: "m".into() }]))]
+	fn test_app_error_serde_roundtrip(#[case] error: AppError) {
+		// Act
+		let json = serde_json::to_string(&error).unwrap();
+		let roundtrip: AppError = serde_json::from_str(&json).unwrap();
+
+		// Assert
+		assert_eq!(error.to_string(), roundtrip.to_string());
+	}
+
+	#[rstest]
+	fn test_field_error_construction() {
+		// Arrange
+		let field_error = FieldError {
+			field: "password".to_string(),
+			message: "must be at least 8 characters".to_string(),
+		};
+
+		// Assert
+		assert_eq!(field_error.field, "password");
+		assert_eq!(field_error.message, "must be at least 8 characters");
+	}
+}

--- a/dashboard/src/shared/types.rs
+++ b/dashboard/src/shared/types.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 /// User information returned after authentication.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct UserInfo {
 	/// User's unique identifier (UUID as string).
 	pub id: String,
@@ -27,7 +27,7 @@ impl From<&crate::apps::auth::models::User> for UserInfo {
 }
 
 /// Response from login/register server functions.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AuthResponse {
 	/// Whether authentication was successful.
 	pub success: bool,
@@ -40,4 +40,73 @@ pub struct AuthResponse {
 	/// available from within `#[server_fn]` handlers because the
 	/// framework constructs the HTTP response externally.
 	pub token: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use rstest::rstest;
+
+	#[rstest]
+	fn test_user_info_serde_roundtrip() {
+		// Arrange
+		let user = UserInfo {
+			id: "550e8400-e29b-41d4-a716-446655440000".to_string(),
+			username: "testuser".to_string(),
+			email: "test@example.com".to_string(),
+		};
+
+		// Act
+		let json = serde_json::to_string(&user).unwrap();
+		let roundtrip: UserInfo = serde_json::from_str(&json).unwrap();
+
+		// Assert
+		assert_eq!(roundtrip.id, user.id);
+		assert_eq!(roundtrip.username, user.username);
+		assert_eq!(roundtrip.email, user.email);
+	}
+
+	#[rstest]
+	fn test_auth_response_success() {
+		// Arrange
+		let response = AuthResponse {
+			success: true,
+			user: Some(UserInfo {
+				id: "user-1".to_string(),
+				username: "admin".to_string(),
+				email: "admin@example.com".to_string(),
+			}),
+			token: Some("jwt-token-abc".to_string()),
+		};
+
+		// Act
+		let json = serde_json::to_string(&response).unwrap();
+		let roundtrip: AuthResponse = serde_json::from_str(&json).unwrap();
+
+		// Assert
+		assert_eq!(roundtrip, response);
+		assert!(roundtrip.success);
+		assert!(roundtrip.user.is_some());
+		assert!(roundtrip.token.is_some());
+	}
+
+	#[rstest]
+	fn test_auth_response_failure() {
+		// Arrange
+		let response = AuthResponse {
+			success: false,
+			user: None,
+			token: None,
+		};
+
+		// Act
+		let json = serde_json::to_string(&response).unwrap();
+		let roundtrip: AuthResponse = serde_json::from_str(&json).unwrap();
+
+		// Assert
+		assert_eq!(roundtrip, response);
+		assert!(!roundtrip.success);
+		assert!(roundtrip.user.is_none());
+		assert!(roundtrip.token.is_none());
+	}
 }

--- a/dashboard/src/shared/ws_messages.rs
+++ b/dashboard/src/shared/ws_messages.rs
@@ -199,4 +199,70 @@ mod tests {
 		// Assert
 		assert!(result.is_err());
 	}
+
+	#[rstest]
+	#[case(DeploymentState::Deploying)]
+	#[case(DeploymentState::Running)]
+	#[case(DeploymentState::Degraded)]
+	#[case(DeploymentState::Failed)]
+	#[case(DeploymentState::Stopped)]
+	fn test_deployment_state_all_variants_roundtrip(#[case] state: DeploymentState) {
+		// Act
+		let json = serde_json::to_string(&state).unwrap();
+		let roundtrip: DeploymentState = serde_json::from_str(&json).unwrap();
+
+		// Assert
+		assert_eq!(roundtrip, state);
+	}
+
+	#[rstest]
+	#[case(NotificationLevel::Info)]
+	#[case(NotificationLevel::Warning)]
+	#[case(NotificationLevel::Critical)]
+	fn test_notification_level_all_variants_roundtrip(#[case] level: NotificationLevel) {
+		// Act
+		let json = serde_json::to_string(&level).unwrap();
+		let roundtrip: NotificationLevel = serde_json::from_str(&json).unwrap();
+
+		// Assert
+		assert_eq!(roundtrip, level);
+	}
+
+	#[rstest]
+	#[case(None)]
+	#[case(Some("".to_string()))]
+	fn test_deployment_status_payload_optional_message(#[case] message: Option<String>) {
+		// Arrange
+		let payload = DeploymentStatusPayload {
+			deployment_id: "dep-1".to_string(),
+			name: "my-app".to_string(),
+			namespace: "default".to_string(),
+			status: DeploymentState::Running,
+			ready_replicas: 1,
+			desired_replicas: 1,
+			message: message.clone(),
+			timestamp: "2026-03-22T00:00:00Z".to_string(),
+		};
+
+		// Act
+		let json = serde_json::to_string(&payload).unwrap();
+		let roundtrip: DeploymentStatusPayload = serde_json::from_str(&json).unwrap();
+
+		// Assert
+		assert_eq!(roundtrip.message, message);
+	}
+
+	mod property_tests {
+		use super::super::*;
+		use proptest::prelude::*;
+
+		proptest! {
+			#[test]
+			fn test_ws_client_message_fuzz_no_panic(s in "\\PC{0,500}") {
+				// Any string should never panic, only return Ok or Err
+				let _ = serde_json::from_str::<WsMessage>(&s);
+				let _ = serde_json::from_str::<WsClientMessage>(&s);
+			}
+		}
+	}
 }

--- a/dashboard/tests/e2e.rs
+++ b/dashboard/tests/e2e.rs
@@ -1,2 +1,6 @@
+#[path = "e2e/auth_clusters.rs"]
+mod auth_clusters;
+#[path = "e2e/auth_clusters_deployments.rs"]
+mod auth_clusters_deployments;
 #[path = "e2e/clusters_deployments.rs"]
 mod clusters_deployments;

--- a/dashboard/tests/e2e/auth_clusters.rs
+++ b/dashboard/tests/e2e/auth_clusters.rs
@@ -1,0 +1,2 @@
+#[path = "auth_clusters/test_token_lifecycle.rs"]
+mod test_token_lifecycle;

--- a/dashboard/tests/e2e/auth_clusters/test_token_lifecycle.rs
+++ b/dashboard/tests/e2e/auth_clusters/test_token_lifecycle.rs
@@ -1,0 +1,231 @@
+//! JWT token lifecycle tests across auth and cluster endpoints.
+//!
+//! Verifies that tokens obtained via register and login are both
+//! accepted by protected cluster endpoints, and that tampered
+//! tokens are correctly rejected.
+
+use reinhardt::prelude::DatabaseConnection;
+use reinhardt::test::APIClient;
+use reinhardt::test::fixtures::TestServerGuard;
+use reinhardt::test::fixtures::{ContainerAsync, GenericImage, api_client_from_url};
+use reinhardt::test::fixtures::{postgres_with_migrations_from_dir, test_server_guard};
+use rstest::*;
+use serde_json::json;
+use serial_test::serial;
+use std::sync::Arc;
+
+use reinhardt_cloud_dashboard::routes;
+
+// ============================================================================
+// Fixtures & Helpers
+// ============================================================================
+
+#[fixture]
+async fn test_app() -> (
+	ContainerAsync<GenericImage>,
+	Arc<DatabaseConnection>,
+	TestServerGuard,
+	APIClient,
+) {
+	unsafe {
+		std::env::set_var(
+			"REINHARDT_CLOUD_JWT_SECRET",
+			"test-secret-minimum-32-bytes-long!!",
+		);
+	}
+	let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
+	let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
+		.await
+		.expect("Failed to start PostgreSQL with migrations");
+	let router = routes().into_server();
+	let server = test_server_guard(router).await;
+	let client = api_client_from_url(&server.url);
+	(container, conn, server, client)
+}
+
+async fn register_and_get_token(client: &APIClient) -> String {
+	let register_data = json!({
+		"username": "testuser",
+		"email": "test@example.com",
+		"password": "securepassword123"
+	});
+	let resp = client
+		.post("/api/auth/register/", &register_data, "json")
+		.await
+		.expect("Register request failed");
+	assert_eq!(resp.status_code(), 201);
+	let body: serde_json::Value = resp.json().expect("Failed to parse JSON response");
+	body["token"].as_str().unwrap().to_string()
+}
+
+async fn authenticate_client(client: &APIClient, token: &str) {
+	client
+		.set_header("Authorization", format!("Bearer {token}"))
+		.await
+		.expect("Failed to set Authorization header");
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+/// Register token is accepted by the cluster creation endpoint.
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+#[serial(database)]
+async fn test_register_token_works_for_cluster_creation(
+	#[future] test_app: (
+		ContainerAsync<GenericImage>,
+		Arc<DatabaseConnection>,
+		TestServerGuard,
+		APIClient,
+	),
+) {
+	// Arrange
+	let (_container, _conn, _server, client) = test_app.await;
+	let token = register_and_get_token(&client).await;
+	authenticate_client(&client, &token).await;
+
+	// Act
+	let cluster_data = json!({
+		"name": "register-token-cluster",
+		"api_url": "https://register.k8s.local:6443"
+	});
+	let resp = client
+		.post("/api/clusters/", &cluster_data, "json")
+		.await
+		.expect("Create cluster request failed");
+
+	// Assert
+	assert_eq!(resp.status_code(), 201);
+}
+
+/// Login token is accepted by the cluster creation endpoint.
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+#[serial(database)]
+async fn test_login_token_works_for_cluster_creation(
+	#[future] test_app: (
+		ContainerAsync<GenericImage>,
+		Arc<DatabaseConnection>,
+		TestServerGuard,
+		APIClient,
+	),
+) {
+	// Arrange
+	let (_container, _conn, _server, client) = test_app.await;
+	let _register_token = register_and_get_token(&client).await;
+
+	// Login with the same credentials
+	let login_data = json!({
+		"username": "testuser",
+		"password": "securepassword123"
+	});
+	let login_resp = client
+		.post("/api/auth/login/", &login_data, "json")
+		.await
+		.expect("Login request failed");
+	assert_eq!(login_resp.status_code(), 200);
+	let login_body: serde_json::Value = login_resp.json().expect("Failed to parse login response");
+	let login_token = login_body["token"].as_str().unwrap();
+	authenticate_client(&client, login_token).await;
+
+	// Act
+	let cluster_data = json!({
+		"name": "login-token-cluster",
+		"api_url": "https://login.k8s.local:6443"
+	});
+	let resp = client
+		.post("/api/clusters/", &cluster_data, "json")
+		.await
+		.expect("Create cluster request failed");
+
+	// Assert
+	assert_eq!(resp.status_code(), 201);
+}
+
+/// Register and login tokens both give access to the same resources.
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+#[serial(database)]
+async fn test_register_and_login_tokens_same_resources(
+	#[future] test_app: (
+		ContainerAsync<GenericImage>,
+		Arc<DatabaseConnection>,
+		TestServerGuard,
+		APIClient,
+	),
+) {
+	// Arrange
+	let (_container, _conn, _server, client) = test_app.await;
+	let register_token = register_and_get_token(&client).await;
+
+	// Create a cluster with the register token
+	authenticate_client(&client, &register_token).await;
+	let cluster_data = json!({
+		"name": "shared-cluster",
+		"api_url": "https://shared.k8s.local:6443"
+	});
+	let create_resp = client
+		.post("/api/clusters/", &cluster_data, "json")
+		.await
+		.expect("Create cluster failed");
+	assert_eq!(create_resp.status_code(), 201);
+
+	// Login to get a new token
+	let login_data = json!({
+		"username": "testuser",
+		"password": "securepassword123"
+	});
+	let login_resp = client
+		.post("/api/auth/login/", &login_data, "json")
+		.await
+		.expect("Login request failed");
+	assert_eq!(login_resp.status_code(), 200);
+	let login_body: serde_json::Value = login_resp.json().expect("Failed to parse login response");
+	let login_token = login_body["token"].as_str().unwrap();
+
+	// Act — list clusters with the login token
+	authenticate_client(&client, login_token).await;
+	let list_resp = client
+		.get("/api/clusters/")
+		.await
+		.expect("List clusters failed");
+
+	// Assert — the cluster created with register token is visible
+	assert_eq!(list_resp.status_code(), 200);
+	let body: serde_json::Value = list_resp.json().expect("Failed to parse list response");
+	let items = body["items"].as_array().expect("items should be an array");
+	assert_eq!(items.len(), 1);
+	assert_eq!(items[0]["name"], "shared-cluster");
+}
+
+/// A tampered token must be rejected at resource endpoints.
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+#[serial(database)]
+async fn test_tampered_token_rejected_at_resource_endpoint(
+	#[future] test_app: (
+		ContainerAsync<GenericImage>,
+		Arc<DatabaseConnection>,
+		TestServerGuard,
+		APIClient,
+	),
+) {
+	// Arrange
+	let (_container, _conn, _server, client) = test_app.await;
+	let token = register_and_get_token(&client).await;
+
+	// Tamper with the token by flipping a character
+	let mut tampered = token.clone();
+	let bytes = unsafe { tampered.as_bytes_mut() };
+	let last = bytes.len() - 1;
+	bytes[last] = if bytes[last] == b'a' { b'b' } else { b'a' };
+	authenticate_client(&client, &tampered).await;
+
+	// Act
+	let resp = client.get("/api/clusters/").await.expect("Request failed");
+
+	// Assert
+	assert_eq!(resp.status_code(), 401);
+}

--- a/dashboard/tests/e2e/auth_clusters_deployments.rs
+++ b/dashboard/tests/e2e/auth_clusters_deployments.rs
@@ -1,0 +1,2 @@
+#[path = "auth_clusters_deployments/test_full_workflow.rs"]
+mod test_full_workflow;

--- a/dashboard/tests/e2e/auth_clusters_deployments/test_full_workflow.rs
+++ b/dashboard/tests/e2e/auth_clusters_deployments/test_full_workflow.rs
@@ -1,0 +1,255 @@
+//! Full user journey tests spanning auth, clusters, and deployments.
+//!
+//! Verifies the complete workflow: register -> create cluster -> create
+//! deployment -> list deployments, and ensures two independent users
+//! have complete resource isolation.
+
+use reinhardt::prelude::DatabaseConnection;
+use reinhardt::test::APIClient;
+use reinhardt::test::fixtures::TestServerGuard;
+use reinhardt::test::fixtures::{ContainerAsync, GenericImage, api_client_from_url};
+use reinhardt::test::fixtures::{postgres_with_migrations_from_dir, test_server_guard};
+use rstest::*;
+use serde_json::json;
+use serial_test::serial;
+use std::sync::Arc;
+
+use reinhardt_cloud_dashboard::routes;
+
+// ============================================================================
+// Fixtures & Helpers
+// ============================================================================
+
+#[fixture]
+async fn test_app() -> (
+	ContainerAsync<GenericImage>,
+	Arc<DatabaseConnection>,
+	TestServerGuard,
+	APIClient,
+) {
+	unsafe {
+		std::env::set_var(
+			"REINHARDT_CLOUD_JWT_SECRET",
+			"test-secret-minimum-32-bytes-long!!",
+		);
+	}
+	let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
+	let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
+		.await
+		.expect("Failed to start PostgreSQL with migrations");
+	let router = routes().into_server();
+	let server = test_server_guard(router).await;
+	let client = api_client_from_url(&server.url);
+	(container, conn, server, client)
+}
+
+async fn register_user(client: &APIClient, username: &str, email: &str) -> String {
+	let data = json!({
+		"username": username,
+		"email": email,
+		"password": "securepassword123"
+	});
+	let resp = client
+		.post("/api/auth/register/", &data, "json")
+		.await
+		.expect("Register request failed");
+	assert_eq!(resp.status_code(), 201);
+	let body: serde_json::Value = resp.json().expect("Failed to parse JSON response");
+	body["token"].as_str().unwrap().to_string()
+}
+
+async fn authenticate_client(client: &APIClient, token: &str) {
+	client
+		.set_header("Authorization", format!("Bearer {token}"))
+		.await
+		.expect("Failed to set Authorization header");
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+/// Full user journey: register -> create cluster -> create deployment -> list.
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+#[serial(database)]
+async fn test_full_user_journey(
+	#[future] test_app: (
+		ContainerAsync<GenericImage>,
+		Arc<DatabaseConnection>,
+		TestServerGuard,
+		APIClient,
+	),
+) {
+	// Arrange
+	let (_container, _conn, _server, client) = test_app.await;
+	let token = register_user(&client, "journeyuser", "journey@example.com").await;
+	authenticate_client(&client, &token).await;
+
+	// Act — create cluster
+	let cluster_data = json!({
+		"name": "journey-cluster",
+		"api_url": "https://journey.k8s.local:6443"
+	});
+	let cluster_resp = client
+		.post("/api/clusters/", &cluster_data, "json")
+		.await
+		.expect("Create cluster failed");
+	assert_eq!(cluster_resp.status_code(), 201);
+	let cluster: serde_json::Value = cluster_resp.json().expect("Failed to parse cluster");
+	let cluster_id = cluster["id"].as_i64().expect("Cluster id should be i64");
+
+	// Act — create deployment
+	let deployment_data = json!({
+		"app_name": "journey-app",
+		"cluster_id": cluster_id,
+		"image": "registry.example.com/journey-app:v1.0.0"
+	});
+	let deploy_resp = client
+		.post("/api/deployments/", &deployment_data, "json")
+		.await
+		.expect("Create deployment failed");
+	assert_eq!(deploy_resp.status_code(), 201);
+	let deployment: serde_json::Value = deploy_resp.json().expect("Failed to parse deployment");
+
+	// Assert — deployment fields match
+	assert_eq!(deployment["app_name"], "journey-app");
+	assert_eq!(deployment["cluster_id"], cluster_id);
+	assert_eq!(
+		deployment["image"],
+		"registry.example.com/journey-app:v1.0.0"
+	);
+	assert_eq!(deployment["status"], "pending");
+	assert!(deployment["id"].is_number());
+
+	// Act — list deployments
+	let list_resp = client
+		.get("/api/deployments/")
+		.await
+		.expect("List deployments failed");
+
+	// Assert — deployment appears in list with correct fields
+	assert_eq!(list_resp.status_code(), 200);
+	let body: serde_json::Value = list_resp.json().expect("Failed to parse list response");
+	let items = body["items"].as_array().expect("items should be an array");
+	assert_eq!(items.len(), 1);
+	assert_eq!(items[0]["app_name"], "journey-app");
+	assert_eq!(items[0]["cluster_id"], cluster_id);
+	assert_eq!(items[0]["image"], "registry.example.com/journey-app:v1.0.0");
+	assert_eq!(body["total"], 1);
+}
+
+/// Two users register independently, create their own resources, and
+/// each sees only their own clusters and deployments.
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+#[serial(database)]
+async fn test_two_users_independent_workflows(
+	#[future] test_app: (
+		ContainerAsync<GenericImage>,
+		Arc<DatabaseConnection>,
+		TestServerGuard,
+		APIClient,
+	),
+) {
+	// Arrange
+	let (_container, _conn, server, client) = test_app.await;
+
+	// --- User A ---
+	let token_a = register_user(&client, "user_a", "a@example.com").await;
+	authenticate_client(&client, &token_a).await;
+
+	let cluster_a = json!({
+		"name": "cluster-a",
+		"api_url": "https://a.k8s.local:6443"
+	});
+	let resp = client
+		.post("/api/clusters/", &cluster_a, "json")
+		.await
+		.expect("Create cluster A failed");
+	assert_eq!(resp.status_code(), 201);
+	let cluster_a_body: serde_json::Value = resp.json().expect("parse cluster A");
+	let cluster_a_id = cluster_a_body["id"].as_i64().unwrap();
+
+	let deploy_a = json!({
+		"app_name": "app-a",
+		"cluster_id": cluster_a_id,
+		"image": "registry.example.com/app-a:v1"
+	});
+	let resp = client
+		.post("/api/deployments/", &deploy_a, "json")
+		.await
+		.expect("Create deployment A failed");
+	assert_eq!(resp.status_code(), 201);
+
+	// --- User B (new client to reset headers) ---
+	let client_b = api_client_from_url(&server.url);
+	let token_b = register_user(&client_b, "user_b", "b@example.com").await;
+	authenticate_client(&client_b, &token_b).await;
+
+	let cluster_b = json!({
+		"name": "cluster-b",
+		"api_url": "https://b.k8s.local:6443"
+	});
+	let resp = client_b
+		.post("/api/clusters/", &cluster_b, "json")
+		.await
+		.expect("Create cluster B failed");
+	assert_eq!(resp.status_code(), 201);
+	let cluster_b_body: serde_json::Value = resp.json().expect("parse cluster B");
+	let cluster_b_id = cluster_b_body["id"].as_i64().unwrap();
+
+	let deploy_b = json!({
+		"app_name": "app-b",
+		"cluster_id": cluster_b_id,
+		"image": "registry.example.com/app-b:v1"
+	});
+	let resp = client_b
+		.post("/api/deployments/", &deploy_b, "json")
+		.await
+		.expect("Create deployment B failed");
+	assert_eq!(resp.status_code(), 201);
+
+	// Assert — User A sees only their resources
+	authenticate_client(&client, &token_a).await;
+	let list_a = client
+		.get("/api/clusters/")
+		.await
+		.expect("List clusters A failed");
+	assert_eq!(list_a.status_code(), 200);
+	let body_a: serde_json::Value = list_a.json().expect("parse clusters A");
+	let items_a = body_a["items"].as_array().expect("items array");
+	assert_eq!(items_a.len(), 1);
+	assert_eq!(items_a[0]["name"], "cluster-a");
+
+	let dep_list_a = client
+		.get("/api/deployments/")
+		.await
+		.expect("List deployments A failed");
+	assert_eq!(dep_list_a.status_code(), 200);
+	let dep_body_a: serde_json::Value = dep_list_a.json().expect("parse deployments A");
+	let dep_items_a = dep_body_a["items"].as_array().expect("items array");
+	assert_eq!(dep_items_a.len(), 1);
+	assert_eq!(dep_items_a[0]["app_name"], "app-a");
+
+	// Assert — User B sees only their resources
+	let list_b = client_b
+		.get("/api/clusters/")
+		.await
+		.expect("List clusters B failed");
+	assert_eq!(list_b.status_code(), 200);
+	let body_b: serde_json::Value = list_b.json().expect("parse clusters B");
+	let items_b = body_b["items"].as_array().expect("items array");
+	assert_eq!(items_b.len(), 1);
+	assert_eq!(items_b[0]["name"], "cluster-b");
+
+	let dep_list_b = client_b
+		.get("/api/deployments/")
+		.await
+		.expect("List deployments B failed");
+	assert_eq!(dep_list_b.status_code(), 200);
+	let dep_body_b: serde_json::Value = dep_list_b.json().expect("parse deployments B");
+	let dep_items_b = dep_body_b["items"].as_array().expect("items array");
+	assert_eq!(dep_items_b.len(), 1);
+	assert_eq!(dep_items_b[0]["app_name"], "app-b");
+}

--- a/dashboard/tests/e2e/clusters_deployments.rs
+++ b/dashboard/tests/e2e/clusters_deployments.rs
@@ -1,2 +1,4 @@
 #[path = "clusters_deployments/test_deployment_with_cluster.rs"]
 mod test_deployment_with_cluster;
+#[path = "clusters_deployments/test_ownership_isolation.rs"]
+mod test_ownership_isolation;

--- a/dashboard/tests/e2e/clusters_deployments/test_ownership_isolation.rs
+++ b/dashboard/tests/e2e/clusters_deployments/test_ownership_isolation.rs
@@ -1,0 +1,235 @@
+//! Cross-user ownership isolation tests for clusters and deployments.
+//!
+//! Verifies that users cannot see each other's clusters or deployments,
+//! and that multiple deployments on the same cluster are handled correctly.
+
+use reinhardt::prelude::DatabaseConnection;
+use reinhardt::test::APIClient;
+use reinhardt::test::fixtures::TestServerGuard;
+use reinhardt::test::fixtures::{ContainerAsync, GenericImage, api_client_from_url};
+use reinhardt::test::fixtures::{postgres_with_migrations_from_dir, test_server_guard};
+use rstest::*;
+use serde_json::json;
+use serial_test::serial;
+use std::sync::Arc;
+
+use reinhardt_cloud_dashboard::routes;
+
+// ============================================================================
+// Fixtures & Helpers
+// ============================================================================
+
+#[fixture]
+async fn test_app() -> (
+	ContainerAsync<GenericImage>,
+	Arc<DatabaseConnection>,
+	TestServerGuard,
+	APIClient,
+) {
+	unsafe {
+		std::env::set_var(
+			"REINHARDT_CLOUD_JWT_SECRET",
+			"test-secret-minimum-32-bytes-long!!",
+		);
+	}
+	let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
+	let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
+		.await
+		.expect("Failed to start PostgreSQL with migrations");
+	let router = routes().into_server();
+	let server = test_server_guard(router).await;
+	let client = api_client_from_url(&server.url);
+	(container, conn, server, client)
+}
+
+async fn register_user(client: &APIClient, username: &str, email: &str) -> String {
+	let data = json!({
+		"username": username,
+		"email": email,
+		"password": "securepassword123"
+	});
+	let resp = client
+		.post("/api/auth/register/", &data, "json")
+		.await
+		.expect("Register request failed");
+	assert_eq!(resp.status_code(), 201);
+	let body: serde_json::Value = resp.json().expect("Failed to parse JSON response");
+	body["token"].as_str().unwrap().to_string()
+}
+
+async fn authenticate_client(client: &APIClient, token: &str) {
+	client
+		.set_header("Authorization", format!("Bearer {token}"))
+		.await
+		.expect("Failed to set Authorization header");
+}
+
+async fn create_cluster(client: &APIClient, name: &str) -> i64 {
+	let data = json!({
+		"name": name,
+		"api_url": format!("https://{name}.k8s.local:6443")
+	});
+	let resp = client
+		.post("/api/clusters/", &data, "json")
+		.await
+		.expect("Create cluster failed");
+	assert_eq!(resp.status_code(), 201);
+	let body: serde_json::Value = resp.json().expect("parse cluster response");
+	body["id"].as_i64().expect("Cluster id should be i64")
+}
+
+async fn create_deployment(client: &APIClient, app_name: &str, cluster_id: i64) -> i64 {
+	let data = json!({
+		"app_name": app_name,
+		"cluster_id": cluster_id,
+		"image": format!("registry.example.com/{app_name}:v1")
+	});
+	let resp = client
+		.post("/api/deployments/", &data, "json")
+		.await
+		.expect("Create deployment failed");
+	assert_eq!(resp.status_code(), 201);
+	let body: serde_json::Value = resp.json().expect("parse deployment response");
+	body["id"].as_i64().expect("Deployment id should be i64")
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+/// Two users with different resource counts see only their own data.
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+#[serial(database)]
+async fn test_two_users_full_isolation(
+	#[future] test_app: (
+		ContainerAsync<GenericImage>,
+		Arc<DatabaseConnection>,
+		TestServerGuard,
+		APIClient,
+	),
+) {
+	// Arrange
+	let (_container, _conn, server, client) = test_app.await;
+
+	// --- User A: 2 clusters, 2 deployments ---
+	let token_a = register_user(&client, "iso_user_a", "iso_a@example.com").await;
+	authenticate_client(&client, &token_a).await;
+
+	let cluster_a1 = create_cluster(&client, "iso-cluster-a1").await;
+	let cluster_a2 = create_cluster(&client, "iso-cluster-a2").await;
+	create_deployment(&client, "app-a1", cluster_a1).await;
+	create_deployment(&client, "app-a2", cluster_a2).await;
+
+	// --- User B: 1 cluster, 1 deployment ---
+	let client_b = api_client_from_url(&server.url);
+	let token_b = register_user(&client_b, "iso_user_b", "iso_b@example.com").await;
+	authenticate_client(&client_b, &token_b).await;
+
+	let cluster_b1 = create_cluster(&client_b, "iso-cluster-b1").await;
+	create_deployment(&client_b, "app-b1", cluster_b1).await;
+
+	// Assert — User A sees exactly 2 clusters and 2 deployments
+	authenticate_client(&client, &token_a).await;
+
+	let clusters_a = client
+		.get("/api/clusters/")
+		.await
+		.expect("List clusters A failed");
+	assert_eq!(clusters_a.status_code(), 200);
+	let ca_body: serde_json::Value = clusters_a.json().expect("parse clusters A");
+	let ca_items = ca_body["items"].as_array().expect("items array");
+	assert_eq!(ca_items.len(), 2, "User A should have exactly 2 clusters");
+	let ca_names: Vec<&str> = ca_items
+		.iter()
+		.map(|c| c["name"].as_str().unwrap())
+		.collect();
+	assert!(ca_names.contains(&"iso-cluster-a1"));
+	assert!(ca_names.contains(&"iso-cluster-a2"));
+
+	let deps_a = client
+		.get("/api/deployments/")
+		.await
+		.expect("List deployments A failed");
+	assert_eq!(deps_a.status_code(), 200);
+	let da_body: serde_json::Value = deps_a.json().expect("parse deployments A");
+	let da_items = da_body["items"].as_array().expect("items array");
+	assert_eq!(
+		da_items.len(),
+		2,
+		"User A should have exactly 2 deployments"
+	);
+
+	// Assert — User B sees exactly 1 cluster and 1 deployment
+	let clusters_b = client_b
+		.get("/api/clusters/")
+		.await
+		.expect("List clusters B failed");
+	assert_eq!(clusters_b.status_code(), 200);
+	let cb_body: serde_json::Value = clusters_b.json().expect("parse clusters B");
+	let cb_items = cb_body["items"].as_array().expect("items array");
+	assert_eq!(cb_items.len(), 1, "User B should have exactly 1 cluster");
+	assert_eq!(cb_items[0]["name"], "iso-cluster-b1");
+
+	let deps_b = client_b
+		.get("/api/deployments/")
+		.await
+		.expect("List deployments B failed");
+	assert_eq!(deps_b.status_code(), 200);
+	let db_body: serde_json::Value = deps_b.json().expect("parse deployments B");
+	let db_items = db_body["items"].as_array().expect("items array");
+	assert_eq!(db_items.len(), 1, "User B should have exactly 1 deployment");
+	assert_eq!(db_items[0]["app_name"], "app-b1");
+}
+
+/// Multiple deployments on the same cluster are all listed correctly.
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+#[serial(database)]
+async fn test_multiple_deployments_same_cluster(
+	#[future] test_app: (
+		ContainerAsync<GenericImage>,
+		Arc<DatabaseConnection>,
+		TestServerGuard,
+		APIClient,
+	),
+) {
+	// Arrange
+	let (_container, _conn, _server, client) = test_app.await;
+	let token = register_user(&client, "multi_deploy_user", "multi@example.com").await;
+	authenticate_client(&client, &token).await;
+
+	let cluster_id = create_cluster(&client, "multi-deploy-cluster").await;
+
+	// Act — create 3 deployments on the same cluster
+	create_deployment(&client, "svc-web", cluster_id).await;
+	create_deployment(&client, "svc-api", cluster_id).await;
+	create_deployment(&client, "svc-worker", cluster_id).await;
+
+	// Assert
+	let list_resp = client
+		.get("/api/deployments/")
+		.await
+		.expect("List deployments failed");
+	assert_eq!(list_resp.status_code(), 200);
+	let body: serde_json::Value = list_resp.json().expect("parse list response");
+	let items = body["items"].as_array().expect("items array");
+	assert_eq!(items.len(), 3, "Expected 3 deployments");
+
+	// All deployments should reference the same cluster_id
+	for item in items {
+		assert_eq!(
+			item["cluster_id"].as_i64().unwrap(),
+			cluster_id,
+			"All deployments should belong to cluster {cluster_id}"
+		);
+	}
+
+	let app_names: Vec<&str> = items
+		.iter()
+		.map(|d| d["app_name"].as_str().unwrap())
+		.collect();
+	assert!(app_names.contains(&"svc-web"));
+	assert!(app_names.contains(&"svc-api"));
+	assert!(app_names.contains(&"svc-worker"));
+}

--- a/dashboard/tests/unit.rs
+++ b/dashboard/tests/unit.rs
@@ -1,0 +1,4 @@
+#[path = "unit/test_jwt_middleware.rs"]
+mod test_jwt_middleware;
+#[path = "unit/test_routes_configuration.rs"]
+mod test_routes_configuration;

--- a/dashboard/tests/unit/test_jwt_middleware.rs
+++ b/dashboard/tests/unit/test_jwt_middleware.rs
@@ -1,0 +1,170 @@
+//! Unit and E2E tests for JwtAuthMiddleware.
+//!
+//! Verifies that `should_continue()` correctly classifies public vs
+//! protected paths, and that the middleware enforces authentication
+//! on protected endpoints at the HTTP level.
+
+use reinhardt::{Middleware, Request};
+use reinhardt_cloud_dashboard::config::middleware::JwtAuthMiddleware;
+use rstest::*;
+
+// ============================================================================
+// Unit: should_continue decision table
+// ============================================================================
+
+#[rstest]
+#[case("/api/auth/login/", false)]
+#[case("/api/auth/register/", false)]
+#[case("/api/openapi.json", false)]
+#[case("/api/docs", false)]
+#[case("/api/docs/", false)]
+#[case("/api/redoc", false)]
+#[case("/api/redoc/", false)]
+#[case("/api/clusters/", true)]
+#[case("/api/deployments/", true)]
+fn test_jwt_middleware_skip_paths(#[case] path: &str, #[case] should_enforce: bool) {
+	// Arrange
+	let middleware = JwtAuthMiddleware;
+	let request = Request::builder().uri(path).build().expect("build request");
+
+	// Act
+	let result = middleware.should_continue(&request);
+
+	// Assert
+	assert_eq!(result, should_enforce, "path={path}");
+}
+
+// ============================================================================
+// E2E: middleware enforcement via test server
+// ============================================================================
+
+use reinhardt::prelude::DatabaseConnection;
+use reinhardt::test::APIClient;
+use reinhardt::test::fixtures::TestServerGuard;
+use reinhardt::test::fixtures::{ContainerAsync, GenericImage, api_client_from_url};
+use reinhardt::test::fixtures::{postgres_with_migrations_from_dir, test_server_guard};
+use serde_json::json;
+use serial_test::serial;
+use std::sync::Arc;
+
+use reinhardt_cloud_dashboard::routes;
+
+/// PostgreSQL + migrations + test server fixture.
+#[fixture]
+async fn test_app() -> (
+	ContainerAsync<GenericImage>,
+	Arc<DatabaseConnection>,
+	TestServerGuard,
+	APIClient,
+) {
+	unsafe {
+		std::env::set_var(
+			"REINHARDT_CLOUD_JWT_SECRET",
+			"test-secret-minimum-32-bytes-long!!",
+		);
+	}
+	let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
+	let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
+		.await
+		.expect("Failed to start PostgreSQL with migrations");
+	let router = routes().into_server();
+	let server = test_server_guard(router).await;
+	let client = api_client_from_url(&server.url);
+	(container, conn, server, client)
+}
+
+/// Helper: register a test user and return the JWT token.
+async fn register_and_get_token(client: &APIClient) -> String {
+	let register_data = json!({
+		"username": "testuser",
+		"email": "test@example.com",
+		"password": "securepassword123"
+	});
+	let resp = client
+		.post("/api/auth/register/", &register_data, "json")
+		.await
+		.expect("Register request failed");
+	assert_eq!(resp.status_code(), 201);
+	let body: serde_json::Value = resp.json().expect("Failed to parse JSON response");
+	body["token"].as_str().unwrap().to_string()
+}
+
+/// Helper: set Authorization header on client.
+async fn authenticate_client(client: &APIClient, token: &str) {
+	client
+		.set_header("Authorization", format!("Bearer {token}"))
+		.await
+		.expect("Failed to set Authorization header");
+}
+
+/// Protected endpoint must reject requests without an Authorization header.
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+#[serial(database)]
+async fn test_jwt_middleware_rejects_no_auth_header(
+	#[future] test_app: (
+		ContainerAsync<GenericImage>,
+		Arc<DatabaseConnection>,
+		TestServerGuard,
+		APIClient,
+	),
+) {
+	// Arrange
+	let (_container, _conn, _server, client) = test_app.await;
+
+	// Act
+	let resp = client.get("/api/clusters/").await.expect("Request failed");
+
+	// Assert
+	assert_eq!(resp.status_code(), 401);
+}
+
+/// Protected endpoint must reject requests with an invalid JWT token.
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+#[serial(database)]
+async fn test_jwt_middleware_rejects_invalid_token(
+	#[future] test_app: (
+		ContainerAsync<GenericImage>,
+		Arc<DatabaseConnection>,
+		TestServerGuard,
+		APIClient,
+	),
+) {
+	// Arrange
+	let (_container, _conn, _server, client) = test_app.await;
+	client
+		.set_header("Authorization", "Bearer invalid-jwt-token".to_string())
+		.await
+		.expect("Failed to set header");
+
+	// Act
+	let resp = client.get("/api/clusters/").await.expect("Request failed");
+
+	// Assert
+	assert_eq!(resp.status_code(), 401);
+}
+
+/// Protected endpoint must accept requests with a valid JWT token.
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+#[serial(database)]
+async fn test_jwt_middleware_accepts_valid_token(
+	#[future] test_app: (
+		ContainerAsync<GenericImage>,
+		Arc<DatabaseConnection>,
+		TestServerGuard,
+		APIClient,
+	),
+) {
+	// Arrange
+	let (_container, _conn, _server, client) = test_app.await;
+	let token = register_and_get_token(&client).await;
+	authenticate_client(&client, &token).await;
+
+	// Act
+	let resp = client.get("/api/clusters/").await.expect("Request failed");
+
+	// Assert
+	assert_eq!(resp.status_code(), 200);
+}

--- a/dashboard/tests/unit/test_routes_configuration.rs
+++ b/dashboard/tests/unit/test_routes_configuration.rs
@@ -1,0 +1,22 @@
+//! Unit tests for application routing configuration.
+
+use rstest::rstest;
+
+use reinhardt_cloud_dashboard::config::apps::get_installed_apps;
+
+#[rstest]
+fn test_installed_apps_exact_content() {
+	// Arrange & Act
+	let apps = get_installed_apps();
+
+	// Assert — verify exact app list, not just contains
+	assert_eq!(
+		apps.len(),
+		3,
+		"Expected exactly 3 installed apps, got: {:?}",
+		apps
+	);
+	assert!(apps.contains(&"auth".to_string()));
+	assert!(apps.contains(&"clusters".to_string()));
+	assert!(apps.contains(&"deployments".to_string()));
+}


### PR DESCRIPTION
## Summary

- Add ~290 test cases across 12 categories for all dashboard apps (auth, clusters, deployments, realtime, validators, shared, middleware)
- 23 new test files + 14 modified files (~4300 lines added)
- All 795 tests pass, clippy clean, formatting clean
- Addresses test coverage gaps identified from GitHub issue analysis (#3367, #3368, #3119, #3118, #3125)

## Test Categories Covered

| Category | Count |
|----------|-------|
| Happy Path | 20 |
| Error Path | 27 |
| Edge Cases | 20 |
| State Transitions | 9 |
| Use Case | 6 |
| Fuzz (proptest) | 6 |
| Property-Based (proptest) | 11 |
| Combinatorial | 3 |
| Sanity | 12 |
| Equivalence Partitioning | 10 |
| Boundary Value Analysis | 13 |
| Decision Table | 5 |

## GitHub Issue Gap Analysis

| Issue | What Tests Now Catch |
|-------|---------------------|
| #3367 (inactive user not rejected) | `test_login_inactive_user_returns_401`, `test_verify_credentials_inactive_user` |
| #3368 (empty JWT token) | `test_register_response_token_is_nonempty_jwt`, `test_login_response_token_is_nonempty_jwt` |
| #3119 (auth middleware bypass) | `test_jwt_middleware_rejects_no_auth_header`, `test_expired_token_returns_401` |
| #3118 (zero permission denial) | `test_user_cannot_see_other_users_clusters`, `test_create_deployment_other_users_cluster_404`, `test_two_users_full_isolation` |
| #3125 (route count-only tests) | `test_jwt_middleware_skip_paths`, `test_installed_apps_exact_content` |

## New Test Files

### Auth (6 files)
- `test_serializer_validation.rs` — BVA/EP for LoginRequest, RegisterRequest
- `test_user_model.rs` — Model construction, password hashing
- `test_session_service.rs` — JWT session token lifecycle
- `test_auth_property.rs` — proptest: JWT roundtrip, password hash, fuzz
- `test_auth_error_paths.rs` — E2E: inactive user, empty body, duplicate username, decision table
- `test_credential_service.rs` — Integration: verify_credentials with real DB

### Clusters (5 files)
- `test_request_validation.rs` — BVA/EP for CreateClusterRequest
- `test_cluster_model.rs` — Model construction, serialization
- `test_cluster_property.rs` — proptest: response conversion, fuzz
- `test_cluster_ownership.rs` — Cross-user isolation, expired/malformed tokens
- `test_cluster_pagination.rs` — Pagination boundaries

### Deployments (5 files)
- `test_request_validation.rs` — BVA/EP for CreateDeploymentRequest
- `test_deployment_model.rs` — Model construction, status values
- `test_deployment_property.rs` — proptest: response conversion, fuzz
- `test_deployment_ownership.rs` — FK validation, cross-user isolation, decision table
- `test_deployment_pagination.rs` — Pagination boundaries

### Shared/Inline (6 files modified)
- `validators.rs` — DNS label: boundary, equivalence, combinatorial, proptest
- `errors.rs` — AppError Display, serde roundtrip
- `types.rs` — UserInfo/AuthResponse serde roundtrip
- `ws_messages.rs` — Enum variant roundtrip, proptest fuzz
- `broadcaster.rs` — Multi-conn, idempotent subscribe, lifecycle
- `consumer.rs` — Decision table, edge cases

### Cross-App (5 files)
- `test_jwt_middleware.rs` — should_continue decision table, E2E enforcement
- `test_routes_configuration.rs` — Exact installed apps validation
- `test_token_lifecycle.rs` — JWT token across auth+clusters
- `test_full_workflow.rs` — Full user journey, two-user isolation
- `test_ownership_isolation.rs` — Cross-app ownership isolation

## Test plan

- [x] `cargo check --lib --tests` passes
- [x] `cargo make clippy-check` passes (0 warnings)
- [x] `cargo make fmt-check` passes
- [x] `cargo nextest run --workspace --all-features` — 795/795 pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)