### PR TITLE
fix(operator): use dot delimiter in owner label value to comply with K8s validation

### DIFF
--- a/crates/reinhardt-cloud-operator/src/resources/labels.rs
+++ b/crates/reinhardt-cloud-operator/src/resources/labels.rs
@@ -72,7 +72,7 @@ pub(crate) fn standard_labels(
 		(
 			"paas.reinhardt-cloud.dev/owner".to_string(),
 			format!(
-				"{}/{}",
+				"{}.{}",
 				app.namespace().unwrap_or_else(|| "<unknown>".to_string()),
 				app.name_any()
 			),
@@ -126,7 +126,7 @@ mod tests {
 		assert_eq!(labels.get("app.kubernetes.io/instance").unwrap(), "my-app");
 		assert_eq!(
 			labels.get("paas.reinhardt-cloud.dev/owner").unwrap(),
-			"default/my-app"
+			"default.my-app"
 		);
 	}
 


### PR DESCRIPTION
## Summary

- Replace slash (`/`) with dot (`.`) delimiter in `paas.reinhardt-cloud.dev/owner` label value
- Kubernetes label values must match `(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?` — slashes are not allowed
- The operator was generating `default/demo-app` which caused a 422 rejection on every resource creation (Deployment, Service, Ingress, etc.)

## Changes

| File | Change |
|------|--------|
| `crates/reinhardt-cloud-operator/src/resources/labels.rs:75` | `format!("{}/{}", ...)` → `format!("{}.{}", ...)` |
| `crates/reinhardt-cloud-operator/src/resources/labels.rs:129` | Test assertion: `"default/my-app"` → `"default.my-app"` |

## Before / After

```
# Before (invalid)
paas.reinhardt-cloud.dev/owner: default/demo-app   ← K8s rejects

# After (valid)
paas.reinhardt-cloud.dev/owner: default.demo-app    ← K8s accepts
```

Fixes #323

## Test plan

- [x] `cargo nextest run -p reinhardt-cloud-operator --all-features` — 321 tests passed
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)