### PR TITLE
chore: use reinhardt-admin fmt-all instead of cargo fmt

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -49,14 +49,14 @@ args = ["clean"]
 # ============================================================================
 
 [tasks.fmt-check]
-description = "Check code formatting"
-command = "cargo"
-args = ["fmt", "--all", "--check"]
+description = "Check all code formatting (Rust + page! DSL)"
+command = "reinhardt-admin"
+args = ["fmt-all", "--check"]
 
 [tasks.fmt-fix]
-description = "Auto-fix code formatting"
-command = "cargo"
-args = ["fmt", "--all"]
+description = "Auto-fix all code formatting (Rust + page! DSL)"
+command = "reinhardt-admin"
+args = ["fmt-all"]
 
 [tasks.clippy-check]
 description = "Run clippy linter"


### PR DESCRIPTION
## Summary
- Replace `cargo fmt --all` with `reinhardt-admin fmt-all` for `fmt-check` and `fmt-fix` tasks in root Makefile.toml
- This ensures page! macro DSL is also formatted alongside Rust code, matching reinhardt's approach

## Test plan
- [ ] `cargo make fmt-check` runs `reinhardt-admin fmt-all --check` successfully
- [ ] `cargo make fmt-fix` runs `reinhardt-admin fmt-all` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)