### PR TITLE
chore(build): enable debug=1 profile for faster compilation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,6 +2,12 @@
 target-dir = "target"
 rustflags = ["-Wunreachable_pub"]
 
+[profile.dev]
+debug = 1
+
+[profile.test]
+debug = 1
+
 # rust-analyzer settings
 # Enable all features to improve type checking in the editor
 [env]


### PR DESCRIPTION
## Summary

- Set `debug = 1` (line-tables-only) in `[profile.dev]` and `[profile.test]` in `.cargo/config.toml`

## Type of Change

- [x] Performance improvement

## Motivation and Context

The default `debug = 2` generates full DWARF debug info (variable types, values, inlined frames). `debug = 1` emits only line number tables, which is sufficient for backtraces and `#[track_caller]`. For large Rust workspaces, debug info generation accounts for a significant portion of compile time.

Expected result: ~10–20% faster steady-state `cargo build` and `cargo test` for dev and test profiles. The first build after this change incurs a one-time full cache invalidation.

## How Was This Tested?

- `cargo check --workspace --all-features` passes without errors
- Consistent with the same change applied to `reinhardt-web` (kent8192/reinhardt-web#3775)

## Performance Impact

- Expected ~10–20% faster steady-state dev and test builds
- One-time cold-build penalty on first build after merge (cache invalidation due to profile change)

## Checklist

- [x] I have followed the Contributing Guidelines
- [x] I have followed the Commit Guidelines
- [x] My changes generate no new warnings
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

- [x] `performance`

## Related Issues

- Related to: kent8192/reinhardt-web#3775 (same optimization applied to reinhardt-web)