### PR TITLE
fix(dashboard): add cors and redis_url to local.example.toml

### DIFF
--- a/dashboard/settings/local.example.toml
+++ b/dashboard/settings/local.example.toml
@@ -40,3 +40,8 @@ name = "reinhardt_cloud_dev"
 user = "postgres"
 password = { secret = "CHANGE-ME" }
 options = {}
+
+[cors]
+# Allowed origins for OriginGuardMiddleware (exact match, no wildcards).
+# OriginGuard filters out "*" — use explicit URLs.
+allow_origins = ["http://localhost:8000", "http://127.0.0.1:8000"]


### PR DESCRIPTION
## Summary

- Add missing `[cors]` section to `dashboard/settings/local.example.toml`
- Add missing `redis_url` setting to the template
- Both omissions cause startup panics for new developers following the setup guide

## Context

| Commit / PR | Added requirement | Updated `local.example.toml`? |
|-------------|-------------------|-------------------------------|
| `94f4deb` (CorsSettings) | `[cors].allow_origins` required by `ProjectSettings` | Only updated `base.example.toml` and `ci.toml` |
| PR #294 (cookie session auth) | `redis_url` required for session storage | Only updated `ci.example.toml` |

## Changes

| File | Change |
|------|--------|
| `dashboard/settings/local.example.toml` | Add `[cors]` section with `allow_origins` for localhost |

Note: `redis_url` was already present on `main` from a prior commit, so only the `[cors]` section needed to be added.

Fixes #324
Fixes #325

## Test plan

- [x] `REINHARDT_ENV=local cargo run --bin manage -- runserver` starts successfully with these settings
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)