### PR TITLE
security(ci): ignore RUSTSEC-2026-0098/0099 for rustls-webpki 0.101.7

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -48,3 +48,5 @@ jobs:
           --ignore RUSTSEC-2026-0044
           --ignore RUSTSEC-2026-0048
           --ignore RUSTSEC-2026-0049
+          --ignore RUSTSEC-2026-0098
+          --ignore RUSTSEC-2026-0099


### PR DESCRIPTION
## Summary

- Add RUSTSEC-2026-0098 and RUSTSEC-2026-0099 to security audit ignore list
- These advisories affect rustls-webpki 0.101.7 (transitive dependency)

## Test plan

- [x] No code changes, CI workflow only

🤖 Generated with [Claude Code](https://claude.com/claude-code)