### PR TITLE
feat(ci): split test execution into partitioned parallel workflows

### DIFF
--- a/.github/docker-images-intra-crate.txt
+++ b/.github/docker-images-intra-crate.txt
@@ -1,0 +1,5 @@
+# Docker images for Intra-Crate Integration Tests
+# Pre-pulled to avoid Docker Hub rate limits
+
+# Databases (used by dashboard e2e tests via TestContainers)
+postgres:16-alpine

--- a/.github/docker-images-test.txt
+++ b/.github/docker-images-test.txt
@@ -1,2 +1,0 @@
-# Add Docker images used in integration tests here
-# ghcr.io/k3d-io/k3d-tools:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,11 +146,31 @@ jobs:
       runner: ${{ needs.determine-runner.outputs.runner }}
       cargo-build-jobs: ${{ needs.determine-runner.outputs.cargo-build-jobs }}
 
-  test:
-    name: Tests
+  unit-test:
+    name: Unit Tests
     needs: [fmt, clippy, determine-runner, check-branch-status]
     if: needs.check-branch-status.outputs.has-conflicts != 'true'
-    uses: ./.github/workflows/test.yml
+    uses: ./.github/workflows/unit-test.yml
+    secrets: inherit
+    with:
+      runner: ${{ needs.determine-runner.outputs.runner }}
+      cargo-build-jobs: ${{ needs.determine-runner.outputs.cargo-build-jobs }}
+
+  intra-crate-integration-test:
+    name: Intra-Crate Integration Tests
+    needs: [fmt, clippy, determine-runner, check-branch-status]
+    if: needs.check-branch-status.outputs.has-conflicts != 'true'
+    uses: ./.github/workflows/intra-crate-integration-test.yml
+    secrets: inherit
+    with:
+      runner: ${{ needs.determine-runner.outputs.runner }}
+      cargo-build-jobs: ${{ needs.determine-runner.outputs.cargo-build-jobs }}
+
+  cross-crate-integration-test:
+    name: Cross-Crate Integration Tests
+    needs: [fmt, clippy, determine-runner, check-branch-status]
+    if: needs.check-branch-status.outputs.has-conflicts != 'true'
+    uses: ./.github/workflows/cross-crate-integration-test.yml
     secrets: inherit
     with:
       runner: ${{ needs.determine-runner.outputs.runner }}
@@ -185,8 +205,12 @@ jobs:
 
   coverage:
     name: Coverage
-    needs: [test, determine-runner]
-    if: always() && needs.test.result == 'success'
+    needs: [unit-test, intra-crate-integration-test, cross-crate-integration-test, determine-runner]
+    if: >-
+      always() &&
+      needs.unit-test.result == 'success' &&
+      needs.intra-crate-integration-test.result == 'success' &&
+      needs.cross-crate-integration-test.result == 'success'
     uses: ./.github/workflows/coverage.yml
     secrets: inherit
     with:
@@ -213,7 +237,9 @@ jobs:
       - determine-runner
       - fmt
       - clippy
-      - test
+      - unit-test
+      - intra-crate-integration-test
+      - cross-crate-integration-test
       - bruno-tests
       - security-audit
       - todo-check
@@ -226,7 +252,9 @@ jobs:
           HAS_CONFLICTS: ${{ needs.check-branch-status.outputs.has-conflicts }}
           FMT_RESULT: ${{ needs.fmt.result }}
           CLIPPY_RESULT: ${{ needs.clippy.result }}
-          TEST_RESULT: ${{ needs.test.result }}
+          UNIT_TEST_RESULT: ${{ needs.unit-test.result }}
+          INTRA_CRATE_RESULT: ${{ needs.intra-crate-integration-test.result }}
+          CROSS_CRATE_RESULT: ${{ needs.cross-crate-integration-test.result }}
           BRUNO_TESTS_RESULT: ${{ needs.bruno-tests.result }}
           SECURITY_AUDIT_RESULT: ${{ needs.security-audit.result }}
           TODO_CHECK_RESULT: ${{ needs.todo-check.result }}
@@ -245,7 +273,9 @@ jobs:
           always_required=(
             "fmt:$FMT_RESULT"
             "clippy:$CLIPPY_RESULT"
-            "test:$TEST_RESULT"
+            "unit-test:$UNIT_TEST_RESULT"
+            "intra-crate-integration-test:$INTRA_CRATE_RESULT"
+            "cross-crate-integration-test:$CROSS_CRATE_RESULT"
             "bruno-tests:$BRUNO_TESTS_RESULT"
             "security-audit:$SECURITY_AUDIT_RESULT"
             "todo-check:$TODO_CHECK_RESULT"

--- a/.github/workflows/cross-crate-integration-test.yml
+++ b/.github/workflows/cross-crate-integration-test.yml
@@ -1,0 +1,98 @@
+name: Cross-Crate Integration Tests
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        description: 'Runner label JSON. Use "\"ubuntu-latest\"" for GitHub-hosted or "[\"self-hosted\",\"linux\",\"arm64\",\"reinhardt-cloud-ci\"]" for self-hosted.'
+        type: string
+        default: '"ubuntu-latest"'
+      cargo-build-jobs:
+        description: "Parallel cargo build jobs (1=GitHub-hosted OOM safe, 8=self-hosted)"
+        type: string
+        default: "1"
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: false
+      DOCKERHUB_TOKEN:
+        required: false
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  CARGO_TARGET_DIR: /tmp/cargo_target
+  CARGO_INCREMENTAL: 0
+  CARGO_BUILD_JOBS: ${{ inputs.cargo-build-jobs || '1' }}
+
+jobs:
+  cross-crate-integration-test:
+    name: Cross-Crate Integration Tests (${{ matrix.partition }}/2)
+    runs-on: ${{ fromJSON(inputs.runner || '"ubuntu-latest"') }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        partition: [1, 2]
+    steps:
+      - name: Free Disk Space (Ubuntu)
+        if: ${{ !contains(inputs.runner, 'self-hosted') }}
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Login to Docker Hub
+        uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install nextest
+        uses: taiki-e/install-action@de6bbd1333b8f331563d54a051e542c7dfef81c3 # v2
+        with:
+          tool: nextest
+
+      - name: Install cargo-make
+        uses: taiki-e/install-action@de6bbd1333b8f331563d54a051e542c7dfef81c3 # v2
+        with:
+          tool: cargo-make
+
+      - name: Setup application settings
+        run: |
+          cp dashboard/settings/base.example.toml dashboard/settings/base.toml
+          cp dashboard/settings/ci.example.toml dashboard/settings/ci.toml
+
+      - name: Run cross-crate integration tests (partition ${{ matrix.partition }}/2)
+        run: |
+          cargo nextest run \
+            --package reinhardt-cloud-integration-tests \
+            --all-features \
+            --partition hash:${{ matrix.partition }}/2 \
+            --no-fail-fast \
+            --no-tests=warn \
+            --status-level=none \
+            --final-status-level=fail
+        env:
+          REINHARDT_ENV: ci
+          REINHARDT_CLOUD_JWT_SECRET: "ci-test-secret-minimum-32-bytes-long!!"
+
+      - name: Docker cleanup after tests
+        if: always()
+        run: docker system prune -af

--- a/.github/workflows/intra-crate-integration-test.yml
+++ b/.github/workflows/intra-crate-integration-test.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Intra-Crate Integration Tests
 
 on:
   workflow_call:
@@ -26,11 +26,27 @@ env:
   CARGO_BUILD_JOBS: ${{ inputs.cargo-build-jobs || '1' }}
 
 jobs:
-  test:
-    name: Tests
+  intra-crate-integration-test:
+    name: Intra-Crate Integration Tests (${{ matrix.partition }}/2)
     runs-on: ${{ fromJSON(inputs.runner || '"ubuntu-latest"') }}
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        partition: [1, 2]
     steps:
+      - name: Free Disk Space (Ubuntu)
+        if: ${{ !contains(inputs.runner, 'self-hosted') }}
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -58,13 +74,47 @@ jobs:
         with:
           tool: cargo-make
 
+      - name: Pull Docker images
+        uses: ./.github/actions/pull-docker-images
+        with:
+          images-file: .github/docker-images-intra-crate.txt
+
+      - name: Additional disk cleanup before tests
+        if: ${{ !contains(inputs.runner, 'self-hosted') }}
+        run: |
+          echo "Disk usage before additional cleanup:"
+          df -h
+          sudo apt-get clean
+          sudo rm -rf /var/lib/apt/lists/* || true
+          # Use -f (not -af) to preserve pre-pulled Docker images
+          docker system prune -f --volumes || true
+          docker builder prune -af || true
+          rm -rf ~/.cache/pip || true
+          rm -rf ~/.npm || true
+          echo "Disk usage after additional cleanup:"
+          df -h
+
       - name: Setup application settings
         run: |
           cp dashboard/settings/base.example.toml dashboard/settings/base.toml
           cp dashboard/settings/ci.example.toml dashboard/settings/ci.toml
 
-      - name: Run tests
-        run: cargo nextest run --workspace --all-features --no-fail-fast
+      - name: Run intra-crate integration tests (partition ${{ matrix.partition }}/2)
+        run: |
+          cargo nextest run \
+            --workspace \
+            --exclude reinhardt-cloud-integration-tests \
+            --test "*" \
+            --all-features \
+            --partition hash:${{ matrix.partition }}/2 \
+            --no-fail-fast \
+            --no-tests=warn \
+            --status-level=none \
+            --final-status-level=fail
         env:
           REINHARDT_ENV: ci
           REINHARDT_CLOUD_JWT_SECRET: "ci-test-secret-minimum-32-bytes-long!!"
+
+      - name: Docker cleanup after tests
+        if: always()
+        run: docker system prune -af

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,0 +1,99 @@
+name: Unit Tests
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        description: 'Runner label JSON. Use "\"ubuntu-latest\"" for GitHub-hosted or "[\"self-hosted\",\"linux\",\"arm64\",\"reinhardt-cloud-ci\"]" for self-hosted.'
+        type: string
+        default: '"ubuntu-latest"'
+      cargo-build-jobs:
+        description: "Parallel cargo build jobs (1=GitHub-hosted OOM safe, 8=self-hosted)"
+        type: string
+        default: "1"
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: false
+      DOCKERHUB_TOKEN:
+        required: false
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  CARGO_TARGET_DIR: /tmp/cargo_target
+  CARGO_INCREMENTAL: 0
+  CARGO_BUILD_JOBS: ${{ inputs.cargo-build-jobs || '1' }}
+
+jobs:
+  unit-test:
+    name: Unit Tests (${{ matrix.partition }}/2)
+    runs-on: ${{ fromJSON(inputs.runner || '"ubuntu-latest"') }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        partition: [1, 2]
+    steps:
+      - name: Free Disk Space (Ubuntu)
+        if: ${{ !contains(inputs.runner, 'self-hosted') }}
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Login to Docker Hub
+        uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install nextest
+        uses: taiki-e/install-action@de6bbd1333b8f331563d54a051e542c7dfef81c3 # v2
+        with:
+          tool: nextest
+
+      - name: Install cargo-make
+        uses: taiki-e/install-action@de6bbd1333b8f331563d54a051e542c7dfef81c3 # v2
+        with:
+          tool: cargo-make
+
+      - name: Setup application settings
+        run: |
+          cp dashboard/settings/base.example.toml dashboard/settings/base.toml
+          cp dashboard/settings/ci.example.toml dashboard/settings/ci.toml
+
+      - name: Run unit tests (partition ${{ matrix.partition }}/2)
+        run: |
+          cargo nextest run \
+            --workspace \
+            --lib --bins \
+            --all-features \
+            --partition hash:${{ matrix.partition }}/2 \
+            --no-fail-fast \
+            --no-tests=warn \
+            --status-level=none \
+            --final-status-level=fail
+        env:
+          REINHARDT_ENV: ci
+          REINHARDT_CLOUD_JWT_SECRET: "ci-test-secret-minimum-32-bytes-long!!"
+
+      - name: Docker cleanup after tests
+        if: always()
+        run: docker system prune -af


### PR DESCRIPTION
## Summary

- Split the single monolithic `test.yml` job into 3 type-specific workflows with nextest hash-based partitioning (2 partitions each, 6 parallel jobs total)
  - `unit-test.yml`: `--workspace --lib --bins` (unit tests across all crates)
  - `intra-crate-integration-test.yml`: `--workspace --test "*"` excluding cross-crate (per-crate integration tests)
  - `cross-crate-integration-test.yml`: `--package reinhardt-cloud-integration-tests` (gRPC integration tests)
- Updated `ci.yml` job dependency graph: `coverage` and `ci-success` now depend on all 3 test jobs
- Deleted orphaned `docker-images-test.txt`, added `docker-images-intra-crate.txt` for TestContainers

Modeled after the reinhardt-web CI partitioning strategy, scaled down for reinhardt-cloud's 10-crate workspace.

## Test plan

- [ ] Verify all 3 test workflows pass with their respective partitions
- [ ] Verify `ci-success` gate correctly requires all 3 test jobs
- [ ] Verify `coverage` job runs only after all 3 test jobs succeed
- [ ] Verify no tests are silently dropped by comparing total test count before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)