### PR TITLE
refactor: upstream workaround removal (reinhardt-web update)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1285,7 +1285,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1851,7 +1851,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2079,7 +2079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4055,7 +4055,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5263,7 +5263,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5703,7 +5703,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "reinhardt-admin"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5754,7 +5754,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-apps"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5784,7 +5784,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-auth"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5829,7 +5829,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-auth-macros"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6073,7 +6073,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-commands"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6129,7 +6129,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-conf"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "chrono",
  "dotenv",
@@ -6155,7 +6155,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-core"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "anyhow",
  "aquamarine 0.6.0",
@@ -6203,7 +6203,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-db"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -6258,7 +6258,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-di"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -6281,7 +6281,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-di-macros"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6292,7 +6292,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-forms"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "anyhow",
  "aquamarine 0.5.0",
@@ -6309,7 +6309,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-http"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6330,7 +6330,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-macros"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "ctor 0.8.0",
  "inventory",
@@ -6344,7 +6344,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-mail"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6365,7 +6365,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-manouche"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "aquamarine 0.6.0",
  "convert_case",
@@ -6378,7 +6378,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-middleware"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6414,7 +6414,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-openapi"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "async-trait",
  "reinhardt-http",
@@ -6426,7 +6426,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-openapi-macros"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6437,7 +6437,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-pages"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "aquamarine 0.5.0",
  "async-trait",
@@ -6476,7 +6476,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-pages-ast"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "aquamarine 0.6.0",
  "convert_case",
@@ -6490,7 +6490,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-pages-macros"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "convert_case",
  "darling 0.20.11",
@@ -6504,7 +6504,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-query"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -6518,7 +6518,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-query-macros"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -6529,7 +6529,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-rest"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6578,7 +6578,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-routers-macros"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6588,7 +6588,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-server"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6607,7 +6607,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-shortcuts"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "bytes",
  "hyper",
@@ -6625,7 +6625,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-test"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "cfg_aliases",
  "reinhardt-auth",
@@ -6645,7 +6645,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-testkit"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "async-dropper",
  "async-trait",
@@ -6666,10 +6666,12 @@ dependencies = [
  "mockall",
  "paste",
  "redis 1.2.0",
+ "reinhardt-auth",
  "reinhardt-core",
  "reinhardt-db",
  "reinhardt-di",
  "reinhardt-http",
+ "reinhardt-middleware",
  "reinhardt-query",
  "reinhardt-server",
  "reinhardt-urls",
@@ -6688,6 +6690,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tokio-util",
+ "totp-lite",
  "tracing",
  "url",
  "urlencoding",
@@ -6697,7 +6700,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-throttling"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -6708,7 +6711,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-urls"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -6741,7 +6744,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-utils"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6777,7 +6780,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-views"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6813,7 +6816,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-web"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6822,6 +6825,7 @@ dependencies = [
  "hyper",
  "inventory",
  "linkme",
+ "paste",
  "reinhardt-admin",
  "reinhardt-apps",
  "reinhardt-auth",
@@ -6853,7 +6857,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-websockets"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#87e1c078dfc3c2198fa0f744e9d8a8f615383d45"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7189,7 +7193,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7272,7 +7276,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8255,7 +8259,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9522,7 +9526,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,15 +85,13 @@ tokio-test = "0.4"
 proptest = "1"
 reinhardt-test = { package = "reinhardt-test", git = "https://github.com/kent8192/reinhardt-web", branch = "main", features = ["testcontainers"] }
 
-# Workaround for kent8192/reinhardt-web#3496 (tracked in reinhardt-cloud#328)
-# Blocked on reinhardt-web#3515 (Injectable bound for factory return types)
-# which prevents updating to reinhardt-web >= 5d9ef22a where url-resolver
-# feature was removed (PR #3513).
+# Workaround for kent8192/reinhardt-web#3673
+# server_fn macro emits cfg(feature = "msw") in consuming crates.
 #
 # Ideal implementation (without workaround):
 #   No [workspace.lints.rust] section needed.
 [workspace.lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("url-resolver"))'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("msw"))'] }
 
 [workspace.lints.clippy]
 module_name_repetitions = "allow"

--- a/dashboard/src/apps/clusters/tests/e2e/test_cluster_crud.rs
+++ b/dashboard/src/apps/clusters/tests/e2e/test_cluster_crud.rs
@@ -2,6 +2,7 @@
 
 #[cfg(test)]
 mod tests {
+	use reinhardt::middleware::session::AsyncSessionBackend;
 	use reinhardt::prelude::DatabaseConnection;
 	use reinhardt::test::APIClient;
 	use reinhardt::test::fixtures::postgres_with_migrations_from_dir;
@@ -11,55 +12,25 @@ mod tests {
 	use serial_test::serial;
 	use std::sync::Arc;
 
-	use crate::config::test_helpers::{TestUrls, test_app};
+	use crate::config::test_helpers::{TestUrls, force_login_user, session_backend, test_app};
 
 	#[fixture]
 	async fn db(
 		test_app: (APIClient, TestUrls),
+		session_backend: Arc<dyn AsyncSessionBackend>,
 	) -> (
 		ContainerAsync<GenericImage>,
 		Arc<DatabaseConnection>,
 		APIClient,
 		TestUrls,
+		Arc<dyn AsyncSessionBackend>,
 	) {
 		let (client, urls) = test_app;
 		let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
 		let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
 			.await
 			.expect("Failed to start PostgreSQL with migrations");
-		(container, conn, client, urls)
-	}
-
-	/// Helper: register a test user and return the session cookie value.
-	async fn register_and_get_session(client: &APIClient) -> String {
-		let register_data = json!({
-			"username": "testuser",
-			"email": "test@example.com",
-			"password": "securepassword123"
-		});
-		let resp = client
-			.post("/api/auth/register/", &register_data, "json")
-			.await
-			.expect("Register request failed");
-		assert_eq!(resp.status_code(), 201);
-		let set_cookie = resp
-			.header("Set-Cookie")
-			.expect("Response should have Set-Cookie header");
-		let session_id = set_cookie
-			.split(';')
-			.next()
-			.unwrap()
-			.strip_prefix("sessionid=")
-			.expect("Cookie should start with sessionid=");
-		session_id.to_string()
-	}
-
-	/// Helper: set session cookie on client.
-	async fn authenticate_client(client: &APIClient, session_id: &str) {
-		client
-			.set_header("Cookie", format!("sessionid={session_id}"))
-			.await
-			.expect("Failed to set Cookie header");
+		(container, conn, client, urls, session_backend)
 	}
 
 	/// Verify unauthenticated GET /api/clusters/ returns 401.
@@ -72,10 +43,11 @@ mod tests {
 			Arc<DatabaseConnection>,
 			APIClient,
 			TestUrls,
+			Arc<dyn AsyncSessionBackend>,
 		),
 	) {
 		// Arrange
-		let (_container, _conn, client, _urls) = db.await;
+		let (_container, _conn, client, _urls, _backend) = db.await;
 
 		// Act
 		let response = client
@@ -97,12 +69,12 @@ mod tests {
 			Arc<DatabaseConnection>,
 			APIClient,
 			TestUrls,
+			Arc<dyn AsyncSessionBackend>,
 		),
 	) {
 		// Arrange
-		let (_container, _conn, client, _urls) = db.await;
-		let session = register_and_get_session(&client).await;
-		authenticate_client(&client, &session).await;
+		let (_container, conn, client, _urls, backend) = db.await;
+		force_login_user(&client, &conn, &backend, "testuser", "test@example.com").await;
 
 		// Act
 		let response = client
@@ -129,12 +101,12 @@ mod tests {
 			Arc<DatabaseConnection>,
 			APIClient,
 			TestUrls,
+			Arc<dyn AsyncSessionBackend>,
 		),
 	) {
 		// Arrange
-		let (_container, _conn, client, _urls) = db.await;
-		let session = register_and_get_session(&client).await;
-		authenticate_client(&client, &session).await;
+		let (_container, conn, client, _urls, backend) = db.await;
+		force_login_user(&client, &conn, &backend, "testuser", "test@example.com").await;
 
 		let cluster_data = json!({
 			"name": "production-cluster",

--- a/dashboard/src/apps/clusters/tests/e2e/test_cluster_ownership.rs
+++ b/dashboard/src/apps/clusters/tests/e2e/test_cluster_ownership.rs
@@ -2,6 +2,7 @@
 
 #[cfg(test)]
 mod tests {
+	use reinhardt::middleware::session::AsyncSessionBackend;
 	use reinhardt::prelude::DatabaseConnection;
 	use reinhardt::test::APIClient;
 	use reinhardt::test::fixtures::postgres_with_migrations_from_dir;
@@ -11,56 +12,27 @@ mod tests {
 	use serial_test::serial;
 	use std::sync::Arc;
 
-	use crate::config::test_helpers::{TestUrls, test_app};
+	use crate::config::test_helpers::{
+		TestUrls, force_login, force_login_user, session_backend, test_app,
+	};
 
 	#[fixture]
 	async fn db(
 		test_app: (APIClient, TestUrls),
+		session_backend: Arc<dyn AsyncSessionBackend>,
 	) -> (
 		ContainerAsync<GenericImage>,
 		Arc<DatabaseConnection>,
 		APIClient,
 		TestUrls,
+		Arc<dyn AsyncSessionBackend>,
 	) {
 		let (client, urls) = test_app;
 		let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
 		let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
 			.await
 			.expect("Failed to start PostgreSQL with migrations");
-		(container, conn, client, urls)
-	}
-
-	/// Helper: register a user and return the session cookie value.
-	async fn register_user(client: &APIClient, username: &str, email: &str) -> String {
-		let data = json!({
-			"username": username,
-			"email": email,
-			"password": "securepassword123"
-		});
-		let resp = client
-			.post("/api/auth/register/", &data, "json")
-			.await
-			.expect("Register request failed");
-		assert_eq!(resp.status_code(), 201);
-		// Extract session cookie from Set-Cookie header
-		let set_cookie = resp
-			.header("Set-Cookie")
-			.expect("Response should have Set-Cookie header");
-		let session_id = set_cookie
-			.split(';')
-			.next()
-			.unwrap()
-			.strip_prefix("sessionid=")
-			.expect("Cookie should start with sessionid=");
-		session_id.to_string()
-	}
-
-	/// Helper: set session cookie on client.
-	async fn authenticate_client(client: &APIClient, session_id: &str) {
-		client
-			.set_header("Cookie", format!("sessionid={session_id}"))
-			.await
-			.expect("Failed to set Cookie header");
+		(container, conn, client, urls, session_backend)
 	}
 
 	/// Helper: create a cluster and return its response body.
@@ -87,17 +59,16 @@ mod tests {
 			Arc<DatabaseConnection>,
 			APIClient,
 			TestUrls,
+			Arc<dyn AsyncSessionBackend>,
 		),
 	) {
 		// Arrange
-		let (_container, _conn, client, _urls) = db.await;
+		let (_container, conn, client, _urls, backend) = db.await;
 
-		let session_a = register_user(&client, "user_a", "a@example.com").await;
-		authenticate_client(&client, &session_a).await;
+		force_login_user(&client, &conn, &backend, "owner_a", "a@example.com").await;
 		create_cluster(&client, "cluster-a").await;
 
-		let session_b = register_user(&client, "user_b", "b@example.com").await;
-		authenticate_client(&client, &session_b).await;
+		force_login_user(&client, &conn, &backend, "owner_b", "b@example.com").await;
 
 		// Act
 		let response = client
@@ -122,18 +93,17 @@ mod tests {
 			Arc<DatabaseConnection>,
 			APIClient,
 			TestUrls,
+			Arc<dyn AsyncSessionBackend>,
 		),
 	) {
 		// Arrange
-		let (_container, _conn, client, _urls) = db.await;
+		let (_container, conn, client, _urls, backend) = db.await;
 
-		let session_a = register_user(&client, "user_a", "a@example.com").await;
-		authenticate_client(&client, &session_a).await;
+		let user_a = force_login_user(&client, &conn, &backend, "owner_a", "a@example.com").await;
 		create_cluster(&client, "cluster-a1").await;
 		create_cluster(&client, "cluster-a2").await;
 
-		let session_b = register_user(&client, "user_b", "b@example.com").await;
-		authenticate_client(&client, &session_b).await;
+		force_login_user(&client, &conn, &backend, "owner_b", "b@example.com").await;
 		create_cluster(&client, "cluster-b1").await;
 
 		// Act -- UserB lists clusters
@@ -152,8 +122,8 @@ mod tests {
 		assert_eq!(items_b.len(), 1);
 		assert_eq!(items_b[0]["name"], "cluster-b1");
 
-		// Act -- switch to UserA
-		authenticate_client(&client, &session_a).await;
+		// Act -- switch back to UserA
+		force_login(&client, &backend, &user_a).await;
 		let resp_a = client
 			.get("/api/clusters/")
 			.await
@@ -179,10 +149,11 @@ mod tests {
 			Arc<DatabaseConnection>,
 			APIClient,
 			TestUrls,
+			Arc<dyn AsyncSessionBackend>,
 		),
 	) {
 		// Arrange
-		let (_container, _conn, client, _urls) = db.await;
+		let (_container, _conn, client, _urls, _backend) = db.await;
 
 		// Act
 		let response = client
@@ -204,11 +175,18 @@ mod tests {
 			Arc<DatabaseConnection>,
 			APIClient,
 			TestUrls,
+			Arc<dyn AsyncSessionBackend>,
 		),
 	) {
 		// Arrange
-		let (_container, _conn, client, _urls) = db.await;
-		authenticate_client(&client, "invalid-session-id-gibberish").await;
+		let (_container, _conn, client, _urls, _backend) = db.await;
+		client
+			.set_header(
+				"Cookie",
+				"sessionid=invalid-session-id-gibberish".to_string(),
+			)
+			.await
+			.expect("Failed to set Cookie header");
 
 		// Act
 		let response = client

--- a/dashboard/src/apps/clusters/tests/e2e/test_cluster_pagination.rs
+++ b/dashboard/src/apps/clusters/tests/e2e/test_cluster_pagination.rs
@@ -2,6 +2,7 @@
 
 #[cfg(test)]
 mod tests {
+	use reinhardt::middleware::session::AsyncSessionBackend;
 	use reinhardt::prelude::DatabaseConnection;
 	use reinhardt::test::APIClient;
 	use reinhardt::test::fixtures::postgres_with_migrations_from_dir;
@@ -11,55 +12,25 @@ mod tests {
 	use serial_test::serial;
 	use std::sync::Arc;
 
-	use crate::config::test_helpers::{TestUrls, test_app};
+	use crate::config::test_helpers::{TestUrls, force_login_user, session_backend, test_app};
 
 	#[fixture]
 	async fn db(
 		test_app: (APIClient, TestUrls),
+		session_backend: Arc<dyn AsyncSessionBackend>,
 	) -> (
 		ContainerAsync<GenericImage>,
 		Arc<DatabaseConnection>,
 		APIClient,
 		TestUrls,
+		Arc<dyn AsyncSessionBackend>,
 	) {
 		let (client, urls) = test_app;
 		let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
 		let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
 			.await
 			.expect("Failed to start PostgreSQL with migrations");
-		(container, conn, client, urls)
-	}
-
-	/// Helper: register a test user and return the session cookie value.
-	async fn register_and_get_session(client: &APIClient) -> String {
-		let register_data = json!({
-			"username": "testuser",
-			"email": "test@example.com",
-			"password": "securepassword123"
-		});
-		let resp = client
-			.post("/api/auth/register/", &register_data, "json")
-			.await
-			.expect("Register request failed");
-		assert_eq!(resp.status_code(), 201);
-		let set_cookie = resp
-			.header("Set-Cookie")
-			.expect("Response should have Set-Cookie header");
-		let session_id = set_cookie
-			.split(';')
-			.next()
-			.unwrap()
-			.strip_prefix("sessionid=")
-			.expect("Cookie should start with sessionid=");
-		session_id.to_string()
-	}
-
-	/// Helper: set session cookie on client.
-	async fn authenticate_client(client: &APIClient, session_id: &str) {
-		client
-			.set_header("Cookie", format!("sessionid={session_id}"))
-			.await
-			.expect("Failed to set Cookie header");
+		(container, conn, client, urls, session_backend)
 	}
 
 	/// Helper: create N clusters with sequential names.
@@ -87,12 +58,12 @@ mod tests {
 			Arc<DatabaseConnection>,
 			APIClient,
 			TestUrls,
+			Arc<dyn AsyncSessionBackend>,
 		),
 	) {
 		// Arrange
-		let (_container, _conn, client, _urls) = db.await;
-		let session = register_and_get_session(&client).await;
-		authenticate_client(&client, &session).await;
+		let (_container, conn, client, _urls, backend) = db.await;
+		force_login_user(&client, &conn, &backend, "testuser", "test@example.com").await;
 		create_clusters(&client, 3).await;
 
 		// Act
@@ -120,12 +91,12 @@ mod tests {
 			Arc<DatabaseConnection>,
 			APIClient,
 			TestUrls,
+			Arc<dyn AsyncSessionBackend>,
 		),
 	) {
 		// Arrange
-		let (_container, _conn, client, _urls) = db.await;
-		let session = register_and_get_session(&client).await;
-		authenticate_client(&client, &session).await;
+		let (_container, conn, client, _urls, backend) = db.await;
+		force_login_user(&client, &conn, &backend, "testuser", "test@example.com").await;
 		create_clusters(&client, 5).await;
 
 		// Act
@@ -152,12 +123,12 @@ mod tests {
 			Arc<DatabaseConnection>,
 			APIClient,
 			TestUrls,
+			Arc<dyn AsyncSessionBackend>,
 		),
 	) {
 		// Arrange
-		let (_container, _conn, client, _urls) = db.await;
-		let session = register_and_get_session(&client).await;
-		authenticate_client(&client, &session).await;
+		let (_container, conn, client, _urls, backend) = db.await;
+		force_login_user(&client, &conn, &backend, "testuser", "test@example.com").await;
 		create_clusters(&client, 2).await;
 
 		// Act
@@ -183,12 +154,12 @@ mod tests {
 			Arc<DatabaseConnection>,
 			APIClient,
 			TestUrls,
+			Arc<dyn AsyncSessionBackend>,
 		),
 	) {
 		// Arrange
-		let (_container, _conn, client, _urls) = db.await;
-		let session = register_and_get_session(&client).await;
-		authenticate_client(&client, &session).await;
+		let (_container, conn, client, _urls, backend) = db.await;
+		force_login_user(&client, &conn, &backend, "testuser", "test@example.com").await;
 
 		// Act
 		let response = client

--- a/dashboard/src/apps/deployments/tests/e2e/test_deployment_crud.rs
+++ b/dashboard/src/apps/deployments/tests/e2e/test_deployment_crud.rs
@@ -2,6 +2,7 @@
 
 #[cfg(test)]
 mod tests {
+	use reinhardt::middleware::session::AsyncSessionBackend;
 	use reinhardt::prelude::DatabaseConnection;
 	use reinhardt::test::APIClient;
 	use reinhardt::test::fixtures::postgres_with_migrations_from_dir;
@@ -11,55 +12,25 @@ mod tests {
 	use serial_test::serial;
 	use std::sync::Arc;
 
-	use crate::config::test_helpers::{TestUrls, test_app};
+	use crate::config::test_helpers::{TestUrls, force_login_user, session_backend, test_app};
 
 	#[fixture]
 	async fn db(
 		test_app: (APIClient, TestUrls),
+		session_backend: Arc<dyn AsyncSessionBackend>,
 	) -> (
 		ContainerAsync<GenericImage>,
 		Arc<DatabaseConnection>,
 		APIClient,
 		TestUrls,
+		Arc<dyn AsyncSessionBackend>,
 	) {
 		let (client, urls) = test_app;
 		let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
 		let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
 			.await
 			.expect("Failed to start PostgreSQL with migrations");
-		(container, conn, client, urls)
-	}
-
-	/// Helper: register a test user and return the session cookie value.
-	async fn register_and_get_session(client: &APIClient) -> String {
-		let register_data = json!({
-			"username": "testuser",
-			"email": "test@example.com",
-			"password": "securepassword123"
-		});
-		let resp = client
-			.post("/api/auth/register/", &register_data, "json")
-			.await
-			.expect("Register request failed");
-		assert_eq!(resp.status_code(), 201);
-		let set_cookie = resp
-			.header("Set-Cookie")
-			.expect("Response should have Set-Cookie header");
-		let session_id = set_cookie
-			.split(';')
-			.next()
-			.unwrap()
-			.strip_prefix("sessionid=")
-			.expect("Cookie should start with sessionid=");
-		session_id.to_string()
-	}
-
-	/// Helper: set session cookie on client.
-	async fn authenticate_client(client: &APIClient, session_id: &str) {
-		client
-			.set_header("Cookie", format!("sessionid={session_id}"))
-			.await
-			.expect("Failed to set Cookie header");
+		(container, conn, client, urls, session_backend)
 	}
 
 	/// Verify unauthenticated GET /api/deployments/ returns 401.
@@ -72,10 +43,11 @@ mod tests {
 			Arc<DatabaseConnection>,
 			APIClient,
 			TestUrls,
+			Arc<dyn AsyncSessionBackend>,
 		),
 	) {
 		// Arrange
-		let (_container, _conn, client, _urls) = db.await;
+		let (_container, _conn, client, _urls, _backend) = db.await;
 
 		// Act
 		let response = client
@@ -97,12 +69,12 @@ mod tests {
 			Arc<DatabaseConnection>,
 			APIClient,
 			TestUrls,
+			Arc<dyn AsyncSessionBackend>,
 		),
 	) {
 		// Arrange
-		let (_container, _conn, client, _urls) = db.await;
-		let session = register_and_get_session(&client).await;
-		authenticate_client(&client, &session).await;
+		let (_container, conn, client, _urls, backend) = db.await;
+		force_login_user(&client, &conn, &backend, "testuser", "test@example.com").await;
 
 		// Act
 		let response = client

--- a/dashboard/src/apps/deployments/tests/e2e/test_deployment_ownership.rs
+++ b/dashboard/src/apps/deployments/tests/e2e/test_deployment_ownership.rs
@@ -2,6 +2,7 @@
 
 #[cfg(test)]
 mod tests {
+	use reinhardt::middleware::session::AsyncSessionBackend;
 	use reinhardt::prelude::DatabaseConnection;
 	use reinhardt::test::APIClient;
 	use reinhardt::test::fixtures::postgres_with_migrations_from_dir;
@@ -11,55 +12,25 @@ mod tests {
 	use serial_test::serial;
 	use std::sync::Arc;
 
-	use crate::config::test_helpers::{TestUrls, test_app};
+	use crate::config::test_helpers::{TestUrls, force_login_user, session_backend, test_app};
 
 	#[fixture]
 	async fn db(
 		test_app: (APIClient, TestUrls),
+		session_backend: Arc<dyn AsyncSessionBackend>,
 	) -> (
 		ContainerAsync<GenericImage>,
 		Arc<DatabaseConnection>,
 		APIClient,
 		TestUrls,
+		Arc<dyn AsyncSessionBackend>,
 	) {
 		let (client, urls) = test_app;
 		let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
 		let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
 			.await
 			.expect("Failed to start PostgreSQL with migrations");
-		(container, conn, client, urls)
-	}
-
-	/// Helper: register a user and return the session cookie value.
-	async fn register_user(client: &APIClient, username: &str, email: &str) -> String {
-		let data = json!({
-			"username": username,
-			"email": email,
-			"password": "securepassword123"
-		});
-		let resp = client
-			.post("/api/auth/register/", &data, "json")
-			.await
-			.expect("Register request failed");
-		assert_eq!(resp.status_code(), 201);
-		let set_cookie = resp
-			.header("Set-Cookie")
-			.expect("Response should have Set-Cookie header");
-		let session_id = set_cookie
-			.split(';')
-			.next()
-			.unwrap()
-			.strip_prefix("sessionid=")
-			.expect("Cookie should start with sessionid=");
-		session_id.to_string()
-	}
-
-	/// Helper: set session cookie on client.
-	async fn authenticate_client(client: &APIClient, session_id: &str) {
-		client
-			.set_header("Cookie", format!("sessionid={session_id}"))
-			.await
-			.expect("Failed to set Cookie header");
+		(container, conn, client, urls, session_backend)
 	}
 
 	/// Helper: create a cluster and return its id.
@@ -102,18 +73,17 @@ mod tests {
 			Arc<DatabaseConnection>,
 			APIClient,
 			TestUrls,
+			Arc<dyn AsyncSessionBackend>,
 		),
 	) {
 		// Arrange
-		let (_container, _conn, client, _urls) = db.await;
+		let (_container, conn, client, _urls, backend) = db.await;
 
-		let session_a = register_user(&client, "user_a", "a@example.com").await;
-		authenticate_client(&client, &session_a).await;
+		force_login_user(&client, &conn, &backend, "user_a", "a@example.com").await;
 		let cluster_id = create_cluster(&client).await;
 		create_deployment(&client, cluster_id).await;
 
-		let session_b = register_user(&client, "user_b", "b@example.com").await;
-		authenticate_client(&client, &session_b).await;
+		force_login_user(&client, &conn, &backend, "user_b", "b@example.com").await;
 
 		// Act
 		let response = client
@@ -138,12 +108,12 @@ mod tests {
 			Arc<DatabaseConnection>,
 			APIClient,
 			TestUrls,
+			Arc<dyn AsyncSessionBackend>,
 		),
 	) {
 		// Arrange
-		let (_container, _conn, client, _urls) = db.await;
-		let session = register_user(&client, "testuser", "test@example.com").await;
-		authenticate_client(&client, &session).await;
+		let (_container, conn, client, _urls, backend) = db.await;
+		force_login_user(&client, &conn, &backend, "testuser", "test@example.com").await;
 
 		let data = json!({
 			"app_name": "my-app",
@@ -178,19 +148,18 @@ mod tests {
 			Arc<DatabaseConnection>,
 			APIClient,
 			TestUrls,
+			Arc<dyn AsyncSessionBackend>,
 		),
 	) {
 		// Arrange
-		let (_container, _conn, client, _urls) = db.await;
+		let (_container, conn, client, _urls, backend) = db.await;
 
 		// UserA creates a cluster
-		let session_a = register_user(&client, "owner", "owner@example.com").await;
-		authenticate_client(&client, &session_a).await;
+		force_login_user(&client, &conn, &backend, "owner", "owner@example.com").await;
 		let cluster_id = create_cluster(&client).await;
 
 		// UserB tries to deploy to it
-		let session_b = register_user(&client, "intruder", "intruder@example.com").await;
-		authenticate_client(&client, &session_b).await;
+		force_login_user(&client, &conn, &backend, "intruder", "intruder@example.com").await;
 
 		let data = json!({
 			"app_name": "evil-app",
@@ -228,30 +197,36 @@ mod tests {
 			Arc<DatabaseConnection>,
 			APIClient,
 			TestUrls,
+			Arc<dyn AsyncSessionBackend>,
 		),
 		#[case] cluster_exists: bool,
 		#[case] is_owner: bool,
 		#[case] expected_status: u16,
 	) {
 		// Arrange
-		let (_container, _conn, client, _urls) = db.await;
+		let (_container, conn, client, _urls, backend) = db.await;
 
 		let cluster_id = if cluster_exists {
 			// Create a cluster owned by user_a
-			let session_a = register_user(&client, "cluster_owner", "cowner@example.com").await;
-			authenticate_client(&client, &session_a).await;
+			force_login_user(
+				&client,
+				&conn,
+				&backend,
+				"cluster_owner",
+				"cowner@example.com",
+			)
+			.await;
 			let cid = create_cluster(&client).await;
 
 			if !is_owner {
 				// Deploy as a different user
-				let session_b = register_user(&client, "deployer", "deployer@example.com").await;
-				authenticate_client(&client, &session_b).await;
+				force_login_user(&client, &conn, &backend, "deployer", "deployer@example.com")
+					.await;
 			}
 			cid
 		} else {
 			// Use a nonexistent cluster id
-			let session = register_user(&client, "solo_user", "solo@example.com").await;
-			authenticate_client(&client, &session).await;
+			force_login_user(&client, &conn, &backend, "solo_user", "solo@example.com").await;
 			99999i64
 		};
 

--- a/dashboard/src/apps/deployments/tests/e2e/test_deployment_pagination.rs
+++ b/dashboard/src/apps/deployments/tests/e2e/test_deployment_pagination.rs
@@ -2,6 +2,7 @@
 
 #[cfg(test)]
 mod tests {
+	use reinhardt::middleware::session::AsyncSessionBackend;
 	use reinhardt::prelude::DatabaseConnection;
 	use reinhardt::test::APIClient;
 	use reinhardt::test::fixtures::postgres_with_migrations_from_dir;
@@ -11,55 +12,25 @@ mod tests {
 	use serial_test::serial;
 	use std::sync::Arc;
 
-	use crate::config::test_helpers::{TestUrls, test_app};
+	use crate::config::test_helpers::{TestUrls, force_login_user, session_backend, test_app};
 
 	#[fixture]
 	async fn db(
 		test_app: (APIClient, TestUrls),
+		session_backend: Arc<dyn AsyncSessionBackend>,
 	) -> (
 		ContainerAsync<GenericImage>,
 		Arc<DatabaseConnection>,
 		APIClient,
 		TestUrls,
+		Arc<dyn AsyncSessionBackend>,
 	) {
 		let (client, urls) = test_app;
 		let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
 		let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
 			.await
 			.expect("Failed to start PostgreSQL with migrations");
-		(container, conn, client, urls)
-	}
-
-	/// Helper: register a user and return the session cookie value.
-	async fn register_and_get_session(client: &APIClient) -> String {
-		let data = json!({
-			"username": "testuser",
-			"email": "test@example.com",
-			"password": "securepassword123"
-		});
-		let resp = client
-			.post("/api/auth/register/", &data, "json")
-			.await
-			.expect("Register request failed");
-		assert_eq!(resp.status_code(), 201);
-		let set_cookie = resp
-			.header("Set-Cookie")
-			.expect("Response should have Set-Cookie header");
-		let session_id = set_cookie
-			.split(';')
-			.next()
-			.unwrap()
-			.strip_prefix("sessionid=")
-			.expect("Cookie should start with sessionid=");
-		session_id.to_string()
-	}
-
-	/// Helper: set session cookie on client.
-	async fn authenticate_client(client: &APIClient, session_id: &str) {
-		client
-			.set_header("Cookie", format!("sessionid={session_id}"))
-			.await
-			.expect("Failed to set Cookie header");
+		(container, conn, client, urls, session_backend)
 	}
 
 	/// Helper: create a cluster and return its id.
@@ -101,12 +72,12 @@ mod tests {
 			Arc<DatabaseConnection>,
 			APIClient,
 			TestUrls,
+			Arc<dyn AsyncSessionBackend>,
 		),
 	) {
 		// Arrange
-		let (_container, _conn, client, _urls) = db.await;
-		let session = register_and_get_session(&client).await;
-		authenticate_client(&client, &session).await;
+		let (_container, conn, client, _urls, backend) = db.await;
+		force_login_user(&client, &conn, &backend, "testuser", "test@example.com").await;
 		let cluster_id = create_cluster(&client).await;
 		for i in 1..=3 {
 			create_deployment(&client, cluster_id, &i.to_string()).await;
@@ -136,12 +107,12 @@ mod tests {
 			Arc<DatabaseConnection>,
 			APIClient,
 			TestUrls,
+			Arc<dyn AsyncSessionBackend>,
 		),
 	) {
 		// Arrange
-		let (_container, _conn, client, _urls) = db.await;
-		let session = register_and_get_session(&client).await;
-		authenticate_client(&client, &session).await;
+		let (_container, conn, client, _urls, backend) = db.await;
+		force_login_user(&client, &conn, &backend, "testuser", "test@example.com").await;
 		let cluster_id = create_cluster(&client).await;
 		for i in 1..=3 {
 			create_deployment(&client, cluster_id, &i.to_string()).await;
@@ -171,12 +142,12 @@ mod tests {
 			Arc<DatabaseConnection>,
 			APIClient,
 			TestUrls,
+			Arc<dyn AsyncSessionBackend>,
 		),
 	) {
 		// Arrange
-		let (_container, _conn, client, _urls) = db.await;
-		let session = register_and_get_session(&client).await;
-		authenticate_client(&client, &session).await;
+		let (_container, conn, client, _urls, backend) = db.await;
+		force_login_user(&client, &conn, &backend, "testuser", "test@example.com").await;
 		let cluster_id = create_cluster(&client).await;
 		for i in 1..=3 {
 			create_deployment(&client, cluster_id, &i.to_string()).await;

--- a/dashboard/src/config/settings.rs
+++ b/dashboard/src/config/settings.rs
@@ -37,7 +37,7 @@
 
 use reinhardt::conf::settings::builder::SettingsBuilder;
 use reinhardt::conf::settings::profile::Profile;
-use reinhardt::conf::settings::sources::{LowPriorityEnvSource, TomlFileSource};
+use reinhardt::conf::settings::sources::{HighPriorityEnvSource, TomlFileSource};
 use reinhardt::settings;
 use std::env;
 use std::path::PathBuf;
@@ -76,23 +76,23 @@ fn profile_name() -> String {
 ///
 /// Sources are merged in priority order (lowest to highest):
 /// 1. Default values (CoreSettings provides its own defaults via serde)
-/// 2. Environment variables with `REINHARDT_` prefix
-/// 3. Base TOML file (`base.toml`)
-/// 4. Environment-specific TOML file (e.g., `local.toml`)
+/// 2. Base TOML file (`base.toml`)
+/// 3. Environment-specific TOML file (e.g., `local.toml`)
+/// 4. Environment variables with `REINHARDT_` prefix (highest)
 fn build_settings() -> ProjectSettings {
 	let profile_str = profile_name();
 	let settings_dir = resolve_settings_dir();
 
 	SettingsBuilder::new()
 		.profile(Profile::parse(&profile_str))
-		// Low priority: Environment variables (for container/CI overrides)
-		.add_source(LowPriorityEnvSource::new().with_prefix("REINHARDT_"))
 		// Medium priority: Base TOML file
 		.add_source(TomlFileSource::new(settings_dir.join("base.toml")))
-		// Highest priority: Environment-specific TOML file
+		// High priority: Environment-specific TOML file
 		.add_source(TomlFileSource::new(
 			settings_dir.join(format!("{}.toml", profile_str)),
 		))
+		// Highest priority: Environment variables (for container/CI overrides)
+		.add_source(HighPriorityEnvSource::new().with_prefix("REINHARDT_"))
 		.build_composed()
 		.expect("Failed to build settings")
 }

--- a/dashboard/src/config/test_helpers.rs
+++ b/dashboard/src/config/test_helpers.rs
@@ -87,6 +87,13 @@ pub fn test_app() -> (APIClient, TestUrls) {
 ///
 /// Connects to the same Redis instance used by the application middleware,
 /// so sessions saved here are visible to `CookieSessionAuthMiddleware`.
+///
+/// Workaround for kent8192/reinhardt-web#3660 (tracked in reinhardt-cloud#344)
+/// Remove this workaround when the upstream issue is resolved.
+///
+/// Ideal implementation (without workaround):
+///   No explicit `session_backend` fixture needed — `client.auth().session()`
+///   resolves the session backend from the DI context automatically.
 #[fixture]
 pub fn session_backend() -> Arc<dyn AsyncSessionBackend> {
 	let redis_url = crate::config::settings::get_redis_url()
@@ -103,10 +110,11 @@ pub fn session_backend() -> Arc<dyn AsyncSessionBackend> {
 /// a session. Use this for initial user setup. For switching back to
 /// an already-created user, use [`force_login`] directly.
 ///
-/// Workaround for kent8192/reinhardt-web#3542 (tracked in reinhardt-cloud#342)
+/// Workaround for kent8192/reinhardt-web#3660 (tracked in reinhardt-cloud#344)
 /// Remove this workaround when the upstream issue is resolved.
 ///
 /// Ideal implementation (without workaround):
+///   let user = User::objects().create_with_conn(conn, &user).await?;
 ///   client.auth()
 ///       .session(&user, session_backend.clone())
 ///       .apply().await
@@ -144,6 +152,15 @@ pub async fn force_login_user(
 /// Creates a new session in the Redis backend for the given user and sets
 /// the `sessionid` cookie. Use this to switch the client to a different
 /// user without creating a new database record.
+///
+/// Workaround for kent8192/reinhardt-web#3660 (tracked in reinhardt-cloud#344)
+/// Remove this workaround when the upstream issue is resolved.
+///
+/// Ideal implementation (without workaround):
+///   client.auth()
+///       .session(user, session_backend.clone())
+///       .apply().await
+///       .expect("Failed to force login");
 pub async fn force_login(
 	client: &APIClient,
 	session_backend: &Arc<dyn AsyncSessionBackend>,

--- a/dashboard/src/config/test_helpers.rs
+++ b/dashboard/src/config/test_helpers.rs
@@ -8,12 +8,18 @@
 //! so tests are robust against path changes as long as route names stay the same.
 
 use std::sync::Arc;
+use std::time::{Duration, SystemTime};
 
 use reinhardt::OpenApiRouter;
+use reinhardt::RedisSessionBackend;
 use reinhardt::di::{InjectionContext, SingletonScope};
+use reinhardt::middleware::session::{AsyncSessionBackend, SessionData};
+use reinhardt::prelude::DatabaseConnection;
 use reinhardt::test::APIClient;
 use rstest::fixture;
+use uuid::Uuid;
 
+use crate::apps::auth::models::User;
 use crate::config::urls::{AllowedOrigins, DashboardRouter};
 
 /// Pre-resolved URL paths for test use.
@@ -75,4 +81,100 @@ pub fn test_app() -> (APIClient, TestUrls) {
 	let handler = OpenApiRouter::wrap(server_router).expect("Failed to wrap with OpenApiRouter");
 	let client = APIClient::from_handler(handler);
 	(client, urls)
+}
+
+/// Redis-backed session backend for force-login in tests.
+///
+/// Connects to the same Redis instance used by the application middleware,
+/// so sessions saved here are visible to `CookieSessionAuthMiddleware`.
+#[fixture]
+pub fn session_backend() -> Arc<dyn AsyncSessionBackend> {
+	let redis_url = crate::config::settings::get_redis_url()
+		.expect("Redis URL must be configured for session tests");
+	Arc::new(
+		RedisSessionBackend::new_from_url(&redis_url)
+			.expect("Failed to create Redis session backend"),
+	)
+}
+
+/// Create a test user in the database and force-login on the client.
+///
+/// Creates the user via ORM, then calls [`force_login`] to establish
+/// a session. Use this for initial user setup. For switching back to
+/// an already-created user, use [`force_login`] directly.
+///
+/// Workaround for kent8192/reinhardt-web#3542 (tracked in reinhardt-cloud#342)
+/// Remove this workaround when the upstream issue is resolved.
+///
+/// Ideal implementation (without workaround):
+///   client.auth()
+///       .session(&user, session_backend.clone())
+///       .apply().await
+///       .expect("Failed to force login");
+pub async fn force_login_user(
+	client: &APIClient,
+	conn: &Arc<DatabaseConnection>,
+	session_backend: &Arc<dyn AsyncSessionBackend>,
+	username: &str,
+	email: &str,
+) -> User {
+	use reinhardt::db::orm::Model;
+
+	let user = User::new(
+		username.to_string(),
+		email.to_string(),
+		String::new(),
+		String::new(),
+		None,
+		true,
+		false,
+		false,
+	);
+	let user = User::objects()
+		.create_with_conn(conn, &user)
+		.await
+		.expect("Failed to create test user");
+
+	force_login(client, session_backend, &user).await;
+	user
+}
+
+/// Force-login an existing user on the client.
+///
+/// Creates a new session in the Redis backend for the given user and sets
+/// the `sessionid` cookie. Use this to switch the client to a different
+/// user without creating a new database record.
+pub async fn force_login(
+	client: &APIClient,
+	session_backend: &Arc<dyn AsyncSessionBackend>,
+	user: &User,
+) {
+	let session_id = Uuid::now_v7().to_string();
+	let now = SystemTime::now();
+	let mut session = SessionData {
+		id: session_id.clone(),
+		data: std::collections::HashMap::new(),
+		created_at: now,
+		last_accessed: now,
+		expires_at: now + Duration::from_secs(1800),
+	};
+	session
+		.set("user_id".to_string(), user.id.to_string())
+		.expect("Failed to set user_id in session");
+	session
+		.set("is_staff".to_string(), user.is_staff)
+		.expect("Failed to set is_staff in session");
+	session
+		.set("is_superuser".to_string(), user.is_superuser)
+		.expect("Failed to set is_superuser in session");
+
+	session_backend
+		.save(&session)
+		.await
+		.expect("Failed to save session to Redis");
+
+	client
+		.set_header("Cookie", format!("sessionid={session_id}"))
+		.await
+		.expect("Failed to set session cookie on client");
 }

--- a/dashboard/src/config/test_helpers.rs
+++ b/dashboard/src/config/test_helpers.rs
@@ -8,16 +8,14 @@
 //! so tests are robust against path changes as long as route names stay the same.
 
 use std::sync::Arc;
-use std::time::{Duration, SystemTime};
 
 use reinhardt::OpenApiRouter;
 use reinhardt::RedisSessionBackend;
 use reinhardt::di::{InjectionContext, SingletonScope};
-use reinhardt::middleware::session::{AsyncSessionBackend, SessionData};
+use reinhardt::middleware::session::AsyncSessionBackend;
 use reinhardt::prelude::DatabaseConnection;
 use reinhardt::test::APIClient;
 use rstest::fixture;
-use uuid::Uuid;
 
 use crate::apps::auth::models::User;
 use crate::config::urls::{AllowedOrigins, DashboardRouter};
@@ -87,13 +85,6 @@ pub fn test_app() -> (APIClient, TestUrls) {
 ///
 /// Connects to the same Redis instance used by the application middleware,
 /// so sessions saved here are visible to `CookieSessionAuthMiddleware`.
-///
-/// Workaround for kent8192/reinhardt-web#3660 (tracked in reinhardt-cloud#344)
-/// Remove this workaround when the upstream issue is resolved.
-///
-/// Ideal implementation (without workaround):
-///   No explicit `session_backend` fixture needed — `client.auth().session()`
-///   resolves the session backend from the DI context automatically.
 #[fixture]
 pub fn session_backend() -> Arc<dyn AsyncSessionBackend> {
 	let redis_url = crate::config::settings::get_redis_url()
@@ -109,16 +100,6 @@ pub fn session_backend() -> Arc<dyn AsyncSessionBackend> {
 /// Creates the user via ORM, then calls [`force_login`] to establish
 /// a session. Use this for initial user setup. For switching back to
 /// an already-created user, use [`force_login`] directly.
-///
-/// Workaround for kent8192/reinhardt-web#3660 (tracked in reinhardt-cloud#344)
-/// Remove this workaround when the upstream issue is resolved.
-///
-/// Ideal implementation (without workaround):
-///   let user = User::objects().create_with_conn(conn, &user).await?;
-///   client.auth()
-///       .session(&user, session_backend.clone())
-///       .apply().await
-///       .expect("Failed to force login");
 pub async fn force_login_user(
 	client: &APIClient,
 	conn: &Arc<DatabaseConnection>,
@@ -152,46 +133,15 @@ pub async fn force_login_user(
 /// Creates a new session in the Redis backend for the given user and sets
 /// the `sessionid` cookie. Use this to switch the client to a different
 /// user without creating a new database record.
-///
-/// Workaround for kent8192/reinhardt-web#3660 (tracked in reinhardt-cloud#344)
-/// Remove this workaround when the upstream issue is resolved.
-///
-/// Ideal implementation (without workaround):
-///   client.auth()
-///       .session(user, session_backend.clone())
-///       .apply().await
-///       .expect("Failed to force login");
 pub async fn force_login(
 	client: &APIClient,
 	session_backend: &Arc<dyn AsyncSessionBackend>,
 	user: &User,
 ) {
-	let session_id = Uuid::now_v7().to_string();
-	let now = SystemTime::now();
-	let mut session = SessionData {
-		id: session_id.clone(),
-		data: std::collections::HashMap::new(),
-		created_at: now,
-		last_accessed: now,
-		expires_at: now + Duration::from_secs(1800),
-	};
-	session
-		.set("user_id".to_string(), user.id.to_string())
-		.expect("Failed to set user_id in session");
-	session
-		.set("is_staff".to_string(), user.is_staff)
-		.expect("Failed to set is_staff in session");
-	session
-		.set("is_superuser".to_string(), user.is_superuser)
-		.expect("Failed to set is_superuser in session");
-
-	session_backend
-		.save(&session)
-		.await
-		.expect("Failed to save session to Redis");
-
 	client
-		.set_header("Cookie", format!("sessionid={session_id}"))
+		.auth()
+		.session(user, session_backend.clone())
+		.apply()
 		.await
-		.expect("Failed to set session cookie on client");
+		.expect("Failed to force login");
 }

--- a/dashboard/src/config/urls.rs
+++ b/dashboard/src/config/urls.rs
@@ -164,7 +164,12 @@ pub(crate) struct DashboardRouter(pub UnifiedRouter);
 /// The `#[inject]` parameter resolves `DashboardRouter` from the DI registry,
 /// which triggers the `make_router` factory and all its transitive dependencies.
 /// The framework creates the `InjectionContext` automatically for async routes.
-#[routes]
+// Workaround for kent8192/reinhardt-web#3662 (tracked in reinhardt-cloud#345)
+// Remove this workaround when the upstream issue is resolved.
+//
+// Ideal implementation (without workaround):
+//   #[routes]  (non-standalone; url_prelude generation enabled)
+#[routes(standalone)]
 pub async fn routes(#[inject] router: Depends<DashboardRouter>) -> UnifiedRouter {
 	router
 		.try_unwrap()

--- a/dashboard/tests/e2e/auth_clusters_deployments/test_full_workflow.rs
+++ b/dashboard/tests/e2e/auth_clusters_deployments/test_full_workflow.rs
@@ -4,6 +4,7 @@
 //! deployment -> list deployments, and ensures two independent users
 //! have complete resource isolation.
 
+use reinhardt::middleware::session::AsyncSessionBackend;
 use reinhardt::prelude::DatabaseConnection;
 use reinhardt::test::APIClient;
 use reinhardt::test::fixtures::postgres_with_migrations_from_dir;
@@ -13,57 +14,31 @@ use serde_json::json;
 use serial_test::serial;
 use std::sync::Arc;
 
-use reinhardt_cloud_dashboard::config::test_helpers::{TestUrls, test_app};
+use reinhardt_cloud_dashboard::config::test_helpers::{
+	TestUrls, force_login_user, session_backend, test_app,
+};
 
 // ============================================================================
-// Fixtures & Helpers
+// Fixtures
 // ============================================================================
 
 #[fixture]
 async fn db(
 	test_app: (APIClient, TestUrls),
+	session_backend: Arc<dyn AsyncSessionBackend>,
 ) -> (
 	ContainerAsync<GenericImage>,
 	Arc<DatabaseConnection>,
 	APIClient,
 	TestUrls,
+	Arc<dyn AsyncSessionBackend>,
 ) {
 	let (client, urls) = test_app;
 	let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
 	let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
 		.await
 		.expect("Failed to start PostgreSQL with migrations");
-	(container, conn, client, urls)
-}
-
-async fn register_user(client: &APIClient, username: &str, email: &str) -> String {
-	let data = json!({
-		"username": username,
-		"email": email,
-		"password": "securepassword123"
-	});
-	let resp = client
-		.post("/api/auth/register/", &data, "json")
-		.await
-		.expect("Register request failed");
-	assert_eq!(resp.status_code(), 201);
-	let set_cookie = resp
-		.header("Set-Cookie")
-		.expect("Response should have Set-Cookie header");
-	let session_id = set_cookie
-		.split(';')
-		.next()
-		.unwrap()
-		.strip_prefix("sessionid=")
-		.expect("Cookie should start with sessionid=");
-	session_id.to_string()
-}
-
-async fn authenticate_client(client: &APIClient, session_id: &str) {
-	client
-		.set_header("Cookie", format!("sessionid={session_id}"))
-		.await
-		.expect("Failed to set Cookie header");
+	(container, conn, client, urls, session_backend)
 }
 
 // ============================================================================
@@ -80,12 +55,19 @@ async fn test_full_user_journey(
 		Arc<DatabaseConnection>,
 		APIClient,
 		TestUrls,
+		Arc<dyn AsyncSessionBackend>,
 	),
 ) {
 	// Arrange
-	let (_container, _conn, client, _urls) = db.await;
-	let session = register_user(&client, "journeyuser", "journey@example.com").await;
-	authenticate_client(&client, &session).await;
+	let (_container, conn, client, _urls, backend) = db.await;
+	force_login_user(
+		&client,
+		&conn,
+		&backend,
+		"journeyuser",
+		"journey@example.com",
+	)
+	.await;
 
 	// Act -- create cluster
 	let cluster_data = json!({
@@ -151,15 +133,15 @@ async fn test_two_users_independent_workflows(
 		Arc<DatabaseConnection>,
 		APIClient,
 		TestUrls,
+		Arc<dyn AsyncSessionBackend>,
 	),
 	test_app: (APIClient, TestUrls),
 ) {
 	// Arrange
-	let (_container, _conn, client, _urls) = db.await;
+	let (_container, conn, client, _urls, backend) = db.await;
 
 	// --- User A ---
-	let session_a = register_user(&client, "user_a", "a@example.com").await;
-	authenticate_client(&client, &session_a).await;
+	force_login_user(&client, &conn, &backend, "user_a", "a@example.com").await;
 
 	let cluster_a = json!({
 		"name": "cluster-a",
@@ -186,8 +168,7 @@ async fn test_two_users_independent_workflows(
 
 	// --- User B (new client to reset headers) ---
 	let (client_b, _) = test_app;
-	let session_b = register_user(&client_b, "user_b", "b@example.com").await;
-	authenticate_client(&client_b, &session_b).await;
+	force_login_user(&client_b, &conn, &backend, "user_b", "b@example.com").await;
 
 	let cluster_b = json!({
 		"name": "cluster-b",
@@ -213,7 +194,6 @@ async fn test_two_users_independent_workflows(
 	assert_eq!(resp.status_code(), 201);
 
 	// Assert -- User A sees only their resources
-	authenticate_client(&client, &session_a).await;
 	let list_a = client
 		.get("/api/clusters/")
 		.await

--- a/dashboard/tests/e2e/clusters_deployments/test_deployment_with_cluster.rs
+++ b/dashboard/tests/e2e/clusters_deployments/test_deployment_with_cluster.rs
@@ -3,6 +3,7 @@
 //! Tests that span multiple apps (e.g., creating a deployment
 //! requires a cluster) belong here.
 
+use reinhardt::middleware::session::AsyncSessionBackend;
 use reinhardt::prelude::DatabaseConnection;
 use reinhardt::test::APIClient;
 use reinhardt::test::fixtures::postgres_with_migrations_from_dir;
@@ -12,7 +13,9 @@ use serde_json::json;
 use serial_test::serial;
 use std::sync::Arc;
 
-use reinhardt_cloud_dashboard::config::test_helpers::{TestUrls, test_app};
+use reinhardt_cloud_dashboard::config::test_helpers::{
+	TestUrls, force_login_user, session_backend, test_app,
+};
 
 // ============================================================================
 // Test Fixtures
@@ -22,50 +25,20 @@ use reinhardt_cloud_dashboard::config::test_helpers::{TestUrls, test_app};
 #[fixture]
 async fn db(
 	test_app: (APIClient, TestUrls),
+	session_backend: Arc<dyn AsyncSessionBackend>,
 ) -> (
 	ContainerAsync<GenericImage>,
 	Arc<DatabaseConnection>,
 	APIClient,
 	TestUrls,
+	Arc<dyn AsyncSessionBackend>,
 ) {
 	let (client, urls) = test_app;
 	let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
 	let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
 		.await
 		.expect("Failed to start PostgreSQL with migrations");
-	(container, conn, client, urls)
-}
-
-/// Helper: register a test user and return the session cookie value.
-async fn register_and_get_session(client: &APIClient) -> String {
-	let register_data = json!({
-		"username": "testuser",
-		"email": "test@example.com",
-		"password": "securepassword123"
-	});
-	let resp = client
-		.post("/api/auth/register/", &register_data, "json")
-		.await
-		.expect("Register request failed");
-	assert_eq!(resp.status_code(), 201);
-	let set_cookie = resp
-		.header("Set-Cookie")
-		.expect("Response should have Set-Cookie header");
-	let session_id = set_cookie
-		.split(';')
-		.next()
-		.unwrap()
-		.strip_prefix("sessionid=")
-		.expect("Cookie should start with sessionid=");
-	session_id.to_string()
-}
-
-/// Helper: set session cookie on client.
-async fn authenticate_client(client: &APIClient, session_id: &str) {
-	client
-		.set_header("Cookie", format!("sessionid={session_id}"))
-		.await
-		.expect("Failed to set Cookie header");
+	(container, conn, client, urls, session_backend)
 }
 
 // ============================================================================
@@ -82,12 +55,12 @@ async fn test_create_deployment_with_cluster(
 		Arc<DatabaseConnection>,
 		APIClient,
 		TestUrls,
+		Arc<dyn AsyncSessionBackend>,
 	),
 ) {
 	// Arrange
-	let (_container, _conn, client, _urls) = db.await;
-	let session = register_and_get_session(&client).await;
-	authenticate_client(&client, &session).await;
+	let (_container, conn, client, _urls, backend) = db.await;
+	force_login_user(&client, &conn, &backend, "testuser", "test@example.com").await;
 
 	// Act -- create a cluster first (deployment requires cluster_id)
 	let cluster_data = json!({

--- a/dashboard/tests/e2e/clusters_deployments/test_ownership_isolation.rs
+++ b/dashboard/tests/e2e/clusters_deployments/test_ownership_isolation.rs
@@ -3,6 +3,7 @@
 //! Verifies that users cannot see each other's clusters or deployments,
 //! and that multiple deployments on the same cluster are handled correctly.
 
+use reinhardt::middleware::session::AsyncSessionBackend;
 use reinhardt::prelude::DatabaseConnection;
 use reinhardt::test::APIClient;
 use reinhardt::test::fixtures::postgres_with_migrations_from_dir;
@@ -12,7 +13,9 @@ use serde_json::json;
 use serial_test::serial;
 use std::sync::Arc;
 
-use reinhardt_cloud_dashboard::config::test_helpers::{TestUrls, test_app};
+use reinhardt_cloud_dashboard::config::test_helpers::{
+	TestUrls, force_login_user, session_backend, test_app,
+};
 
 // ============================================================================
 // Fixtures & Helpers
@@ -21,48 +24,20 @@ use reinhardt_cloud_dashboard::config::test_helpers::{TestUrls, test_app};
 #[fixture]
 async fn db(
 	test_app: (APIClient, TestUrls),
+	session_backend: Arc<dyn AsyncSessionBackend>,
 ) -> (
 	ContainerAsync<GenericImage>,
 	Arc<DatabaseConnection>,
 	APIClient,
 	TestUrls,
+	Arc<dyn AsyncSessionBackend>,
 ) {
 	let (client, urls) = test_app;
 	let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
 	let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
 		.await
 		.expect("Failed to start PostgreSQL with migrations");
-	(container, conn, client, urls)
-}
-
-async fn register_user(client: &APIClient, username: &str, email: &str) -> String {
-	let data = json!({
-		"username": username,
-		"email": email,
-		"password": "securepassword123"
-	});
-	let resp = client
-		.post("/api/auth/register/", &data, "json")
-		.await
-		.expect("Register request failed");
-	assert_eq!(resp.status_code(), 201);
-	let set_cookie = resp
-		.header("Set-Cookie")
-		.expect("Response should have Set-Cookie header");
-	let session_id = set_cookie
-		.split(';')
-		.next()
-		.unwrap()
-		.strip_prefix("sessionid=")
-		.expect("Cookie should start with sessionid=");
-	session_id.to_string()
-}
-
-async fn authenticate_client(client: &APIClient, session_id: &str) {
-	client
-		.set_header("Cookie", format!("sessionid={session_id}"))
-		.await
-		.expect("Failed to set Cookie header");
+	(container, conn, client, urls, session_backend)
 }
 
 async fn create_cluster(client: &APIClient, name: &str) -> i64 {
@@ -108,15 +83,15 @@ async fn test_two_users_full_isolation(
 		Arc<DatabaseConnection>,
 		APIClient,
 		TestUrls,
+		Arc<dyn AsyncSessionBackend>,
 	),
 	test_app: (APIClient, TestUrls),
 ) {
 	// Arrange
-	let (_container, _conn, client, _urls) = db.await;
+	let (_container, conn, client, _urls, backend) = db.await;
 
 	// --- User A: 2 clusters, 2 deployments ---
-	let session_a = register_user(&client, "iso_user_a", "iso_a@example.com").await;
-	authenticate_client(&client, &session_a).await;
+	force_login_user(&client, &conn, &backend, "iso_user_a", "iso_a@example.com").await;
 
 	let cluster_a1 = create_cluster(&client, "iso-cluster-a1").await;
 	let cluster_a2 = create_cluster(&client, "iso-cluster-a2").await;
@@ -125,15 +100,19 @@ async fn test_two_users_full_isolation(
 
 	// --- User B: 1 cluster, 1 deployment ---
 	let (client_b, _) = test_app;
-	let session_b = register_user(&client_b, "iso_user_b", "iso_b@example.com").await;
-	authenticate_client(&client_b, &session_b).await;
+	force_login_user(
+		&client_b,
+		&conn,
+		&backend,
+		"iso_user_b",
+		"iso_b@example.com",
+	)
+	.await;
 
 	let cluster_b1 = create_cluster(&client_b, "iso-cluster-b1").await;
 	create_deployment(&client_b, "app-b1", cluster_b1).await;
 
 	// Assert -- User A sees exactly 2 clusters and 2 deployments
-	authenticate_client(&client, &session_a).await;
-
 	let clusters_a = client
 		.get("/api/clusters/")
 		.await
@@ -194,12 +173,19 @@ async fn test_multiple_deployments_same_cluster(
 		Arc<DatabaseConnection>,
 		APIClient,
 		TestUrls,
+		Arc<dyn AsyncSessionBackend>,
 	),
 ) {
 	// Arrange
-	let (_container, _conn, client, _urls) = db.await;
-	let session = register_user(&client, "multi_deploy_user", "multi@example.com").await;
-	authenticate_client(&client, &session).await;
+	let (_container, conn, client, _urls, backend) = db.await;
+	force_login_user(
+		&client,
+		&conn,
+		&backend,
+		"multi_deploy_user",
+		"multi@example.com",
+	)
+	.await;
 
 	let cluster_id = create_cluster(&client, "multi-deploy-cluster").await;
 


### PR DESCRIPTION
## Summary

- Update reinhardt-web to latest main (87e1c078d), resolving 7 upstream tracking issues
- Replace `LowPriorityEnvSource` with `HighPriorityEnvSource` for correct env var priority
- Replace manual force_login workaround with `client.auth().session()` API
- Add `#[routes(standalone)]` workaround for reinhardt-web#3669
- Replace url-resolver check-cfg with msw check-cfg (reinhardt-web#3673)

## Upstream Issues Resolved

- Fixes #337 — per-test settings override (reinhardt-web#3518)
- Fixes #338 — force_login API (reinhardt-web#3519)
- Fixes #339 — auth-testing feature forwarding (reinhardt-web#3532)
- Fixes #340 — Injectable bound (reinhardt-web#3533)
- Fixes #341, fixes #342 — __reinhardt_for_each_app (reinhardt-web#3542)
- Fixes #344 — url_patterns macro (reinhardt-web#3660)

## New Upstream Issues Reported

- reinhardt-web#3669 — #[url_patterns] and #[routes] url_prelude fail with multi-file views → reinhardt-cloud#345
- reinhardt-web#3673 — server_fn macro emits unexpected cfg(feature = "msw")

## Test plan

- [x] `cargo check --workspace --all-features` passes
- [x] `cargo nextest run -p reinhardt-cloud-dashboard --all-features` — 272 tests pass
- [x] `cargo make fmt-check` passes
- [x] `cargo make clippy-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)