### PR TITLE
fix(ci): exclude English prose from rust-commented-out-code semgrep rule

### DIFF
--- a/.semgrep/nonprod-markers.yml
+++ b/.semgrep/nonprod-markers.yml
@@ -91,7 +91,13 @@ rules:
   - id: rust-commented-out-code
     patterns:
       # [ \t]* (zero-or-more) catches both "// let" and "//let" styles.
-      - pattern-regex: "(?m)^[ \\t]*//[ \\t]*(?:let(?:\\s+mut)?\\s+[A-Za-z_]|fn\\s+[A-Za-z_]\\w*\\s*[(<]|pub(?:\\s*\\([^)]*\\))?\\s+fn\\s+[A-Za-z_]|impl(?:\\s*<|\\s+[A-Za-z_])|use\\s+(?:crate|super|self|[A-Za-z_]\\w*)::|if\\s+[A-Za-z_(]|match\\s+[A-Za-z_(]|return(?:\\s+[^\\n]*)?;|struct\\s+[A-Za-z_]\\w*\\s*[{<(]|enum\\s+[A-Za-z_]\\w*\\s*[{<]|println!\\s*\\(|eprintln!\\s*\\(|dbg!\\s*\\(|assert(?:_eq|_ne)?!\\s*\\()"
+      # `if` / `match` alternatives require a trailing `{` on the same line to
+      # avoid matching English prose that happens to start with those keywords
+      # (e.g. "// if two users share..." or "// match the credentials...").
+      # Real commented-out Rust control flow on a single line always opens a
+      # block with `{`, so requiring `{` eliminates the prose false positive
+      # without losing legitimate detections. See reinhardt-cloud#395.
+      - pattern-regex: "(?m)^[ \\t]*//[ \\t]*(?:let(?:\\s+mut)?\\s+[A-Za-z_]|fn\\s+[A-Za-z_]\\w*\\s*[(<]|pub(?:\\s*\\([^)]*\\))?\\s+fn\\s+[A-Za-z_]|impl(?:\\s*<|\\s+[A-Za-z_])|use\\s+(?:crate|super|self|[A-Za-z_]\\w*)::|if\\s+[A-Za-z_(][^\\n]*\\{|match\\s+[A-Za-z_(][^\\n]*\\{|return(?:\\s+[^\\n]*)?;|struct\\s+[A-Za-z_]\\w*\\s*[{<(]|enum\\s+[A-Za-z_]\\w*\\s*[{<]|println!\\s*\\(|eprintln!\\s*\\(|dbg!\\s*\\(|assert(?:_eq|_ne)?!\\s*\\()"
       # Exclude "Ideal implementation (without workaround):" code blocks: those comments
       # use 3+ spaces of indentation after // per CLAUDE.md's "Workaround Comments" section.
       - pattern-not-regex: "^[ \\t]*//[ \\t]{3,}"


### PR DESCRIPTION
## Summary

- Tighten `if` / `match` alternatives in the `rust-commented-out-code` rule (`.semgrep/nonprod-markers.yml`) to require a trailing `{` on the same line, eliminating false positives on English prose comments that happen to begin with either keyword.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Motivation and Context

The previous regex matched any comment of the form `// if <word>` or `// match <word>`, which blocked unrelated PR CI (e.g. PR #377 run 24618998957) on two legitimate explanatory comments in `main`:

- `crates/reinhardt-cloud-operator/src/inference/database.rs:162` — `// match the credentials created here.`
- `dashboard/src/apps/deployments/views/deployment_logs.rs:112` — `// if two users share the same app_name. A stricter filter (e.g. by a`

Real single-line commented-out Rust control flow always opens a block with `{` on the same line, so requiring `{` for the `if` / `match` alternatives removes the prose FP without losing legitimate detections. Other alternatives (`let`, `fn`, `pub`, `use`, `struct`, `enum`, `return ... ;`, macro invocations) are already code-specific enough to leave unchanged.

Fixes #395

## How Was This Tested?

- Ran the updated rule against both flagged files: 0 findings (FP resolved).
- Ran the updated rule against a synthetic fixture containing `// if x == 5 {`, `// match y {`, `// if let Some(v) = opt {` alongside prose like `// if two users ...` and `// match the credentials ...`: only the three real commented-out snippets are flagged (3 blocking findings), prose is ignored. Behaviour preserved.
- Semgrep pinned image (`semgrep/semgrep:1.155.0`), same as CI.

## Checklist

- [x] Rule change verified locally with both FP and positive-detection fixtures
- [x] No Rust source changes; CI behaviour only
- [x] Conventional Commits format

🤖 Generated with [Claude Code](https://claude.com/claude-code)