### PR TITLE
chore: remove private_interfaces workaround (reinhardt-web#3498 resolved)

### DIFF
--- a/dashboard/src/config/urls.rs
+++ b/dashboard/src/config/urls.rs
@@ -165,13 +165,6 @@ pub(crate) struct DashboardRouter(pub UnifiedRouter);
 /// which triggers the `make_router` factory and all its transitive dependencies.
 /// The framework creates the `InjectionContext` automatically for async routes.
 #[routes]
-// Workaround for kent8192/reinhardt-web#3498 (tracked in reinhardt-cloud#329)
-// Remove this workaround when the upstream issue is resolved.
-//
-// Ideal implementation (without workaround):
-//   #[routes]
-//   pub async fn routes(#[inject] router: Depends<DashboardRouter>) -> UnifiedRouter {
-#[allow(private_interfaces)]
 pub async fn routes(#[inject] router: Depends<DashboardRouter>) -> UnifiedRouter {
 	router
 		.try_unwrap()


### PR DESCRIPTION
## Summary

- Remove `#[allow(private_interfaces)]` and workaround comments from `routes()` in `dashboard/src/config/urls.rs`
- The `#[routes]` macro now emits this allow attribute automatically (reinhardt-web PR #3500)

## Test plan

- [x] `cargo check --workspace --all-features` — no warnings
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)