### PR TITLE
feat(agent): add dockerfile and ghcr publishing job

### DIFF
--- a/.github/workflows/build-release-assets.yml
+++ b/.github/workflows/build-release-assets.yml
@@ -8,6 +8,8 @@ on:
 
 permissions:
   contents: write
+  # Required for pushing images to GHCR in the build-agent-image job.
+  packages: write
 
 jobs:
   build-assets:
@@ -74,3 +76,71 @@ jobs:
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           files: ${{ matrix.binary }}-${{ matrix.target }}
+
+  build-agent-image:
+    name: Build and publish reinhardt-cloud-agent image
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    # Only publish the Agent image for agent releases. Using the release-plz
+    # crate-scoped tag prefix keeps the image version aligned with the crate.
+    if: startsWith(github.ref_name, 'reinhardt-cloud-agent@v')
+    permissions:
+      contents: read
+      packages: write
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/reinhardt-cloud-agent
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Derive semver image tag
+        id: tag
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        # release-plz tags look like `reinhardt-cloud-agent@v0.1.0`. The
+        # portion after `@` is the semver we want on the image tag.
+        run: |
+          semver="${REF_NAME##*@}"
+          echo "semver=${semver}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
+
+      - name: Cache Buildx layers
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
+        with:
+          path: /tmp/.buildx-cache
+          key: buildx-agent-${{ github.ref_name }}
+          restore-keys: |
+            buildx-agent-
+
+      - name: Log in to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6
+        with:
+          context: .
+          file: crates/reinhardt-cloud-agent/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.semver }}
+            ${{ env.IMAGE_NAME }}:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+      - name: Rotate Buildx cache
+        # Moves the fresh cache into place so the next run restores it cleanly
+        # without the cache growing unbounded across runs.
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/crates/reinhardt-cloud-agent/Dockerfile
+++ b/crates/reinhardt-cloud-agent/Dockerfile
@@ -1,0 +1,57 @@
+# syntax=docker/dockerfile:1.7
+#
+# Multi-stage Dockerfile for reinhardt-cloud-agent.
+#
+# - Builder stage: pinned Rust toolchain (matches rust-toolchain.toml) with
+#   cargo-chef for dependency-layer caching and protoc for tonic codegen.
+# - Runtime stage: Google distroless cc image running as the built-in nonroot
+#   user (uid 65532). The Agent initiates outbound gRPC to the control plane
+#   and does not listen on any port, so no EXPOSE directive is needed.
+
+###############################################################################
+# Stage 1: cargo-chef planner
+# Computes a recipe from the workspace manifest so the dependency build layer
+# can be cached independently from the application source.
+###############################################################################
+FROM rust:1.94-bookworm AS chef
+
+# protoc is required by the `reinhardt-cloud-proto` build script (tonic-build).
+# libssl-dev is omitted on purpose: the workspace uses rustls for TLS.
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends protobuf-compiler \
+	&& rm -rf /var/lib/apt/lists/*
+
+RUN cargo install cargo-chef --locked --version ^0.1
+
+WORKDIR /build
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+###############################################################################
+# Stage 2: builder
+# Restores cached dependency artifacts from the chef recipe, then compiles the
+# agent binary in release mode.
+###############################################################################
+FROM chef AS builder
+
+COPY --from=planner /build/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json --bin reinhardt-cloud-agent
+
+COPY . .
+RUN cargo build --release --bin reinhardt-cloud-agent \
+	&& strip target/release/reinhardt-cloud-agent
+
+###############################################################################
+# Stage 3: runtime
+# Distroless cc-debian12:nonroot provides libc, CA certificates, and runs as
+# uid 65532 by default. No shell, no package manager, minimal attack surface.
+###############################################################################
+FROM gcr.io/distroless/cc-debian12:nonroot AS runtime
+
+COPY --from=builder /build/target/release/reinhardt-cloud-agent /usr/local/bin/reinhardt-cloud-agent
+
+USER nonroot:nonroot
+
+ENTRYPOINT ["/usr/local/bin/reinhardt-cloud-agent"]

--- a/crates/reinhardt-cloud-agent/Dockerfile.dockerignore
+++ b/crates/reinhardt-cloud-agent/Dockerfile.dockerignore
@@ -1,0 +1,62 @@
+# Keep the build context small and deterministic.
+#
+# The Dockerfile builds from the repository root (so cargo-chef can see the
+# full workspace manifest and Cargo.lock). The entries below exclude files
+# that are not required at build time: local tooling state, editor/IDE
+# artifacts, git metadata, docs, and every `target/` directory produced by
+# cargo.
+
+# Version control
+.git
+.gitattributes
+.gitignore
+.gitmessage
+
+# Cargo build artifacts (every workspace member)
+target
+**/target
+
+# Editor / IDE state
+.idea
+.vscode
+.zed
+.cursor
+*.swp
+*~
+.DS_Store
+
+# Claude Code / agent tooling state
+.claude
+.serena
+.devin
+.aider*
+
+# Coast / local runtime
+Coastfile
+
+# Docs and top-level markdown (not needed for the binary build).
+# README.md at the agent crate root is still included via `!` below.
+docs
+**/*.md
+!crates/reinhardt-cloud-agent/README.md
+!README.md
+
+# Test/CI artefacts
+tests/fixtures/**/target
+.cargo/registry
+.cargo/git
+
+# Node / dashboard assets not needed for the Rust binary build
+dashboard/node_modules
+dashboard/**/dist
+dashboard/**/build
+
+# Helm/Terraform/infra (not required by the agent binary)
+charts
+infra
+
+# Misc
+*.log
+.env
+.env.*
+!.env.example


### PR DESCRIPTION
## Summary

This PR addresses:

- Multi-stage Dockerfile for `reinhardt-cloud-agent` using cargo-chef dependency caching and a `gcr.io/distroless/cc-debian12:nonroot` runtime (uid 65532, no shell, no package manager).
- Per-Dockerfile `.dockerignore` (BuildKit convention) excluding `target/`, `.git`, `charts`, `infra`, Node artifacts, and agent-tooling state to keep the build context small.
- New `build-agent-image` job in `.github/workflows/build-release-assets.yml` that builds linux/amd64 + linux/arm64, pushes to GHCR, and rotates the Buildx cache. Gated on release-plz tag prefix `reinhardt-cloud-agent@v*` so it only publishes on agent crate releases.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] CI/CD changes

## Motivation and Context

The Agent crate currently has no container image and is not built by any release workflow, blocking in-cluster deployment. This PR ships the first container distribution path for the Agent so #359's Helm chart has something to pull.

Fixes #358

## How Was This Tested?

- `cargo make fmt-check` — 0 would be formatted, 312 unchanged, 0 errors
- `cargo make clippy-check` — all crates pass with `-D warnings`
- Workflow YAML reviewed against existing `build-assets` job conventions (pinned action SHAs, explicit permissions, timeout).
- `docker build` end-to-end validation deferred to the CI runner (the reinhardt-cloud-agent image pulls the full workspace through cargo-chef and requires ~GB of scratch space that is inappropriate for the local dev host).
- `actionlint` / `yamllint` — not installed on host, skipped.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Enables #359 (Agent Helm chart) — PR #401 will reference the image this workflow publishes.

## Labels to Apply

### Type Label
- [x] `enhancement`

### Scope Label
- [x] `ci-cd`
- [x] `kubernetes`

---

**Additional Context:**

- The runtime image uses `gcr.io/distroless/cc-debian12:nonroot` (uid 65532) and sets no `EXPOSE` directive because the Agent is an outbound-only client.
- `protoc` is installed in the builder stage because `reinhardt-cloud-proto`'s `tonic-build` requires it; `libssl-dev` is not installed because the workspace uses rustls.
- The `build-agent-image` job uses `if: startsWith(github.ref_name, 'reinhardt-cloud-agent@v')` so crate-level release-plz tags publish only the affected image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)