### PR TITLE
feat(ci): add breaking change discussion announcement workflow

### DIFF
--- a/.github/workflows/announce-breaking-change.yml
+++ b/.github/workflows/announce-breaking-change.yml
@@ -1,0 +1,156 @@
+name: Announce Breaking Change
+
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Backfill mode'
+        type: choice
+        options: ['by-pr-number', 'all']
+        default: 'by-pr-number'
+      pr-numbers:
+        description: 'Comma-separated PR numbers (for by-pr-number mode)'
+        required: false
+        default: ''
+
+jobs:
+  announce:
+    name: Announce Breaking Change
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.merged == true &&
+      (
+        contains(join(github.event.pull_request.labels.*.name, ','), 'breaking-change')
+        || contains(github.event.pull_request.title, '!:')
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kent8192/reinhardt-web/.github/actions/announce-breaking-change@main
+        with:
+          source-repo: reinhardt-cloud
+          pr-number: ${{ github.event.pull_request.number }}
+          pr-title: ${{ github.event.pull_request.title }}
+          pr-url: ${{ github.event.pull_request.html_url }}
+          pr-body: ${{ github.event.pull_request.body }}
+          merged-at: ${{ github.event.pull_request.merged_at }}
+          github-token: ${{ secrets.DISCUSSION_PAT }}
+
+  backfill:
+    name: Backfill Breaking Change Announcements
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.DISCUSSION_PAT }}
+      SOURCE_REPO: reinhardt-cloud
+      TARGET_REPO: kent8192/reinhardt-cloud
+      INPUT_MODE: ${{ inputs.mode }}
+      INPUT_PR_NUMBERS: ${{ inputs.pr-numbers }}
+    steps:
+      - name: Run backfill
+        run: |
+          process_pr() {
+            local pr_number="$1"
+            echo "--- Processing PR #${pr_number} ---"
+
+            local pr_data
+            pr_data=$(gh pr view "$pr_number" --repo "$TARGET_REPO" \
+              --json title,body,url,mergedAt 2>&1) || {
+              echo "ERROR: Failed to fetch PR #${pr_number}: ${pr_data}"
+              return 1
+            }
+
+            local pr_title pr_url merged_at
+            pr_title=$(echo "$pr_data" | jq -r '.title')
+            pr_url=$(echo "$pr_data" | jq -r '.url')
+            merged_at=$(echo "$pr_data" | jq -r '.mergedAt')
+
+            local search_key="[${SOURCE_REPO}#${pr_number}]"
+            local count
+            count=$(gh api graphql -f query="
+              {
+                search(type: DISCUSSION, query: \"repo:kent8192/reinhardt-web in:title \\\"${search_key}\\\"\", first: 1) {
+                  discussionCount
+                }
+              }
+            " --jq '.data.search.discussionCount')
+
+            if [ "$count" -gt 0 ]; then
+              echo "SKIP: Discussion already exists for ${search_key}"
+              return 0
+            fi
+
+            local pr_body
+            pr_body=$(echo "$pr_data" | jq -r '.body // ""')
+
+            local details
+            details=$(printf '%s' "$pr_body" | awk '
+              /^## Breaking Changes/ { found=1; next }
+              /^## / { if (found) exit }
+              found { print }
+            ')
+            details=$(echo "$details" | sed '/./,$!d' | sed -e :a -e '/^\n*$/{$d;N;ba;}')
+
+            if [ -z "$details" ]; then
+              details=$(printf '%s' "$pr_body" | awk '
+                /^BREAKING CHANGE:/ { found=1 }
+                found { print }
+              ')
+            fi
+
+            if [ -z "$details" ]; then
+              details=$(printf '%s' "$pr_body" | head -100)
+            fi
+
+            local merged_date="${merged_at%%T*}"
+            local disc_title="${search_key} ${pr_title}"
+
+            cat > /tmp/discussion-body.md <<BODY_EOF
+          ## Breaking Change: ${SOURCE_REPO}
+
+          **PR**: ${SOURCE_REPO}#${pr_number} — ${pr_title}
+          **Merged**: ${merged_date}
+          **Link**: ${pr_url}
+
+          ### Details
+
+          ${details}
+          BODY_EOF
+
+            gh discussion create \
+              --repo kent8192/reinhardt-web \
+              --category "Breaking Changes" \
+              --title "$disc_title" \
+              --body-file /tmp/discussion-body.md
+
+            echo "CREATED: ${disc_title}"
+            sleep 2
+          }
+
+          if [ "$INPUT_MODE" = "by-pr-number" ]; then
+            if [ -z "$INPUT_PR_NUMBERS" ]; then
+              echo "ERROR: pr-numbers is required for by-pr-number mode"
+              exit 1
+            fi
+            IFS=',' read -ra NUMBERS <<< "$INPUT_PR_NUMBERS"
+            for num in "${NUMBERS[@]}"; do
+              num=$(echo "$num" | xargs)
+              process_pr "$num" || true
+            done
+
+          elif [ "$INPUT_MODE" = "all" ]; then
+            echo "Scanning all merged PRs for breaking changes..."
+            gh pr list --repo "$TARGET_REPO" --state merged --limit 500 \
+              --json number,title,labels,body \
+              | jq -r '[.[] | select(
+                  ([.labels[].name] | any(. == "breaking-change")) or
+                  (.title | test("!:")) or
+                  (.body | test("\\[x\\] Breaking change"; "i"))
+                )] | sort_by(.number) | .[].number' \
+              | while read -r num; do
+                process_pr "$num" || true
+              done
+          fi
+
+          echo "Backfill complete."

--- a/.github/workflows/announce-breaking-change.yml
+++ b/.github/workflows/announce-breaking-change.yml
@@ -21,13 +21,16 @@ jobs:
     if: >-
       github.event_name == 'pull_request' &&
       github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       (
-        contains(join(github.event.pull_request.labels.*.name, ','), 'breaking-change')
+        contains(github.event.pull_request.labels.*.name, 'breaking-change')
         || contains(github.event.pull_request.title, '!:')
       )
     runs-on: ubuntu-latest
     steps:
-      - uses: kent8192/reinhardt-web/.github/actions/announce-breaking-change@main
+      # Pin to SHA after kent8192/reinhardt-web#3470 is merged.
+      # To update: gh api repos/kent8192/reinhardt-web/git/refs/heads/main --jq '.object.sha'
+      - uses: kent8192/reinhardt-web/.github/actions/announce-breaking-change@16a12640397aec6cbc3ee44bf1dcc512cc607ecd # main
         with:
           source-repo: reinhardt-cloud
           pr-number: ${{ github.event.pull_request.number }}
@@ -54,12 +57,13 @@ jobs:
             local pr_number="$1"
             echo "--- Processing PR #${pr_number} ---"
 
-            local pr_data
-            pr_data=$(gh pr view "$pr_number" --repo "$TARGET_REPO" \
-              --json title,body,url,mergedAt 2>&1) || {
-              echo "ERROR: Failed to fetch PR #${pr_number}: ${pr_data}"
+            local pr_data pr_err
+            if ! pr_data=$(gh pr view "$pr_number" --repo "$TARGET_REPO" \
+              --json title,body,url,mergedAt 2>/tmp/pr_err.txt); then
+              pr_err=$(cat /tmp/pr_err.txt)
+              echo "ERROR: Failed to fetch PR #${pr_number}: ${pr_err}"
               return 1
-            }
+            fi
 
             local pr_title pr_url merged_at
             pr_title=$(echo "$pr_data" | jq -r '.title')
@@ -128,6 +132,8 @@ jobs:
             sleep 2
           }
 
+          failures=0
+
           if [ "$INPUT_MODE" = "by-pr-number" ]; then
             if [ -z "$INPUT_PR_NUMBERS" ]; then
               echo "ERROR: pr-numbers is required for by-pr-number mode"
@@ -136,21 +142,33 @@ jobs:
             IFS=',' read -ra NUMBERS <<< "$INPUT_PR_NUMBERS"
             for num in "${NUMBERS[@]}"; do
               num=$(echo "$num" | xargs)
-              process_pr "$num" || true
+              process_pr "$num" || failures=$((failures + 1))
             done
 
           elif [ "$INPUT_MODE" = "all" ]; then
             echo "Scanning all merged PRs for breaking changes..."
-            gh pr list --repo "$TARGET_REPO" --state merged --limit 500 \
-              --json number,title,labels,body \
-              | jq -r '[.[] | select(
+            fail_file=$(mktemp)
+            echo 0 > "$fail_file"
+            gh api --paginate "repos/${TARGET_REPO}/pulls?state=closed&per_page=100" \
+              --jq '[.[] | select(.merged_at != null)] | .[].number' \
+              | while read -r candidate; do
+                pr_json=$(gh pr view "$candidate" --repo "$TARGET_REPO" \
+                  --json title,labels,body 2>/dev/null) || continue
+                is_breaking=$(echo "$pr_json" | jq -r '
                   ([.labels[].name] | any(. == "breaking-change")) or
                   (.title | test("!:")) or
                   (.body | test("\\[x\\] Breaking change"; "i"))
-                )] | sort_by(.number) | .[].number' \
-              | while read -r num; do
-                process_pr "$num" || true
+                ')
+                if [ "$is_breaking" = "true" ]; then
+                  process_pr "$candidate" || echo $(( $(cat "$fail_file") + 1 )) > "$fail_file"
+                fi
               done
+            failures=$(cat "$fail_file")
+            rm -f "$fail_file"
           fi
 
+          if [ "$failures" -gt 0 ]; then
+            echo "Backfill completed with ${failures} failure(s)."
+            exit 1
+          fi
           echo "Backfill complete."


### PR DESCRIPTION
## Summary

- Add workflow that auto-creates GitHub Discussions in reinhardt-web's "Breaking Changes" category when PRs with `breaking-change` label or `!:` title notation are merged
- Uses shared composite action from `kent8192/reinhardt-web/.github/actions/announce-breaking-change@main`
- Includes `workflow_dispatch` backfill support for historical PRs

### Dependency

Requires kent8192/reinhardt-web#3470 to be merged first (composite action must be on `main`).

### Prerequisites

- `DISCUSSION_PAT` secret must be configured with `discussions:write` permission on reinhardt-web

### Backfill plan

After merge + PAT setup, run `by-pr-number` backfill with: `8,57,70,79,85,96`

## Test plan

- [ ] Verify YAML syntax passes lint
- [ ] After dependency PR merged + PAT setup: run `by-pr-number` backfill with a single PR (#96)
- [ ] Verify discussion created with `[reinhardt-cloud#96]` prefix
- [ ] Run full backfill for all 6 historical PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)