### PR TITLE
ci(fmt): add reinhardt-admin installation step to format check workflow

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -32,5 +32,8 @@ jobs:
         with:
           tool: cargo-make
 
+      - name: Install reinhardt-admin
+        run: cargo install reinhardt-admin-cli --version "=0.1.0-rc.15" --locked
+
       - name: Check code formatting
         run: cargo make fmt-check


### PR DESCRIPTION
## Summary

- Add `reinhardt-admin-cli` installation step to the Format Check CI workflow
- Required because `cargo make fmt-check` now delegates to `reinhardt-admin fmt-all --check` (changed in #293), which was not available in CI

## Type of Change

- [x] CI/CD changes

## Motivation and Context

After #293 switched `fmt-check` / `fmt-fix` tasks from `cargo fmt` to `reinhardt-admin fmt-all`, the Format Check CI job fails with `No such file or directory` because `reinhardt-admin` is not installed in the CI environment. This PR adds the missing installation step.

Related to: #293

## How Was This Tested?

- CI will run the format check with `reinhardt-admin` installed

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] My changes generate no new warnings
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

### Type Label (select one)
- [x] `ci-cd` - CI/CD workflow changes

### Scope Label (select all that apply)
- [x] `ci-cd` - CI/CD workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)