### PR TITLE
fix(dashboard)!: wrap framework types in newtypes for DI orphan rule compliance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
  "log",
  "num",
  "pin-project-lite",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
@@ -1285,7 +1285,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1851,7 +1851,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2079,7 +2079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2205,7 +2205,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb330bbd4cb7a5b9f559427f06f98a4f853a137c8298f3bd3f8ca57663e21986"
 dependencies = [
  "portable-atomic",
- "rand 0.9.2",
+ "rand 0.9.3",
  "web-time",
 ]
 
@@ -3379,9 +3379,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -4055,7 +4055,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4318,7 +4318,7 @@ dependencies = [
  "hmac 0.12.1",
  "pkcs12",
  "pkcs5",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rc2",
  "sha1",
  "sha2 0.10.9",
@@ -4835,7 +4835,7 @@ dependencies = [
  "hmac 0.13.0",
  "md-5 0.11.0",
  "memchr",
- "rand 0.10.0",
+ "rand 0.10.1",
  "sha2 0.11.0",
  "stringprep",
 ]
@@ -5003,7 +5003,7 @@ dependencies = [
  "bit-vec",
  "bitflags 2.11.0",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax 0.8.10",
@@ -5240,7 +5240,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -5263,7 +5263,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5312,9 +5312,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -5322,9 +5322,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -5411,7 +5411,7 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "simd_helpers",
  "thiserror 2.0.18",
@@ -5548,7 +5548,7 @@ dependencies = [
  "num-bigint",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ryu",
  "sha1_smol",
  "socket2 0.6.3",
@@ -5703,7 +5703,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "reinhardt-admin"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5754,7 +5754,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-apps"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5784,7 +5784,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-auth"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5802,7 +5802,7 @@ dependencies = [
  "inventory",
  "jsonwebtoken 10.3.0",
  "password-hash",
- "rand 0.9.2",
+ "rand 0.9.3",
  "reinhardt-apps",
  "reinhardt-auth-macros",
  "reinhardt-core",
@@ -5829,7 +5829,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-auth-macros"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6027,7 +6027,7 @@ dependencies = [
  "http-body-util",
  "k8s-openapi",
  "kube",
- "rand 0.9.2",
+ "rand 0.9.3",
  "reinhardt-cloud-core",
  "reinhardt-cloud-types",
  "rstest",
@@ -6073,7 +6073,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-commands"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6092,7 +6092,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rcgen",
  "regex",
  "reinhardt-admin",
@@ -6129,7 +6129,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-conf"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "chrono",
  "dotenv",
@@ -6155,7 +6155,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-core"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "anyhow",
  "aquamarine 0.6.0",
@@ -6181,7 +6181,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "prost 0.14.3",
- "rand 0.9.2",
+ "rand 0.9.3",
  "regex",
  "reinhardt-macros",
  "rmp-serde",
@@ -6203,7 +6203,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-db"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -6232,7 +6232,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "rand 0.9.2",
+ "rand 0.9.3",
  "refinery",
  "regex",
  "reinhardt-conf",
@@ -6258,7 +6258,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-di"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -6281,7 +6281,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-di-macros"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6292,7 +6292,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-forms"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "anyhow",
  "aquamarine 0.5.0",
@@ -6309,7 +6309,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-http"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6330,7 +6330,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-macros"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "ctor 0.8.0",
  "inventory",
@@ -6344,7 +6344,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-mail"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6365,7 +6365,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-manouche"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "aquamarine 0.6.0",
  "convert_case",
@@ -6378,7 +6378,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-middleware"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6392,7 +6392,7 @@ dependencies = [
  "hyper",
  "ipnet",
  "log",
- "rand 0.9.2",
+ "rand 0.9.3",
  "redis 0.27.6",
  "regex",
  "reinhardt-auth",
@@ -6414,7 +6414,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-openapi"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "async-trait",
  "reinhardt-http",
@@ -6426,7 +6426,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-openapi-macros"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6437,7 +6437,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-pages"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "aquamarine 0.5.0",
  "async-trait",
@@ -6476,7 +6476,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-pages-ast"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "aquamarine 0.6.0",
  "convert_case",
@@ -6490,7 +6490,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-pages-macros"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "convert_case",
  "darling 0.20.11",
@@ -6504,7 +6504,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-query"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -6518,7 +6518,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-query-macros"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -6529,7 +6529,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-rest"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6578,7 +6578,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-routers-macros"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6588,7 +6588,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-server"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6607,7 +6607,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-shortcuts"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "bytes",
  "hyper",
@@ -6625,7 +6625,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-test"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "cfg_aliases",
  "reinhardt-auth",
@@ -6645,7 +6645,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-testkit"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "async-dropper",
  "async-trait",
@@ -6697,7 +6697,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-throttling"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -6708,7 +6708,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-urls"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -6741,7 +6741,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-utils"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6758,7 +6758,7 @@ dependencies = [
  "hyper",
  "mime_guess",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.3",
  "regex",
  "reinhardt-core",
  "reinhardt-http",
@@ -6777,7 +6777,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-views"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6813,7 +6813,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-web"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6853,7 +6853,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-websockets"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#cf41601049778142cb7f5f08a9fcc84e2f75da07"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7189,7 +7189,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7272,7 +7272,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7283,9 +7283,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -8255,7 +8255,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8502,7 +8502,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand 0.10.0",
+ "rand 0.10.1",
  "socket2 0.6.3",
  "tokio",
  "tokio-util",
@@ -8964,7 +8964,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.3",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
@@ -9336,9 +9336,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -9350,9 +9350,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9360,9 +9360,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9370,9 +9370,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -9383,9 +9383,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -9426,9 +9426,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9522,7 +9522,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/dashboard/src/config/test_helpers.rs
+++ b/dashboard/src/config/test_helpers.rs
@@ -14,9 +14,7 @@ use reinhardt::di::{InjectionContext, SingletonScope};
 use reinhardt::test::APIClient;
 use rstest::fixture;
 
-use reinhardt::urls::prelude::UnifiedRouter;
-
-use crate::config::urls::AllowedOrigins;
+use crate::config::urls::{AllowedOrigins, DashboardRouter};
 
 /// Pre-resolved URL paths for test use.
 ///
@@ -38,7 +36,7 @@ pub struct TestUrls {
 /// `AllowedOrigins` is pre-registered with `"http://testserver"` so the
 /// `OriginGuardMiddleware` accepts requests from `APIClient::from_handler`.
 /// All other singletons (`WsBroadcaster`, `LocalAuthService`,
-/// `CookieSessionConfig`) are resolved lazily via their
+/// `DashboardSessionConfig`) are resolved lazily via their
 /// `#[injectable_factory]` registrations.
 #[fixture]
 pub fn test_app() -> (APIClient, TestUrls) {
@@ -46,12 +44,13 @@ pub fn test_app() -> (APIClient, TestUrls) {
 	scope.set(AllowedOrigins(vec!["http://testserver".into()]));
 	let di_ctx = Arc::new(InjectionContext::builder(scope).build());
 
-	let router: Arc<UnifiedRouter> = tokio::task::block_in_place(|| {
-		tokio::runtime::Handle::current().block_on(di_ctx.resolve::<UnifiedRouter>())
+	let router: Arc<DashboardRouter> = tokio::task::block_in_place(|| {
+		tokio::runtime::Handle::current().block_on(di_ctx.resolve::<DashboardRouter>())
 	})
-	.expect("Failed to resolve UnifiedRouter");
+	.expect("Failed to resolve DashboardRouter");
 	let server_router = Arc::try_unwrap(router)
-		.expect("UnifiedRouter has multiple owners after resolve")
+		.expect("DashboardRouter has multiple owners after resolve")
+		.0
 		.into_server();
 
 	let rev = |name: &str| -> String {

--- a/dashboard/src/config/urls.rs
+++ b/dashboard/src/config/urls.rs
@@ -6,7 +6,7 @@
 //!
 //! ## DI-based configuration
 //!
-//! `AllowedOrigins`, `CookieSessionConfig`, `WsBroadcaster`, and
+//! `AllowedOrigins`, `DashboardSessionConfig`, `WsBroadcaster`, and
 //! `LocalAuthService` are auto-registered as singletons via
 //! `#[injectable_factory]`. These are aggregated into
 //! `RouterInfrastructure` (a transient factory) together with the
@@ -68,11 +68,19 @@ async fn create_allowed_origins() -> AllowedOrigins {
 	}
 }
 
-/// DI factory — builds `CookieSessionConfig` from settings.
+/// Application-specific cookie session configuration.
+///
+/// Wraps the framework's `CookieSessionConfig` to comply with the
+/// DI pseudo orphan rule (kent8192/reinhardt-web#3468). Factories
+/// must not return framework-managed types directly.
+#[derive(Debug)]
+pub(crate) struct DashboardSessionConfig(pub CookieSessionConfig);
+
+/// DI factory — builds `DashboardSessionConfig` from settings.
 #[injectable_factory(scope = "singleton")]
-async fn create_cookie_session_config() -> CookieSessionConfig {
+async fn create_cookie_session_config() -> DashboardSessionConfig {
 	let settings = crate::config::settings::get_settings();
-	CookieSessionConfig {
+	DashboardSessionConfig(CookieSessionConfig {
 		cookie_name: "sessionid".to_string(),
 		sliding_ttl: std::time::Duration::from_secs(1800),
 		absolute_max: std::time::Duration::from_secs(86400),
@@ -84,7 +92,7 @@ async fn create_cookie_session_config() -> CookieSessionConfig {
 			"/api/docs".to_string(),
 			"/api/redoc".to_string(),
 		],
-	}
+	})
 }
 
 // ── Router infrastructure ───────────────────────────────────────────
@@ -105,7 +113,7 @@ pub(crate) struct RouterInfrastructure {
 
 /// DI factory — builds shared router infrastructure components.
 ///
-/// Resolves `AllowedOrigins`, `CookieSessionConfig`, `WsBroadcaster`,
+/// Resolves `AllowedOrigins`, `DashboardSessionConfig`, `WsBroadcaster`,
 /// and `LocalAuthService` from the DI registry, then constructs the
 /// DI context, admin site routes, and Redis session backend.
 /// `WsBroadcaster` and `LocalAuthService` are injected solely to
@@ -113,7 +121,7 @@ pub(crate) struct RouterInfrastructure {
 #[injectable_factory(scope = "transient")]
 async fn create_router_infrastructure(
 	#[inject] allowed_origins: Depends<AllowedOrigins>,
-	#[inject] session_config: Depends<CookieSessionConfig>,
+	#[inject] session_config: Depends<DashboardSessionConfig>,
 	#[inject] _ws_broadcaster: Depends<WsBroadcaster>,
 	#[inject] _local_auth_service: Depends<LocalAuthService>,
 ) -> RouterInfrastructure {
@@ -137,22 +145,38 @@ async fn create_router_infrastructure(
 		admin_di,
 		session_backend,
 		allowed_origins: allowed_origins.0.clone(),
-		session_config: (*session_config).clone(),
+		session_config: session_config.0.clone(),
 	}
 }
 
 // ── Router construction ─────────────────────────────────────────────
 
+/// Application-specific router wrapper.
+///
+/// Wraps the framework's `UnifiedRouter` to comply with the DI pseudo
+/// orphan rule (kent8192/reinhardt-web#3468). The `#[routes]` entry
+/// point unwraps this to return the inner `UnifiedRouter` to the framework.
+#[derive(Debug)]
+pub(crate) struct DashboardRouter(pub UnifiedRouter);
+
 /// Entry point for the `#[routes]` macro (called by the framework).
 ///
-/// The `#[inject]` parameter resolves `UnifiedRouter` from the DI registry,
+/// The `#[inject]` parameter resolves `DashboardRouter` from the DI registry,
 /// which triggers the `make_router` factory and all its transitive dependencies.
 /// The framework creates the `InjectionContext` automatically for async routes.
 #[routes]
-pub async fn routes(#[inject] router: Depends<UnifiedRouter>) -> UnifiedRouter {
+// Workaround for kent8192/reinhardt-web#3498 (tracked in reinhardt-cloud#329)
+// Remove this workaround when the upstream issue is resolved.
+//
+// Ideal implementation (without workaround):
+//   #[routes]
+//   pub async fn routes(#[inject] router: Depends<DashboardRouter>) -> UnifiedRouter {
+#[allow(private_interfaces)]
+pub async fn routes(#[inject] router: Depends<DashboardRouter>) -> UnifiedRouter {
 	router
 		.try_unwrap()
-		.expect("UnifiedRouter has multiple owners after resolve")
+		.expect("DashboardRouter has multiple owners after resolve")
+		.0
 }
 
 /// Build the application router by resolving dependencies from DI.
@@ -162,35 +186,37 @@ pub async fn routes(#[inject] router: Depends<UnifiedRouter>) -> UnifiedRouter {
 /// like `AllowedOrigins` by pre-registering in the `SingletonScope`
 /// before calling this function.
 #[injectable_factory(scope = "transient")]
-async fn make_router(#[inject] infra: Depends<RouterInfrastructure>) -> UnifiedRouter {
+async fn make_router(#[inject] infra: Depends<RouterInfrastructure>) -> DashboardRouter {
 	let infra = infra
 		.try_unwrap()
 		.unwrap_or_else(|_| panic!("RouterInfrastructure has multiple owners after resolve"));
 
-	UnifiedRouter::new()
-		// Admin panel
-		.mount("/admin/", infra.admin_router)
-		.mount("/static/admin/", admin_static_routes())
-		.with_prefix("/api/")
-		.with_di_registrations(infra.admin_di)
-		// REST API endpoints
-		.mount("/auth/", crate::apps::auth::urls::url_patterns())
-		.mount("/clusters/", crate::apps::clusters::urls::url_patterns())
-		.mount("/deployments/", crate::apps::deployments::urls::url_patterns())
-		.server(|s| {
-			s.server_fn(server::login::login::marker)
-				.server_fn(server::register::register::marker)
-				.server_fn(server::logout::logout::marker)
-				.server_fn(server::me::me::marker)
-		})
-		.with_di_context(infra.di_ctx)
-		.with_middleware(SecurityMiddleware::new())
-		.with_middleware(CspPathMiddleware)
-		.with_middleware(OriginGuardMiddleware::new(infra.allowed_origins))
-		.with_middleware(CookieSessionAuthMiddleware::with_config(
-			infra.session_backend,
-			infra.session_config,
-		))
+	DashboardRouter(
+		UnifiedRouter::new()
+			// Admin panel
+			.mount("/admin/", infra.admin_router)
+			.mount("/static/admin/", admin_static_routes())
+			.with_prefix("/api/")
+			.with_di_registrations(infra.admin_di)
+			// REST API endpoints
+			.mount("/auth/", crate::apps::auth::urls::url_patterns())
+			.mount("/clusters/", crate::apps::clusters::urls::url_patterns())
+			.mount("/deployments/", crate::apps::deployments::urls::url_patterns())
+			.server(|s| {
+				s.server_fn(server::login::login::marker)
+					.server_fn(server::register::register::marker)
+					.server_fn(server::logout::logout::marker)
+					.server_fn(server::me::me::marker)
+			})
+			.with_di_context(infra.di_ctx)
+			.with_middleware(SecurityMiddleware::new())
+			.with_middleware(CspPathMiddleware)
+			.with_middleware(OriginGuardMiddleware::new(infra.allowed_origins))
+			.with_middleware(CookieSessionAuthMiddleware::with_config(
+				infra.session_backend,
+				infra.session_config,
+			)),
+	)
 }
 
 // ── WebSocket routes ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Introduce `DashboardRouter(UnifiedRouter)` and `DashboardSessionConfig(CookieSessionConfig)` newtypes to comply with the DI pseudo orphan rule (kent8192/reinhardt-web#3468)
- Update `make_router()`, `create_cookie_session_config()`, `create_router_infrastructure()`, `routes()`, and `test_app()` fixture to use the newtypes
- Update `Cargo.lock` to latest reinhardt-web main (`baa45d63`)

## Breaking Change

This is a breaking change in the DI registration layer. The `UnifiedRouter` and `CookieSessionConfig` types are no longer directly registered in the DI container — they are wrapped in application-specific newtypes. Any code that resolves these types from DI must use `DashboardRouter` / `DashboardSessionConfig` instead.

## Workaround

`#[allow(private_interfaces)]` is applied to `routes()` because the `#[routes]` macro requires `pub` visibility while `DashboardRouter` is `pub(crate)`. Tracked upstream in kent8192/reinhardt-web#3498.

## Test plan

- [x] `cargo check --workspace` passes with no errors or warnings
- [ ] `cargo nextest run --workspace` (requires Docker for TestContainers)
- [ ] `runserver` starts without orphan rule panic

Fixes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)