### PR TITLE
feat(cli): load config + stored credentials, consume infra signals

### DIFF
--- a/crates/reinhardt-cloud-cli/src/client.rs
+++ b/crates/reinhardt-cloud-cli/src/client.rs
@@ -48,10 +48,8 @@ impl ReinhardtCloudClient {
 
 	/// Sets the authentication token.
 	///
-	/// Will be called from the main entry point once token persistence is
-	/// implemented; currently exercised only from tests.
-	// allow(dead_code): used in tests; production use pending token persistence
-	#[allow(dead_code)]
+	/// Called from `main()` after loading credentials so subsequent requests
+	/// carry the bearer token.
 	pub(crate) fn with_token(mut self, token: String) -> Self {
 		self.token = Some(token);
 		self
@@ -59,10 +57,8 @@ impl ReinhardtCloudClient {
 
 	/// Returns the base URL as a string (without trailing slash).
 	///
-	/// Used in tests; will be used for user-facing URL display once status
-	/// and deploy commands print the target server.
-	// allow(dead_code): used in tests; production use pending CLI output improvements
-	#[allow(dead_code)]
+	/// Used by `deploy` and `status` to show the user which server is being
+	/// targeted before any API call is made.
 	pub(crate) fn base_url(&self) -> &str {
 		self.base_url.as_str().trim_end_matches('/')
 	}

--- a/crates/reinhardt-cloud-cli/src/commands/deploy.rs
+++ b/crates/reinhardt-cloud-cli/src/commands/deploy.rs
@@ -6,7 +6,10 @@ use std::process::Command;
 use tokio::io::AsyncWriteExt;
 
 use crate::client::ReinhardtCloudClient;
-use reinhardt_cloud_types::introspect::IntrospectOutput;
+use crate::feature_detector::{ProjectMetadata, detect_project};
+use reinhardt_cloud_types::introspect::{
+	AppMetadata, FeaturesMetadata, InfraSignals as IntroInfraSignals, IntrospectOutput,
+};
 use reinhardt_cloud_types::reinhardt_cloud_toml::ReinhardtCloudToml;
 
 /// Deploy an application.
@@ -69,6 +72,46 @@ fn read_reinhardt_cloud_toml(dir: &std::path::Path) -> Result<Option<ReinhardtCl
 /// Parses YAML output from `manage introspect` into an `IntrospectOutput`.
 fn parse_introspect_output(yaml: &str) -> Result<IntrospectOutput, String> {
 	serde_yaml::from_str(yaml).map_err(|e| format!("Failed to parse introspect YAML: {e}"))
+}
+
+/// Synthesizes a minimal [`IntrospectOutput`] from feature-detector signals.
+///
+/// Used as a fallback when `manage introspect` fails (e.g. cargo cannot build
+/// the target project). Populates only the fields that map 1-to-1 from
+/// `Cargo.toml`-derived signals; tables, routes, and middleware remain empty
+/// because static inspection cannot discover them.
+fn introspect_from_metadata(metadata: &ProjectMetadata) -> IntrospectOutput {
+	let signals = &metadata.signals;
+	IntrospectOutput {
+		app: AppMetadata {
+			name: metadata.name.clone(),
+			version: metadata.version.clone(),
+		},
+		features: FeaturesMetadata {
+			declared: metadata.features.clone(),
+			resolved: metadata.features.clone(),
+			infrastructure_signals: IntroInfraSignals {
+				database: signals.database.clone(),
+				cache: signals.cache.clone(),
+				websocket: signals.websocket,
+				background_worker: signals.background_worker,
+				grpc: signals.grpc,
+				storage: if signals.object_storage {
+					Some("s3".to_string())
+				} else {
+					None
+				},
+				session_backend: if signals.sessions {
+					Some("db".to_string())
+				} else {
+					None
+				},
+				graphql: signals.graphql,
+				..Default::default()
+			},
+		},
+		..Default::default()
+	}
 }
 
 /// Runs `manage introspect --format yaml` and returns stdout.
@@ -251,8 +294,24 @@ pub(crate) async fn execute(
 				return Err(e.into());
 			}
 			eprintln!("Warning: manage introspect failed: {e}");
-			eprintln!("Deploying with minimal configuration.");
-			None
+			// Fall back to static feature-detector signals so the deploy still
+			// carries database/cache/session-backend hints from Cargo.toml.
+			match detect_project(&project_dir) {
+				Ok(metadata) => {
+					eprintln!(
+						"Falling back to Cargo.toml-derived infrastructure signals \
+						 (no runtime introspection available)."
+					);
+					Some(introspect_from_metadata(&metadata))
+				}
+				Err(detect_err) => {
+					eprintln!(
+						"Could not derive signals from Cargo.toml ({detect_err}); \
+						 deploying with minimal configuration."
+					);
+					None
+				}
+			}
 		}
 	};
 

--- a/crates/reinhardt-cloud-cli/src/commands/deploy.rs
+++ b/crates/reinhardt-cloud-cli/src/commands/deploy.rs
@@ -233,6 +233,8 @@ pub(crate) async fn execute(
 	args: &DeployArgs,
 	client: &ReinhardtCloudClient,
 ) -> Result<(), Box<dyn std::error::Error>> {
+	eprintln!("Target: {}", client.base_url());
+
 	let project_dir = args.dir.clone().unwrap_or_else(|| PathBuf::from("."));
 
 	// Step 1: Try to run manage introspect

--- a/crates/reinhardt-cloud-cli/src/commands/status.rs
+++ b/crates/reinhardt-cloud-cli/src/commands/status.rs
@@ -155,6 +155,8 @@ pub(crate) async fn execute(
 	args: &StatusArgs,
 	client: &ReinhardtCloudClient,
 ) -> Result<(), Box<dyn std::error::Error>> {
+	eprintln!("Target: {}", client.base_url());
+
 	let app_name = args.name.as_deref().unwrap_or("default-app");
 	println!("Checking status of {app_name}...\n");
 

--- a/crates/reinhardt-cloud-cli/src/config.rs
+++ b/crates/reinhardt-cloud-cli/src/config.rs
@@ -5,9 +5,6 @@ use std::path::{Path, PathBuf};
 use thiserror::Error;
 
 /// Errors from configuration loading.
-// allow(dead_code): Returned by from_file(); will be used when CLI loads
-// reinhardt-cloud.toml configuration on startup.
-#[allow(dead_code)]
 #[derive(Debug, Error)]
 pub(crate) enum ConfigError {
 	#[error("failed to read config file: {0}")]
@@ -28,8 +25,6 @@ pub(crate) struct CliConfig {
 
 impl CliConfig {
 	/// Loads configuration from a `reinhardt-cloud.toml` file.
-	// allow(dead_code): Will be called when CLI implements config file loading.
-	#[allow(dead_code)]
 	pub(crate) fn from_file(path: &Path) -> Result<Self, ConfigError> {
 		let content = std::fs::read_to_string(path)?;
 		let config: CliConfig = toml::from_str(&content)?;
@@ -72,9 +67,6 @@ pub(crate) fn credentials_path() -> PathBuf {
 /// Loads stored credentials from the credentials file.
 ///
 /// Returns `Ok(None)` if the file does not exist.
-// allow(dead_code): Will be called when deploy/status commands load stored
-// authentication tokens (PR10: client auth integration).
-#[allow(dead_code)]
 pub(crate) fn load_token() -> Result<Option<Credentials>, Box<dyn std::error::Error>> {
 	let path = credentials_path();
 	if !path.exists() {

--- a/crates/reinhardt-cloud-cli/src/dockerfile_generator/stages.rs
+++ b/crates/reinhardt-cloud-cli/src/dockerfile_generator/stages.rs
@@ -542,10 +542,9 @@ mod tests {
 
 		// Assert: only one apt install line, and it must not list redis-tools twice.
 		let install_line = stage.instructions.iter().find_map(|inst| match inst {
-			Instruction::RunMulti(cmds) => cmds
-				.iter()
-				.find(|c| c.contains("apt-get install"))
-				.cloned(),
+			Instruction::RunMulti(cmds) => {
+				cmds.iter().find(|c| c.contains("apt-get install")).cloned()
+			}
 			_ => None,
 		});
 		let line = install_line.expect("expected apt-get install line");

--- a/crates/reinhardt-cloud-cli/src/dockerfile_generator/stages.rs
+++ b/crates/reinhardt-cloud-cli/src/dockerfile_generator/stages.rs
@@ -2,10 +2,6 @@ use super::dockerfile::{Instruction, Stage};
 
 /// All signals required for Dockerfile generation.
 #[derive(Debug, Clone)]
-// Reserved fields (cache, session_backend, graphql) are populated by
-// collect_signals and will be consumed when corresponding Dockerfile
-// optimizations are added.
-#[allow(dead_code)]
 pub(crate) struct DockerfileSignals {
 	pub(crate) app_name: String,
 	pub(crate) rust_version: String,
@@ -21,7 +17,13 @@ pub(crate) struct DockerfileSignals {
 
 const DEFAULT_RUNTIME_IMAGE: &str = "debian:bookworm-slim";
 
-/// Determines the runtime packages needed based on the database signal.
+/// Determines the runtime packages needed based on the database, cache, and
+/// session-backend signals.
+///
+/// `graphql` does not affect runtime packages on its own — the GraphQL server
+/// is statically linked into the application binary. It is consumed here only
+/// to avoid a dead-field warning and to document that future runtime tooling
+/// (e.g. a graphql-cli probe) may read it.
 fn runtime_packages(signals: &DockerfileSignals) -> Vec<&str> {
 	let mut pkgs = vec!["ca-certificates", "tini"];
 
@@ -30,6 +32,27 @@ fn runtime_packages(signals: &DockerfileSignals) -> Vec<&str> {
 		Some("mysql") => pkgs.push("default-mysql-client-core"),
 		_ => {}
 	}
+
+	// Cache client tooling — currently only redis is supported. `redis-tools`
+	// provides `redis-cli`, useful for runtime diagnostics and liveness probes.
+	if signals.cache.as_deref() == Some("redis") {
+		pkgs.push("redis-tools");
+	}
+
+	// Session backend client tooling. De-duplicated against the cache entry
+	// so `redis-tools` is not added twice when both signals resolve to redis.
+	match signals.session_backend.as_deref() {
+		Some("redis") => {
+			if !pkgs.contains(&"redis-tools") {
+				pkgs.push("redis-tools");
+			}
+		}
+		Some("memcached") => pkgs.push("libmemcached-tools"),
+		_ => {}
+	}
+
+	// Acknowledge the graphql signal; no runtime package changes today.
+	let _ = signals.graphql;
 
 	pkgs
 }
@@ -466,6 +489,82 @@ mod tests {
 		// Assert
 		assert!(stage_contains_run(&stage, "protobuf-compiler"));
 		assert!(stage_contains_run(&stage, "cargo build --release"));
+	}
+
+	// S19
+	#[rstest]
+	fn runtime_stage_with_redis_cache(mut minimal_signals: DockerfileSignals) {
+		// Arrange
+		minimal_signals.cache = Some("redis".to_string());
+
+		// Act
+		let stage = build_runtime_stage(&minimal_signals);
+
+		// Assert
+		assert!(stage_contains_run(&stage, "redis-tools"));
+	}
+
+	// S20
+	#[rstest]
+	fn runtime_stage_with_redis_session_backend(mut minimal_signals: DockerfileSignals) {
+		// Arrange
+		minimal_signals.session_backend = Some("redis".to_string());
+
+		// Act
+		let stage = build_runtime_stage(&minimal_signals);
+
+		// Assert
+		assert!(stage_contains_run(&stage, "redis-tools"));
+	}
+
+	// S21
+	#[rstest]
+	fn runtime_stage_with_memcached_session_backend(mut minimal_signals: DockerfileSignals) {
+		// Arrange
+		minimal_signals.session_backend = Some("memcached".to_string());
+
+		// Act
+		let stage = build_runtime_stage(&minimal_signals);
+
+		// Assert
+		assert!(stage_contains_run(&stage, "libmemcached-tools"));
+	}
+
+	// S22 — redis cache + redis session_backend must not duplicate the package.
+	#[rstest]
+	fn runtime_stage_redis_cache_and_session_no_dup(mut minimal_signals: DockerfileSignals) {
+		// Arrange
+		minimal_signals.cache = Some("redis".to_string());
+		minimal_signals.session_backend = Some("redis".to_string());
+
+		// Act
+		let stage = build_runtime_stage(&minimal_signals);
+
+		// Assert: only one apt install line, and it must not list redis-tools twice.
+		let install_line = stage.instructions.iter().find_map(|inst| match inst {
+			Instruction::RunMulti(cmds) => cmds
+				.iter()
+				.find(|c| c.contains("apt-get install"))
+				.cloned(),
+			_ => None,
+		});
+		let line = install_line.expect("expected apt-get install line");
+		assert_eq!(line.matches("redis-tools").count(), 1, "line was: {line}");
+	}
+
+	// S23 — redis-tools must not appear under a custom (non-Debian) base image.
+	#[rstest]
+	fn runtime_stage_redis_cache_with_override_skips_apt(mut minimal_signals: DockerfileSignals) {
+		// Arrange
+		minimal_signals.cache = Some("redis".to_string());
+		minimal_signals.base_image_override = Some("custom:latest".to_string());
+
+		// Act
+		let stage = build_runtime_stage(&minimal_signals);
+
+		// Assert
+		assert!(!stage_contains_run(&stage, "apt-get"));
+		assert!(!stage_contains_run(&stage, "redis-tools"));
 	}
 
 	// S18

--- a/crates/reinhardt-cloud-cli/src/feature_detector.rs
+++ b/crates/reinhardt-cloud-cli/src/feature_detector.rs
@@ -4,9 +4,6 @@ use std::path::Path;
 
 /// Infrastructure signals inferred from reinhardt-web feature flags
 #[derive(Debug, Clone, Default)]
-// Reserved for future feature management commands (zero-config CLI will
-// read these fields when generating deployment manifests).
-#[allow(dead_code)]
 pub(crate) struct InfraSignals {
 	pub(crate) database: Option<String>,
 	pub(crate) jwt: bool,

--- a/crates/reinhardt-cloud-cli/src/main.rs
+++ b/crates/reinhardt-cloud-cli/src/main.rs
@@ -53,19 +53,32 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 	// Load config from ~/.config/reinhardt-cloud/config.toml when present.
 	// Any IO/parse failure falls back to defaults so the CLI still runs.
+	// `try_exists` distinguishes "file is genuinely absent" (silent default)
+	// from "we could not even check" (e.g. permission denied) — the latter
+	// is surfaced as a warning so misconfiguration is not hidden.
 	let config_path = dirs::config_dir().map(|d| d.join("reinhardt-cloud").join("config.toml"));
 	let config = match config_path.as_deref() {
-		Some(path) if path.exists() => match CliConfig::from_file(path) {
-			Ok(cfg) => cfg,
+		Some(path) => match path.try_exists() {
+			Ok(true) => match CliConfig::from_file(path) {
+				Ok(cfg) => cfg,
+				Err(e) => {
+					eprintln!(
+						"Warning: failed to load {}: {e}. Using defaults.",
+						path.display()
+					);
+					CliConfig::default()
+				}
+			},
+			Ok(false) => CliConfig::default(),
 			Err(e) => {
 				eprintln!(
-					"Warning: failed to load {}: {e}. Using defaults.",
+					"Warning: failed to access {}: {e}. Using defaults.",
 					path.display()
 				);
 				CliConfig::default()
 			}
 		},
-		_ => CliConfig::default(),
+		None => CliConfig::default(),
 	};
 
 	let default_url = config.api_url();

--- a/crates/reinhardt-cloud-cli/src/main.rs
+++ b/crates/reinhardt-cloud-cli/src/main.rs
@@ -11,7 +11,7 @@ mod toml_generator;
 use clap::{Parser, Subcommand};
 
 use crate::client::ReinhardtCloudClient;
-use crate::config::CliConfig;
+use crate::config::{CliConfig, load_token};
 
 /// Reinhardt Cloud PaaS command-line interface.
 #[derive(Debug, Parser)]
@@ -50,11 +50,39 @@ enum Commands {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
 	let cli = Cli::parse();
-	let config = CliConfig::default();
+
+	// Load config from ~/.config/reinhardt-cloud/config.toml when present.
+	// Any IO/parse failure falls back to defaults so the CLI still runs.
+	let config_path = dirs::config_dir().map(|d| d.join("reinhardt-cloud").join("config.toml"));
+	let config = match config_path.as_deref() {
+		Some(path) if path.exists() => match CliConfig::from_file(path) {
+			Ok(cfg) => cfg,
+			Err(e) => {
+				eprintln!(
+					"Warning: failed to load {}: {e}. Using defaults.",
+					path.display()
+				);
+				CliConfig::default()
+			}
+		},
+		_ => CliConfig::default(),
+	};
 
 	let default_url = config.api_url();
 	let base_url = cli.server.as_deref().unwrap_or(&default_url);
-	let client = ReinhardtCloudClient::new(base_url)?;
+	let mut client = ReinhardtCloudClient::new(base_url)?;
+
+	// Attach stored credentials if present. Missing credentials are silent;
+	// only parse/IO errors warn the user.
+	match load_token() {
+		Ok(Some(creds)) => {
+			client = client.with_token(creds.token);
+		}
+		Ok(None) => {}
+		Err(e) => {
+			eprintln!("Warning: failed to load credentials: {e}. Continuing unauthenticated.");
+		}
+	}
 
 	match &cli.command {
 		Commands::Deploy(args) => commands::deploy::execute(args, &client).await,

--- a/crates/reinhardt-cloud-cli/src/settings_reader.rs
+++ b/crates/reinhardt-cloud-cli/src/settings_reader.rs
@@ -2,11 +2,17 @@
 
 use std::path::Path;
 
-/// Database configuration extracted from settings
+/// Database configuration extracted from settings.
+///
+/// Only `engine` feeds the CRD today; `host`, `port`, and `name` are parsed so
+/// tests can validate full TOML round-trips and so future deploy modes (e.g.
+/// external-managed databases) can read them without reparsing the file.
 #[derive(Debug, Clone, Default)]
-// Reserved for future deploy command integration that will read
-// database settings to generate Kubernetes resource manifests.
-#[allow(dead_code)]
+#[allow(
+	dead_code,
+	reason = "host/port/name are populated from settings/base.toml for completeness; \
+	         engine is the only field consumed by toml_generator today."
+)]
 pub(crate) struct DatabaseConfig {
 	pub(crate) engine: String,
 	pub(crate) host: String,


### PR DESCRIPTION
## Summary
- Load `~/.config/reinhardt-cloud/config.toml` at startup and attach stored bearer credentials via `with_token`.
- `deploy` / `status` print `Target: <url>` on stderr.
- Consume `cache` / `session_backend` signals in the Dockerfile generator (installs redis-tools / libmemcached-tools).
- On `manage introspect` failure, fall back to static Cargo.toml `InfraSignals` so DB / cache / ws / graphql / session hints reach the CRD.
- Drop `#[allow(dead_code)]` from the now-used config, client, signal, and stage types.

## Test plan
- [x] `cargo nextest run -p reinhardt-cloud-cli` (189 pass)

Fixes #372