### PR TITLE
chore: migrate UUID v4 to v7

### DIFF
--- a/crates/reinhardt-cloud-agent/src/main.rs
+++ b/crates/reinhardt-cloud-agent/src/main.rs
@@ -71,7 +71,7 @@ async fn main() {
 	tracing_subscriber::fmt::init();
 
 	let args = Args::parse();
-	let agent_id = Uuid::new_v4();
+	let agent_id = Uuid::now_v7();
 
 	info!(
 		agent_id = %agent_id,

--- a/crates/reinhardt-cloud-core/src/auth.rs
+++ b/crates/reinhardt-cloud-core/src/auth.rs
@@ -59,7 +59,7 @@ mod tests {
 	#[rstest]
 	fn test_create_and_verify_token_roundtrip() {
 		// Arrange
-		let user_id = Uuid::new_v4();
+		let user_id = Uuid::now_v7();
 		let username = "alice";
 
 		// Act
@@ -75,7 +75,7 @@ mod tests {
 	#[rstest]
 	fn test_verify_token_with_wrong_secret() {
 		// Arrange
-		let user_id = Uuid::new_v4();
+		let user_id = Uuid::now_v7();
 		let token = create_token(user_id, "bob", TEST_SECRET, 24).unwrap();
 
 		// Act
@@ -88,7 +88,7 @@ mod tests {
 	#[rstest]
 	fn test_expired_token_is_rejected() {
 		// Arrange
-		let user_id = Uuid::new_v4();
+		let user_id = Uuid::now_v7();
 		// Create a token that expired 1 hour ago
 		let token = create_token(user_id, "charlie", TEST_SECRET, -1).unwrap();
 
@@ -102,7 +102,7 @@ mod tests {
 	#[rstest]
 	fn test_claims_contain_correct_fields() {
 		// Arrange
-		let user_id = Uuid::new_v4();
+		let user_id = Uuid::now_v7();
 		let username = "dave";
 
 		// Act

--- a/crates/reinhardt-cloud-core/src/mocks.rs
+++ b/crates/reinhardt-cloud-core/src/mocks.rs
@@ -33,7 +33,7 @@ impl MockAuthService {
 	/// Create a new mock with default success responses.
 	pub fn new() -> Self {
 		let default_claims = Claims {
-			sub: Uuid::new_v4().to_string(),
+			sub: Uuid::now_v7().to_string(),
 			username: "test-user".to_string(),
 			exp: chrono::Utc::now().timestamp() + 86400,
 			iat: chrono::Utc::now().timestamp(),
@@ -99,7 +99,7 @@ impl MockBuildService {
 	/// Create a new mock with default success responses.
 	pub fn new() -> Self {
 		let default_status = BuildStatus {
-			build_id: Uuid::new_v4(),
+			build_id: Uuid::now_v7(),
 			app_name: "test-app".to_string(),
 			phase: reinhardt_cloud_types::build::BuildPhase::Building,
 			completed: false,
@@ -346,7 +346,7 @@ mod tests {
 	async fn test_mock_cluster_agent_service() {
 		// Arrange
 		let service = MockClusterAgentService::new();
-		let agent_id = Uuid::new_v4();
+		let agent_id = Uuid::now_v7();
 
 		// Act
 		let health = service.get_agent_health(agent_id).await.unwrap();

--- a/crates/reinhardt-cloud-core/src/services/build/local.rs
+++ b/crates/reinhardt-cloud-core/src/services/build/local.rs
@@ -55,7 +55,7 @@ impl BuildService for LocalBuildService {
 		&self,
 		request: BuildRequest,
 	) -> Result<Pin<Box<dyn Stream<Item = Result<BuildEvent, ApiError>> + Send>>, ApiError> {
-		let build_id = Uuid::new_v4();
+		let build_id = Uuid::now_v7();
 		let cancel_token = CancellationToken::new();
 		let now = Utc::now();
 
@@ -180,7 +180,7 @@ async fn run_build_pipeline(
 	}
 
 	// Emit artifact ready
-	let digest = format!("sha256:{:x}", Uuid::new_v4().as_u128());
+	let digest = format!("sha256:{:x}", Uuid::now_v7().as_u128());
 	let _ = tx
 		.send(Ok(BuildEvent::ArtifactReady {
 			artifact_url: format!("{image}@{digest}"),
@@ -326,7 +326,7 @@ mod tests {
 		let service = LocalBuildService::new();
 
 		// Act
-		let result = service.get_build_status(Uuid::new_v4()).await;
+		let result = service.get_build_status(Uuid::now_v7()).await;
 
 		// Assert
 		assert!(result.is_err());

--- a/crates/reinhardt-cloud-core/tests/auth_tests.rs
+++ b/crates/reinhardt-cloud-core/tests/auth_tests.rs
@@ -19,7 +19,7 @@ const TEST_SECRET: &[u8] = b"test-secret-key-for-jwt-signing";
 #[rstest]
 fn test_verify_wrong_secret_returns_invalid_signature() {
 	// Arrange
-	let user_id = Uuid::new_v4();
+	let user_id = Uuid::now_v7();
 	let token = create_token(user_id, "alice", TEST_SECRET, 24).unwrap();
 
 	// Act
@@ -36,7 +36,7 @@ fn test_verify_wrong_secret_returns_invalid_signature() {
 #[rstest]
 fn test_expired_token_returns_expired_error() {
 	// Arrange
-	let user_id = Uuid::new_v4();
+	let user_id = Uuid::now_v7();
 	// Create a token that expired 1 hour ago
 	let token = create_token(user_id, "bob", TEST_SECRET, -1).unwrap();
 
@@ -82,7 +82,7 @@ fn test_verify_empty_token() {
 #[rstest]
 fn test_auth_token_with_zero_expiry() {
 	// Arrange
-	let user_id = Uuid::new_v4();
+	let user_id = Uuid::now_v7();
 
 	// Act — create a token with 0 hours expiry (expires at creation time)
 	let token = create_token(user_id, "zero-expiry", TEST_SECRET, 0).unwrap();
@@ -101,7 +101,7 @@ fn test_auth_token_with_zero_expiry() {
 #[rstest]
 fn test_usecase_token_lifecycle() {
 	// Arrange
-	let user_id = Uuid::new_v4();
+	let user_id = Uuid::now_v7();
 	let username = "lifecycle-user";
 
 	// Act — create -> verify -> check claims

--- a/crates/reinhardt-cloud-core/tests/build_service_tests.rs
+++ b/crates/reinhardt-cloud-core/tests/build_service_tests.rs
@@ -122,7 +122,7 @@ async fn test_build_status_during_execution(local_build_service: LocalBuildServi
 	// Arrange
 	let service = local_build_service;
 	let request = BuildRequest {
-		app_name: format!("status-during-{}", Uuid::new_v4()),
+		app_name: format!("status-during-{}", Uuid::now_v7()),
 		image: "registry.example.com/test:v1".to_string(),
 		env_vars: vec![],
 		dockerfile: None,
@@ -163,7 +163,7 @@ async fn test_build_status_during_execution(local_build_service: LocalBuildServi
 async fn test_cancel_nonexistent_build_returns_not_found(local_build_service: LocalBuildService) {
 	// Arrange
 	let service = local_build_service;
-	let random_id = Uuid::new_v4();
+	let random_id = Uuid::now_v7();
 
 	// Act
 	let result = service.cancel_build(random_id).await;
@@ -188,7 +188,7 @@ async fn test_cancel_completed_build_returns_bad_request(local_build_service: Lo
 	// Arrange
 	let service = local_build_service;
 	let request = BuildRequest {
-		app_name: format!("cancel-completed-{}", Uuid::new_v4()),
+		app_name: format!("cancel-completed-{}", Uuid::now_v7()),
 		image: "registry.example.com/test:v1".to_string(),
 		env_vars: vec![],
 		dockerfile: None,
@@ -204,7 +204,7 @@ async fn test_cancel_completed_build_returns_bad_request(local_build_service: Lo
 	// This test verifies the error path for a nonexistent build after
 	// completion. The actual "already completed" path requires internal
 	// build_id access which is private. The inline tests cover that case.
-	let random_id = Uuid::new_v4();
+	let random_id = Uuid::now_v7();
 	let result = service.cancel_build(random_id).await;
 
 	// Assert
@@ -226,7 +226,7 @@ async fn test_get_nonexistent_build_returns_not_found_with_details(
 ) {
 	// Arrange
 	let service = local_build_service;
-	let random_id = Uuid::new_v4();
+	let random_id = Uuid::now_v7();
 
 	// Act
 	let result = service.get_build_status(random_id).await;
@@ -298,7 +298,7 @@ async fn test_build_state_idempotent_after_completion(local_build_service: Local
 	// Arrange
 	let service = local_build_service;
 	let request = BuildRequest {
-		app_name: format!("idempotent-{}", Uuid::new_v4()),
+		app_name: format!("idempotent-{}", Uuid::now_v7()),
 		image: "registry.example.com/test:v1".to_string(),
 		env_vars: vec![],
 		dockerfile: None,
@@ -331,7 +331,7 @@ async fn test_usecase_concurrent_builds(local_build_service: LocalBuildService) 
 	let service = local_build_service;
 	let requests: Vec<BuildRequest> = (0..3)
 		.map(|i| BuildRequest {
-			app_name: format!("concurrent-app-{i}-{}", Uuid::new_v4()),
+			app_name: format!("concurrent-app-{i}-{}", Uuid::now_v7()),
 			image: format!("registry.example.com/app-{i}:latest"),
 			env_vars: vec![],
 			dockerfile: None,
@@ -388,7 +388,7 @@ async fn test_build_with_all_optional_fields(local_build_service: LocalBuildServ
 	// Arrange
 	let service = local_build_service;
 	let request = BuildRequest {
-		app_name: format!("full-opts-{}", Uuid::new_v4()),
+		app_name: format!("full-opts-{}", Uuid::now_v7()),
 		image: "registry.example.com/full:v2".to_string(),
 		env_vars: vec![
 			EnvVar {
@@ -509,7 +509,7 @@ async fn test_build_cancel_state_decision_table(
 	if build_exists {
 		// Start a build and cancel while running
 		let request = BuildRequest {
-			app_name: format!("decision-{}", Uuid::new_v4()),
+			app_name: format!("decision-{}", Uuid::now_v7()),
 			image: "registry.example.com/test:v1".to_string(),
 			env_vars: vec![],
 			dockerfile: None,
@@ -525,7 +525,7 @@ async fn test_build_cancel_state_decision_table(
 
 	if expect_not_found {
 		// Act
-		let random_id = Uuid::new_v4();
+		let random_id = Uuid::now_v7();
 		let result = service.cancel_build(random_id).await;
 
 		// Assert

--- a/crates/reinhardt-cloud-core/tests/fixtures.rs
+++ b/crates/reinhardt-cloud-core/tests/fixtures.rs
@@ -38,7 +38,7 @@ pub fn local_build_service() -> LocalBuildService {
 #[fixture]
 pub fn build_request() -> BuildRequest {
 	BuildRequest {
-		app_name: format!("test-app-{}", Uuid::new_v4()),
+		app_name: format!("test-app-{}", Uuid::now_v7()),
 		image: "registry.example.com/test:latest".to_string(),
 		env_vars: vec![],
 		dockerfile: None,

--- a/crates/reinhardt-cloud-grpc/src/interceptor.rs
+++ b/crates/reinhardt-cloud-grpc/src/interceptor.rs
@@ -81,7 +81,7 @@ mod tests {
 	fn test_validate_valid_token() {
 		// Arrange
 		let interceptor = JwtInterceptor::new(TEST_SECRET);
-		let user_id = Uuid::new_v4();
+		let user_id = Uuid::now_v7();
 		let token = auth::create_token(user_id, "alice", TEST_SECRET, 24).unwrap();
 
 		// Act
@@ -109,7 +109,7 @@ mod tests {
 	fn test_validate_wrong_secret() {
 		// Arrange
 		let interceptor = JwtInterceptor::new(b"different-secret");
-		let user_id = Uuid::new_v4();
+		let user_id = Uuid::now_v7();
 		let token = auth::create_token(user_id, "bob", TEST_SECRET, 24).unwrap();
 
 		// Act
@@ -123,7 +123,7 @@ mod tests {
 	fn test_validate_expired_token() {
 		// Arrange
 		let interceptor = JwtInterceptor::new(TEST_SECRET);
-		let user_id = Uuid::new_v4();
+		let user_id = Uuid::now_v7();
 		let token = auth::create_token(user_id, "charlie", TEST_SECRET, -1).unwrap();
 
 		// Act
@@ -151,7 +151,7 @@ mod tests {
 	fn test_interceptor_call_malformed_bearer() {
 		// Arrange
 		let mut interceptor = JwtInterceptor::new(TEST_SECRET);
-		let user_id = Uuid::new_v4();
+		let user_id = Uuid::now_v7();
 		let token = auth::create_token(user_id, "alice", TEST_SECRET, 24).unwrap();
 		let mut req = Request::new(());
 		// Use "Token" prefix instead of "Bearer"
@@ -187,7 +187,7 @@ mod tests {
 	fn test_interceptor_reusable_across_calls() {
 		// Arrange
 		let mut interceptor = JwtInterceptor::new(TEST_SECRET);
-		let user_id = Uuid::new_v4();
+		let user_id = Uuid::now_v7();
 		let valid_token = auth::create_token(user_id, "alice", TEST_SECRET, 24).unwrap();
 
 		// Act — first call: valid token
@@ -222,7 +222,7 @@ mod tests {
 	fn test_interceptor_empty_secret() {
 		// Arrange — empty secret
 		let interceptor = JwtInterceptor::new(&[]);
-		let user_id = Uuid::new_v4();
+		let user_id = Uuid::now_v7();
 		// Token created with the original secret won't match empty secret
 		let token = auth::create_token(user_id, "alice", TEST_SECRET, 24).unwrap();
 

--- a/crates/reinhardt-cloud-grpc/src/registry.rs
+++ b/crates/reinhardt-cloud-grpc/src/registry.rs
@@ -187,7 +187,7 @@ mod tests {
 	fn test_register_and_list() {
 		// Arrange
 		let registry = AgentRegistry::new();
-		let id = Uuid::new_v4();
+		let id = Uuid::now_v7();
 		let info = test_agent_info(id);
 
 		// Act
@@ -203,7 +203,7 @@ mod tests {
 	fn test_unregister() {
 		// Arrange
 		let registry = AgentRegistry::new();
-		let id = Uuid::new_v4();
+		let id = Uuid::now_v7();
 		let _rx = registry.register(test_agent_info(id));
 
 		// Act
@@ -217,7 +217,7 @@ mod tests {
 	fn test_heartbeat_keeps_agent_healthy() {
 		// Arrange
 		let registry = AgentRegistry::new();
-		let id = Uuid::new_v4();
+		let id = Uuid::now_v7();
 		let _rx = registry.register(test_agent_info(id));
 
 		// Act
@@ -232,7 +232,7 @@ mod tests {
 	async fn test_send_command() {
 		// Arrange
 		let registry = AgentRegistry::new();
-		let id = Uuid::new_v4();
+		let id = Uuid::now_v7();
 		let mut rx = registry.register(test_agent_info(id));
 
 		// Act
@@ -250,7 +250,7 @@ mod tests {
 	fn test_update_health() {
 		// Arrange
 		let registry = AgentRegistry::new();
-		let id = Uuid::new_v4();
+		let id = Uuid::now_v7();
 		let _rx = registry.register(test_agent_info(id));
 		let health = AgentHealth {
 			agent_id: id,
@@ -274,7 +274,7 @@ mod tests {
 	async fn test_send_command_to_nonexistent_agent() {
 		// Arrange
 		let registry = AgentRegistry::new();
-		let id = Uuid::new_v4();
+		let id = Uuid::now_v7();
 		let cmd = AgentCommand::Restart {
 			app_name: "web".to_string(),
 		};
@@ -292,7 +292,7 @@ mod tests {
 	async fn test_send_command_channel_closed() {
 		// Arrange
 		let registry = AgentRegistry::new();
-		let id = Uuid::new_v4();
+		let id = Uuid::now_v7();
 		let rx = registry.register(test_agent_info(id));
 		drop(rx); // close the receiver side
 
@@ -312,7 +312,7 @@ mod tests {
 	fn test_get_health_nonexistent_agent() {
 		// Arrange
 		let registry = AgentRegistry::new();
-		let id = Uuid::new_v4();
+		let id = Uuid::now_v7();
 
 		// Act
 		let result = registry.get_health(&id);
@@ -325,7 +325,7 @@ mod tests {
 	fn test_is_healthy_nonexistent_agent() {
 		// Arrange
 		let registry = AgentRegistry::new();
-		let id = Uuid::new_v4();
+		let id = Uuid::now_v7();
 
 		// Act
 		let result = registry.is_healthy(&id);
@@ -338,7 +338,7 @@ mod tests {
 	fn test_register_same_agent_twice() {
 		// Arrange
 		let registry = AgentRegistry::new();
-		let id = Uuid::new_v4();
+		let id = Uuid::now_v7();
 		let _rx1 = registry.register(test_agent_info(id));
 
 		// Act — register same agent_id again
@@ -355,8 +355,8 @@ mod tests {
 	fn test_unregister_nonexistent_agent() {
 		// Arrange
 		let registry = AgentRegistry::new();
-		let id = Uuid::new_v4();
-		let other = Uuid::new_v4();
+		let id = Uuid::now_v7();
+		let other = Uuid::now_v7();
 		let _rx = registry.register(test_agent_info(id));
 
 		// Act — unregister a non-existent agent
@@ -370,7 +370,7 @@ mod tests {
 	fn test_heartbeat_nonexistent_agent() {
 		// Arrange
 		let registry = AgentRegistry::new();
-		let id = Uuid::new_v4();
+		let id = Uuid::now_v7();
 
 		// Act — heartbeat for non-existent agent
 		registry.heartbeat(&id);
@@ -384,7 +384,7 @@ mod tests {
 	async fn test_agent_lifecycle_full() {
 		// Arrange
 		let registry = AgentRegistry::new();
-		let id = Uuid::new_v4();
+		let id = Uuid::now_v7();
 		let mut rx = registry.register(test_agent_info(id));
 
 		// Act — heartbeat
@@ -427,7 +427,7 @@ mod tests {
 	fn test_evict_stale_agents() {
 		// Arrange
 		let registry = AgentRegistry::new();
-		let id = Uuid::new_v4();
+		let id = Uuid::now_v7();
 		let _rx = registry.register(test_agent_info(id));
 
 		// Set heartbeat to 2 minutes ago (well past 90s threshold)
@@ -447,7 +447,7 @@ mod tests {
 	fn test_is_healthy_heartbeat_boundary() {
 		// Arrange
 		let registry = AgentRegistry::new();
-		let id = Uuid::new_v4();
+		let id = Uuid::now_v7();
 		let _rx = registry.register(test_agent_info(id));
 
 		// Just under 90s ago -> healthy
@@ -477,9 +477,9 @@ mod tests {
 	async fn test_multiple_agents_independent_channels() {
 		// Arrange
 		let registry = AgentRegistry::new();
-		let id1 = Uuid::new_v4();
-		let id2 = Uuid::new_v4();
-		let id3 = Uuid::new_v4();
+		let id1 = Uuid::now_v7();
+		let id2 = Uuid::now_v7();
+		let id3 = Uuid::now_v7();
 		let mut rx1 = registry.register(test_agent_info(id1));
 		let mut rx2 = registry.register(test_agent_info(id2));
 		let mut rx3 = registry.register(test_agent_info(id3));
@@ -542,7 +542,7 @@ mod tests {
 		for _ in 0..10 {
 			let reg = registry.clone();
 			handles.push(tokio::spawn(async move {
-				let id = Uuid::new_v4();
+				let id = Uuid::now_v7();
 				let _rx = reg.register(AgentInfo {
 					agent_id: id,
 					cluster_name: "test".to_string(),

--- a/crates/reinhardt-cloud-grpc/src/services/cluster_agent.rs
+++ b/crates/reinhardt-cloud-grpc/src/services/cluster_agent.rs
@@ -311,7 +311,7 @@ mod tests {
 	fn test_proto_event_to_domain_connected() {
 		// Arrange
 		let ts = fixed_timestamp();
-		let agent_id = Uuid::new_v4();
+		let agent_id = Uuid::now_v7();
 		let proto = pb::AgentEvent {
 			event: Some(pb::agent_event::Event::Connected(pb::AgentConnected {
 				agent_id: agent_id.to_string(),
@@ -377,7 +377,7 @@ mod tests {
 	fn test_proto_event_to_domain_heartbeat() {
 		// Arrange
 		let ts = fixed_timestamp();
-		let agent_id = Uuid::new_v4();
+		let agent_id = Uuid::now_v7();
 		let proto = pb::AgentEvent {
 			event: Some(pb::agent_event::Event::Heartbeat(pb::AgentHeartbeat {
 				agent_id: agent_id.to_string(),

--- a/crates/reinhardt-cloud-types/src/agent.rs
+++ b/crates/reinhardt-cloud-types/src/agent.rs
@@ -111,7 +111,7 @@ mod tests {
 	fn test_agent_info_serde_roundtrip() {
 		// Arrange
 		let info = AgentInfo {
-			agent_id: Uuid::new_v4(),
+			agent_id: Uuid::now_v7(),
 			cluster_name: "prod-us-east".to_string(),
 			node_name: "node-01".to_string(),
 			version: "0.1.0".to_string(),
@@ -162,7 +162,7 @@ mod tests {
 	fn test_agent_event_variants_serde_roundtrip() {
 		// Arrange
 		let now = Utc::now();
-		let agent_id = Uuid::new_v4();
+		let agent_id = Uuid::now_v7();
 		let events = vec![
 			AgentEvent::Connected {
 				agent_id,
@@ -204,7 +204,7 @@ mod tests {
 	fn test_agent_health_serde_roundtrip() {
 		// Arrange
 		let health = AgentHealth {
-			agent_id: Uuid::new_v4(),
+			agent_id: Uuid::now_v7(),
 			healthy: true,
 			cpu_usage_percent: 45.2,
 			memory_usage_percent: 67.8,
@@ -227,7 +227,7 @@ mod tests {
 	fn test_agent_health_cpu_zero() {
 		// Arrange
 		let health = AgentHealth {
-			agent_id: Uuid::new_v4(),
+			agent_id: Uuid::now_v7(),
 			healthy: true,
 			cpu_usage_percent: 0.0,
 			memory_usage_percent: 50.0,
@@ -247,7 +247,7 @@ mod tests {
 	fn test_agent_health_cpu_hundred() {
 		// Arrange
 		let health = AgentHealth {
-			agent_id: Uuid::new_v4(),
+			agent_id: Uuid::now_v7(),
 			healthy: false,
 			cpu_usage_percent: 100.0,
 			memory_usage_percent: 99.0,
@@ -311,7 +311,7 @@ mod tests {
 	fn test_agent_info_empty_version() {
 		// Arrange
 		let info = AgentInfo {
-			agent_id: Uuid::new_v4(),
+			agent_id: Uuid::now_v7(),
 			cluster_name: "test-cluster".to_string(),
 			node_name: "node-01".to_string(),
 			version: "".to_string(),
@@ -336,7 +336,7 @@ mod tests {
 	fn test_agent_health_percentage_boundaries(#[case] cpu: f64) {
 		// Arrange
 		let health = AgentHealth {
-			agent_id: Uuid::new_v4(),
+			agent_id: Uuid::now_v7(),
 			healthy: true,
 			cpu_usage_percent: cpu,
 			memory_usage_percent: 50.0,

--- a/crates/reinhardt-cloud-types/src/build.rs
+++ b/crates/reinhardt-cloud-types/src/build.rs
@@ -169,7 +169,7 @@ mod tests {
 	fn test_build_status_serde_roundtrip() {
 		// Arrange
 		let status = BuildStatus {
-			build_id: Uuid::new_v4(),
+			build_id: Uuid::now_v7(),
 			app_name: "test-app".to_string(),
 			phase: BuildPhase::Pushing,
 			completed: false,
@@ -212,7 +212,7 @@ mod tests {
 	fn test_build_status_completed_with_failure() {
 		// Arrange
 		let status = BuildStatus {
-			build_id: Uuid::new_v4(),
+			build_id: Uuid::now_v7(),
 			app_name: "failing-app".to_string(),
 			phase: BuildPhase::Finalizing,
 			completed: true,

--- a/crates/reinhardt-cloud-types/src/cluster.rs
+++ b/crates/reinhardt-cloud-types/src/cluster.rs
@@ -16,7 +16,7 @@ impl Cluster {
 	/// Creates a new active cluster with a generated UUID.
 	pub fn new(name: &str, api_url: &str) -> Self {
 		Self {
-			id: Uuid::new_v4(),
+			id: Uuid::now_v7(),
 			name: name.to_string(),
 			api_url: api_url.to_string(),
 			is_active: true,

--- a/crates/reinhardt-cloud-types/src/deployment.rs
+++ b/crates/reinhardt-cloud-types/src/deployment.rs
@@ -26,7 +26,7 @@ impl Deployment {
 	/// Creates a new deployment in `Pending` status.
 	pub fn new(app_name: &str, cluster_id: Uuid, image: &str) -> Self {
 		Self {
-			id: Uuid::new_v4(),
+			id: Uuid::now_v7(),
 			app_name: app_name.to_string(),
 			cluster_id,
 			status: DeploymentStatus::Pending,
@@ -51,7 +51,7 @@ mod tests {
 	#[rstest]
 	fn test_deployment_new_defaults_to_pending() {
 		// Arrange
-		let cluster_id = Uuid::new_v4();
+		let cluster_id = Uuid::now_v7();
 
 		// Act
 		let deploy = Deployment::new("my-app", cluster_id, "my-app:latest");
@@ -70,7 +70,7 @@ mod tests {
 	#[case(DeploymentStatus::Succeeded, true)]
 	fn test_is_terminal(#[case] status: DeploymentStatus, #[case] expected: bool) {
 		// Arrange
-		let mut deploy = Deployment::new("app", Uuid::new_v4(), "img:v1");
+		let mut deploy = Deployment::new("app", Uuid::now_v7(), "img:v1");
 
 		// Act
 		deploy.status = status;

--- a/crates/reinhardt-cloud-types/src/user.rs
+++ b/crates/reinhardt-cloud-types/src/user.rs
@@ -16,7 +16,7 @@ impl User {
 	/// Creates a new user with a generated UUID.
 	pub fn new(username: &str, email: &str, password_hash: &str) -> Self {
 		Self {
-			id: Uuid::new_v4(),
+			id: Uuid::now_v7(),
 			username: username.to_string(),
 			email: email.to_string(),
 			password_hash: password_hash.to_string(),

--- a/dashboard/src/apps/clusters/tests/unit/test_cluster_model.rs
+++ b/dashboard/src/apps/clusters/tests/unit/test_cluster_model.rs
@@ -10,7 +10,7 @@ mod tests {
 	#[rstest]
 	fn test_cluster_new_sets_fields() {
 		// Arrange
-		let user_id = Uuid::new_v4();
+		let user_id = Uuid::now_v7();
 		let name = "production".to_string();
 		let api_url = "https://k8s.example.com:6443".to_string();
 
@@ -27,7 +27,7 @@ mod tests {
 	#[rstest]
 	fn test_cluster_new_id_is_none() {
 		// Arrange
-		let user_id = Uuid::new_v4();
+		let user_id = Uuid::now_v7();
 
 		// Act
 		let cluster = Cluster::new(
@@ -46,7 +46,7 @@ mod tests {
 	#[case(false)]
 	fn test_cluster_is_active_flag(#[case] active: bool) {
 		// Arrange
-		let user_id = Uuid::new_v4();
+		let user_id = Uuid::now_v7();
 
 		// Act
 		let cluster = Cluster::new(
@@ -64,7 +64,7 @@ mod tests {
 	fn test_cluster_serialization_roundtrip() {
 		// Arrange
 		let cluster = Cluster::new(
-			Uuid::new_v4(),
+			Uuid::now_v7(),
 			"roundtrip".to_string(),
 			"https://k8s.example.com:6443".to_string(),
 			true,

--- a/dashboard/src/apps/clusters/tests/unit/test_cluster_property.rs
+++ b/dashboard/src/apps/clusters/tests/unit/test_cluster_property.rs
@@ -18,7 +18,7 @@ mod tests {
 		) {
 			// Arrange
 			let cluster = Cluster::new(
-				Uuid::new_v4(),
+				Uuid::now_v7(),
 				name.clone(),
 				api_url.clone(),
 				is_active,

--- a/dashboard/src/apps/clusters/tests/unit/test_serializer.rs
+++ b/dashboard/src/apps/clusters/tests/unit/test_serializer.rs
@@ -27,7 +27,7 @@ mod tests {
 	fn test_cluster_response_with_none_id_serializes_to_null() {
 		// Arrange
 		let cluster = Cluster::new(
-			Uuid::new_v4(),
+			Uuid::now_v7(),
 			"staging".to_string(),
 			"https://staging.k8s.io:6443".to_string(),
 			true,
@@ -46,7 +46,7 @@ mod tests {
 	fn test_cluster_response_with_some_id_serializes_to_number() {
 		// Arrange
 		let mut cluster = Cluster::new(
-			Uuid::new_v4(),
+			Uuid::now_v7(),
 			"production".to_string(),
 			"https://prod.k8s.io:6443".to_string(),
 			true,
@@ -66,7 +66,7 @@ mod tests {
 	fn test_cluster_response_from_orm_model() {
 		// Arrange
 		let cluster = Cluster::new(
-			Uuid::new_v4(),
+			Uuid::now_v7(),
 			"staging".to_string(),
 			"https://staging.k8s.io:6443".to_string(),
 			true,

--- a/dashboard/src/apps/deployments/tests/unit/test_deployment_model.rs
+++ b/dashboard/src/apps/deployments/tests/unit/test_deployment_model.rs
@@ -11,7 +11,7 @@ mod tests {
 	#[rstest]
 	fn test_deployment_new_sets_fields() {
 		// Arrange
-		let user_id = Uuid::new_v4();
+		let user_id = Uuid::now_v7();
 		let app_name = "my-app".to_string();
 		let cluster_id = 42i64;
 		let status = "pending".to_string();
@@ -39,7 +39,7 @@ mod tests {
 	fn test_deployment_new_id_is_none() {
 		// Arrange & Act
 		let deployment = Deployment::new(
-			Uuid::new_v4(),
+			Uuid::now_v7(),
 			"app".to_string(),
 			1,
 			"pending".to_string(),
@@ -59,7 +59,7 @@ mod tests {
 	fn test_deployment_status_values(#[case] status: &str) {
 		// Arrange & Act
 		let deployment = Deployment::new(
-			Uuid::new_v4(),
+			Uuid::now_v7(),
 			"app".to_string(),
 			1,
 			status.to_string(),
@@ -75,7 +75,7 @@ mod tests {
 	fn test_deployment_serialization_roundtrip() {
 		// Arrange
 		let mut deployment = Deployment::new(
-			Uuid::new_v4(),
+			Uuid::now_v7(),
 			"roundtrip-app".to_string(),
 			99,
 			"running".to_string(),

--- a/dashboard/src/apps/deployments/tests/unit/test_serializer.rs
+++ b/dashboard/src/apps/deployments/tests/unit/test_serializer.rs
@@ -14,7 +14,7 @@ mod tests {
 	fn test_deployment_response_status_serializes_to_string() {
 		// Arrange
 		let deployment = Deployment::new(
-			Uuid::new_v4(),
+			Uuid::now_v7(),
 			"my-app".to_string(),
 			1,
 			"pending".to_string(),
@@ -34,7 +34,7 @@ mod tests {
 	fn test_deployment_response_with_none_id_serializes_to_null() {
 		// Arrange
 		let deployment = Deployment::new(
-			Uuid::new_v4(),
+			Uuid::now_v7(),
 			"my-app".to_string(),
 			1,
 			"pending".to_string(),
@@ -54,7 +54,7 @@ mod tests {
 	fn test_deployment_response_with_some_id_serializes_to_number() {
 		// Arrange
 		let mut deployment = Deployment::new(
-			Uuid::new_v4(),
+			Uuid::now_v7(),
 			"my-app".to_string(),
 			1,
 			"running".to_string(),

--- a/dashboard/src/apps/realtime/consumer.rs
+++ b/dashboard/src/apps/realtime/consumer.rs
@@ -96,7 +96,7 @@ impl NotificationConsumer {
 				if user_id.is_none() {
 					return ParsedAction::Rejected {
 						response: WsMessage::SystemNotification(SystemNotificationPayload {
-							id: uuid::Uuid::new_v4().to_string(),
+							id: uuid::Uuid::now_v7().to_string(),
 							level: NotificationLevel::Critical,
 							title: "Authentication required".to_string(),
 							message: "You must be authenticated to subscribe".to_string(),
@@ -178,7 +178,7 @@ fn extract_cookie_value(cookie_header: &str, name: &str) -> Option<String> {
 #[async_trait::async_trait]
 impl WebSocketConsumer for NotificationConsumer {
 	async fn on_connect(&self, context: &mut ConsumerContext) -> WebSocketResult<()> {
-		let connection_id = Uuid::new_v4().to_string();
+		let connection_id = Uuid::now_v7().to_string();
 		context
 			.metadata
 			.insert(META_CONNECTION_ID.to_string(), connection_id.clone());

--- a/tests/integration/tests/agent_grpc_integration.rs
+++ b/tests/integration/tests/agent_grpc_integration.rs
@@ -50,7 +50,7 @@ async fn test_report_health_through_grpc() {
 	let (addr, _handle) = start_agent_server().await;
 	let mut client = connect_agent_client(addr).await;
 
-	let agent_id = Uuid::new_v4();
+	let agent_id = Uuid::now_v7();
 	let now = chrono::Utc::now();
 	let health_report = pb::AgentHealthReport {
 		agent_id: agent_id.to_string(),

--- a/tests/integration/tests/build_grpc_integration.rs
+++ b/tests/integration/tests/build_grpc_integration.rs
@@ -139,7 +139,7 @@ async fn test_cancel_nonexistent_build_through_grpc() {
 	// Act -- CancelBuild with a valid UUID that does not correspond to any build
 	let result = client
 		.cancel_build(pb::CancelBuildRequest {
-			build_id: uuid::Uuid::new_v4().to_string(),
+			build_id: uuid::Uuid::now_v7().to_string(),
 		})
 		.await;
 
@@ -165,7 +165,7 @@ async fn test_get_build_status_unknown_build() {
 	// Act -- GetBuildStatus with a valid UUID that does not exist
 	let result = client
 		.get_build_status(pb::GetBuildStatusRequest {
-			build_id: uuid::Uuid::new_v4().to_string(),
+			build_id: uuid::Uuid::now_v7().to_string(),
 		})
 		.await;
 


### PR DESCRIPTION
## Summary

- Replace all `Uuid::new_v4()` with `Uuid::now_v7()` (88 occurrences, RFC 9562)
- Add `"v7"` feature to workspace uuid dependency, bump minimum to 1.7
- Does NOT update reinhardt-web dependency (blocked on reinhardt-web#3515)

## Test plan

- [x] `cargo check --workspace --all-features` — passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)