### PR TITLE
fix(operator): add /static/ path to Ingress with explicit ingress_host

### DIFF
--- a/crates/reinhardt-cloud-operator/src/reconciler.rs
+++ b/crates/reinhardt-cloud-operator/src/reconciler.rs
@@ -190,6 +190,31 @@ async fn apply(app: Arc<ReinhardtApp>, ctx: &Context, namespace: &str) -> Result
 			pages_config.as_ref(),
 		)
 		.await?;
+	} else if let Some(host) = app
+		.spec
+		.services
+		.as_ref()
+		.and_then(|s| s.ingress_host.as_deref())
+	{
+		// Explicit ingress_host: create Ingress with host-based routing
+		// and include pages /static/ path if pages is enabled (fixes #97).
+		let port = resolve_app_port(&app);
+		let routes = vec![reinhardt_cloud_types::introspect::RouteMetadata {
+			path: "/".to_string(),
+			methods: vec![],
+			name: None,
+			namespace: None,
+		}];
+		reconcile_ingress_resource_with_host(
+			&app,
+			&ctx.client,
+			namespace,
+			&routes,
+			port,
+			Some(host),
+			pages_config.as_ref(),
+		)
+		.await?;
 	}
 
 	// Cache provisioning — explicit spec.cache takes precedence,
@@ -695,10 +720,10 @@ fn should_provision_mail(app: &ReinhardtApp) -> bool {
 fn resolve_ingress_config(
 	app: &ReinhardtApp,
 ) -> Option<(Vec<reinhardt_cloud_types::introspect::RouteMetadata>, u16)> {
-	// Explicit ingress_host in services spec is handled by the existing
-	// reconcile path (build_service/build_ingress from explicit fields).
-	// Here we only handle introspect-derived routes when no explicit
-	// services config provides an ingress host.
+	// Explicit ingress_host is handled by the else-if branch in the reconciler
+	// (reconcile_ingress_resource_with_host). Here we only handle
+	// introspect-derived routes when no explicit services config provides
+	// an ingress host.
 	let has_explicit_ingress = app
 		.spec
 		.services
@@ -852,6 +877,20 @@ async fn reconcile_ingress_resource(
 	port: u16,
 	pages_config: Option<&ResolvedPagesConfig>,
 ) -> Result<(), Error> {
+	reconcile_ingress_resource_with_host(app, client, namespace, routes, port, None, pages_config)
+		.await
+}
+
+/// Reconciles the `Ingress` resource via server-side apply, with an optional explicit host.
+async fn reconcile_ingress_resource_with_host(
+	app: &ReinhardtApp,
+	client: &Client,
+	namespace: &str,
+	routes: &[reinhardt_cloud_types::introspect::RouteMetadata],
+	port: u16,
+	host: Option<&str>,
+	pages_config: Option<&ResolvedPagesConfig>,
+) -> Result<(), Error> {
 	let name = app.name_any();
 	let ssapply = PatchParams::apply("reinhardt-cloud-operator").force();
 
@@ -860,7 +899,7 @@ async fn reconcile_ingress_resource(
 		.introspect
 		.as_ref()
 		.map(|i| &i.features.infrastructure_signals);
-	let Some(desired) = build_ingress(app, routes, port, None, signals, pages_config)? else {
+	let Some(desired) = build_ingress(app, routes, port, host, signals, pages_config)? else {
 		info!("No Ingress paths for {namespace}/{name}, skipping Ingress creation");
 		return Ok(());
 	};

--- a/crates/reinhardt-cloud-operator/src/resources/ingress.rs
+++ b/crates/reinhardt-cloud-operator/src/resources/ingress.rs
@@ -544,4 +544,33 @@ mod tests {
 			.unwrap();
 		assert!(static_idx < root_idx);
 	}
+
+	#[rstest]
+	fn test_build_ingress_explicit_host_with_pages_adds_static_path() {
+		// Arrange — simulates #97: explicit ingress_host + pages enabled
+		let app = make_test_app("pages-app");
+		let routes = vec![RouteMetadata {
+			path: "/".to_string(),
+			methods: vec![],
+			name: None,
+			namespace: None,
+		}];
+		let pages = crate::inference::pages::ResolvedPagesConfig::default();
+
+		// Act
+		let ingress =
+			build_ingress(&app, &routes, 8080, Some("my-app.example.com"), None, Some(&pages))
+				.unwrap()
+				.unwrap();
+		let spec = ingress.spec.unwrap();
+		let rules = spec.rules.unwrap();
+		let paths = &rules[0].http.as_ref().unwrap().paths;
+
+		// Assert — host is set and /static/ path is present
+		assert_eq!(rules[0].host.as_deref(), Some("my-app.example.com"));
+		assert!(paths.iter().any(|p| p.path.as_deref() == Some("/static/")));
+		let static_path = paths.iter().find(|p| p.path.as_deref() == Some("/static/")).unwrap();
+		let svc_port = &static_path.backend.service.as_ref().unwrap().port.as_ref().unwrap();
+		assert_eq!(svc_port.number, Some(8080));
+	}
 }


### PR DESCRIPTION
## Summary

- Fix bug where `/static/` Ingress path for the pages sidecar was not added when `spec.services.ingress_host` was explicitly set
- Extract `reconcile_ingress_resource_with_host()` to support optional explicit host parameter
- Add test covering the explicit host + pages scenario

## Root Cause

`resolve_ingress_config()` returns `None` when `ingress_host` is set, causing `reconcile_ingress_resource()` (which passes `pages_config`) to be skipped entirely. The new `else if` branch handles this case by building the Ingress with the explicit host and pages config.

## Test plan

- [x] `test_build_ingress_explicit_host_with_pages_adds_static_path` — verifies `/static/` path is present with explicit host + pages
- [x] All 23 existing ingress tests pass
- [ ] Manual verification with a `ReinhardtApp` CR using both `ingress_host` and `pages`

Fixes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)