### PR TITLE
chore(deps): update reinhardt-web to 69c4abca and fix workaround references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1285,7 +1285,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1851,7 +1851,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2079,7 +2079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4055,7 +4055,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5263,7 +5263,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5703,7 +5703,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "reinhardt-admin"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5754,7 +5754,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-apps"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5784,7 +5784,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-auth"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5829,7 +5829,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-auth-macros"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6073,7 +6073,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-commands"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6129,7 +6129,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-conf"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "chrono",
  "dotenv",
@@ -6155,7 +6155,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-core"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "anyhow",
  "aquamarine 0.6.0",
@@ -6203,7 +6203,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-db"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -6258,7 +6258,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-di"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -6281,7 +6281,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-di-macros"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6292,7 +6292,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-forms"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "anyhow",
  "aquamarine 0.5.0",
@@ -6309,7 +6309,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-http"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6330,7 +6330,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-macros"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "ctor 0.8.0",
  "inventory",
@@ -6344,7 +6344,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-mail"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6365,7 +6365,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-manouche"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "aquamarine 0.6.0",
  "convert_case",
@@ -6378,7 +6378,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-middleware"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6414,7 +6414,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-openapi"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "async-trait",
  "reinhardt-http",
@@ -6426,7 +6426,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-openapi-macros"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6437,7 +6437,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-pages"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "aquamarine 0.5.0",
  "async-trait",
@@ -6476,7 +6476,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-pages-ast"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "aquamarine 0.6.0",
  "convert_case",
@@ -6490,7 +6490,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-pages-macros"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "convert_case",
  "darling 0.20.11",
@@ -6504,7 +6504,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-query"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -6518,7 +6518,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-query-macros"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -6529,7 +6529,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-rest"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6578,7 +6578,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-routers-macros"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6588,7 +6588,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-server"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6607,7 +6607,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-shortcuts"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "bytes",
  "hyper",
@@ -6625,7 +6625,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-test"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "cfg_aliases",
  "reinhardt-auth",
@@ -6645,7 +6645,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-testkit"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "async-dropper",
  "async-trait",
@@ -6666,10 +6666,12 @@ dependencies = [
  "mockall",
  "paste",
  "redis 1.2.0",
+ "reinhardt-auth",
  "reinhardt-core",
  "reinhardt-db",
  "reinhardt-di",
  "reinhardt-http",
+ "reinhardt-middleware",
  "reinhardt-query",
  "reinhardt-server",
  "reinhardt-urls",
@@ -6688,6 +6690,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tokio-util",
+ "totp-lite",
  "tracing",
  "url",
  "urlencoding",
@@ -6697,7 +6700,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-throttling"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -6708,7 +6711,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-urls"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -6741,7 +6744,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-utils"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6777,7 +6780,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-views"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6813,7 +6816,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-web"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6822,6 +6825,7 @@ dependencies = [
  "hyper",
  "inventory",
  "linkme",
+ "paste",
  "reinhardt-admin",
  "reinhardt-apps",
  "reinhardt-auth",
@@ -6853,7 +6857,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-websockets"
 version = "0.1.0-rc.15"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#baa45d63cf01be9b598225d37301c6c27186a936"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#69c4abca06caa0124ce7cf2c2d851f431c089217"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7189,7 +7193,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7272,7 +7276,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8255,7 +8259,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9522,7 +9526,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,15 +85,14 @@ tokio-test = "0.4"
 proptest = "1"
 reinhardt-test = { package = "reinhardt-test", git = "https://github.com/kent8192/reinhardt-web", branch = "main", features = ["testcontainers"] }
 
-# Workaround for kent8192/reinhardt-web#3496 (tracked in reinhardt-cloud#328)
-# Blocked on reinhardt-web#3515 (Injectable bound for factory return types)
-# which prevents updating to reinhardt-web >= 5d9ef22a where url-resolver
-# feature was removed (PR #3513).
+# Workaround for kent8192/reinhardt-web#3700 (tracked in reinhardt-cloud#348)
+# #[server_fn] macro still emits cfg(feature = "msw") in consuming crates
+# after #3692 fix. Original issue: kent8192/reinhardt-web#3673.
 #
 # Ideal implementation (without workaround):
 #   No [workspace.lints.rust] section needed.
 [workspace.lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("url-resolver"))'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("msw"))'] }
 
 [workspace.lints.clippy]
 module_name_repetitions = "allow"

--- a/dashboard/src/config/urls.rs
+++ b/dashboard/src/config/urls.rs
@@ -164,7 +164,7 @@ pub(crate) struct DashboardRouter(pub UnifiedRouter);
 /// The `#[inject]` parameter resolves `DashboardRouter` from the DI registry,
 /// which triggers the `make_router` factory and all its transitive dependencies.
 /// The framework creates the `InjectionContext` automatically for async routes.
-#[routes]
+#[routes(standalone)]
 pub async fn routes(#[inject] router: Depends<DashboardRouter>) -> UnifiedRouter {
 	router
 		.try_unwrap()


### PR DESCRIPTION
## Summary

- Update reinhardt-web dependency to latest main (69c4abca)
- Replace url-resolver check-cfg workaround (reinhardt-web#3496) with msw check-cfg (reinhardt-web#3700)
- Add `#[routes(standalone)]` for compatibility with updated macro behavior

## Test plan

- [x] `cargo check --workspace --all-features` passes (1 warning: client-router cfg from routes macro)
- [x] `cargo nextest run --workspace --all-features` — all 1336 tests pass
- [x] No new warnings introduced

Refs #348, refs #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)