### PR TITLE
fix(deps): bump rustls-webpki to 0.103.13 to patch RUSTSEC-2026-0104

### DIFF
--- a/.github/workflows/bruno-tests.yml
+++ b/.github/workflows/bruno-tests.yml
@@ -91,11 +91,11 @@ jobs:
         run: npm install -g @usebruno/cli@3.1.3
 
       - name: Build application
-        run: cargo build --package reinhardt-cloud-dashboard --bin manage
+        run: cargo build --locked --package reinhardt-cloud-dashboard --bin manage
 
       - name: Run database migrations
         working-directory: dashboard
-        run: cargo run --package reinhardt-cloud-dashboard --bin manage migrate
+        run: cargo run --locked --package reinhardt-cloud-dashboard --bin manage migrate
         env:
           REINHARDT_ENV: ci
           REINHARDT_CLOUD_JWT_SECRET: "ci-test-secret-minimum-32-bytes-long!!"
@@ -104,7 +104,7 @@ jobs:
       - name: Start application server
         working-directory: dashboard
         run: |
-          cargo run --package reinhardt-cloud-dashboard --bin manage runserver &
+          cargo run --locked --package reinhardt-cloud-dashboard --bin manage runserver &
           SERVER_PID=$!
           echo "SERVER_PID=$SERVER_PID" >> "$GITHUB_ENV"
 

--- a/.github/workflows/build-release-assets.yml
+++ b/.github/workflows/build-release-assets.yml
@@ -59,14 +59,14 @@ jobs:
       - name: Build binary (native)
         if: matrix.cross != true
         run: |
-          cargo build --release --bin ${{ matrix.binary }} --target ${{ matrix.target }}
+          cargo build --locked --release --bin ${{ matrix.binary }} --target ${{ matrix.target }}
           mv target/${{ matrix.target }}/release/${{ matrix.binary }} \
              ${{ matrix.binary }}-${{ matrix.target }}
 
       - name: Build binary (cross)
         if: matrix.cross == true
         run: |
-          cross build --release --bin ${{ matrix.binary }} --target ${{ matrix.target }}
+          cross build --locked --release --bin ${{ matrix.binary }} --target ${{ matrix.target }}
           mv target/${{ matrix.target }}/release/${{ matrix.binary }} \
              ${{ matrix.binary }}-${{ matrix.target }}
 

--- a/.github/workflows/cross-crate-integration-test.yml
+++ b/.github/workflows/cross-crate-integration-test.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Run cross-crate integration tests (partition ${{ matrix.partition }}/2)
         run: |
-          cargo nextest run \
+          cargo nextest run --locked \
             --package reinhardt-cloud-integration-tests \
             --all-features \
             --partition hash:${{ matrix.partition }}/2 \

--- a/.github/workflows/cross-platform-check.yml
+++ b/.github/workflows/cross-platform-check.yml
@@ -42,4 +42,4 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run cargo check (${{ matrix.os }})
-        run: cargo check --workspace --all --all-features
+        run: cargo check --locked --workspace --all --all-features

--- a/.github/workflows/intra-crate-integration-test.yml
+++ b/.github/workflows/intra-crate-integration-test.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Run intra-crate integration tests (partition ${{ matrix.partition }}/2)
         run: |
-          cargo nextest run \
+          cargo nextest run --locked \
             --workspace \
             --exclude reinhardt-cloud-integration-tests \
             --test "*" \

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Run unit tests (partition ${{ matrix.partition }}/2)
         run: |
-          cargo nextest run \
+          cargo nextest run --locked \
             --workspace \
             --lib --bins \
             --all-features \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7445,9 +7445,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -17,6 +17,7 @@ description = "Run cargo check on workspace"
 command = "cargo"
 args = [
 	"check",
+	"--locked",
 	"--workspace",
 	"--all-features",
 	"--all-targets",
@@ -28,6 +29,7 @@ description = "Build workspace"
 command = "cargo"
 args = [
 	"build",
+	"--locked",
 	"--workspace",
 	"--all-features",
 	"--all-targets",
@@ -37,7 +39,14 @@ args = [
 [tasks.build-release]
 description = "Build workspace in release mode"
 command = "cargo"
-args = ["build", "--workspace", "--all-features", "--release", "--quiet"]
+args = [
+	"build",
+	"--locked",
+	"--workspace",
+	"--all-features",
+	"--release",
+	"--quiet",
+]
 
 [tasks.clean]
 description = "Clean build artifacts"
@@ -63,6 +72,7 @@ description = "Run clippy linter"
 command = "cargo"
 args = [
 	"clippy",
+	"--locked",
 	"--workspace",
 	"--all",
 	"--all-features",
@@ -77,6 +87,7 @@ command = "cargo"
 args = [
 	"clippy",
 	"--fix",
+	"--locked",
 	"--workspace",
 	"--all",
 	"--all-features",
@@ -91,6 +102,7 @@ description = "Check for development-only code (todo!, unimplemented!, dbg!)"
 command = "cargo"
 args = [
 	"clippy",
+	"--locked",
 	"--workspace",
 	"--all",
 	"--all-features",
@@ -110,6 +122,7 @@ command = "cargo"
 args = [
 	"nextest",
 	"run",
+	"--locked",
 	"--workspace",
 	"--all-features",
 	"--no-fail-fast",
@@ -121,6 +134,7 @@ command = "cargo"
 args = [
 	"nextest",
 	"run",
+	"--locked",
 	"--workspace",
 	"--lib",
 	"--all-features",
@@ -130,7 +144,7 @@ args = [
 [tasks.doc-test]
 description = "Run documentation tests"
 command = "cargo"
-args = ["test", "--workspace", "--all-features", "--doc"]
+args = ["test", "--locked", "--workspace", "--all-features", "--doc"]
 
 # ============================================================================
 # Documentation Tasks
@@ -139,12 +153,19 @@ args = ["test", "--workspace", "--all-features", "--doc"]
 [tasks.doc]
 description = "Build documentation"
 command = "cargo"
-args = ["doc", "--workspace", "--all-features", "--no-deps"]
+args = ["doc", "--locked", "--workspace", "--all-features", "--no-deps"]
 
 [tasks.doc-open]
 description = "Build and open documentation"
 command = "cargo"
-args = ["doc", "--workspace", "--all-features", "--no-deps", "--open"]
+args = [
+	"doc",
+	"--locked",
+	"--workspace",
+	"--all-features",
+	"--no-deps",
+	"--open",
+]
 
 # ============================================================================
 # Security Tasks
@@ -177,7 +198,7 @@ args = [
 [tasks.runserver]
 description = "Start local development server (requires PostgreSQL)"
 command = "cargo"
-args = ["run", "--bin", "manage", "--", "runserver"]
+args = ["run", "--locked", "--bin", "manage", "--", "runserver"]
 
 [tasks.runserver.env]
 REINHARDT_ENV = "local"
@@ -185,7 +206,7 @@ REINHARDT_ENV = "local"
 [tasks.showurls]
 description = "Display all registered URL patterns"
 command = "cargo"
-args = ["run", "--bin", "manage", "--", "showurls"]
+args = ["run", "--locked", "--bin", "manage", "--", "showurls"]
 
 [tasks.showurls.env]
 REINHARDT_ENV = "local"
@@ -193,7 +214,7 @@ REINHARDT_ENV = "local"
 [tasks.migrate]
 description = "Apply database migrations"
 command = "cargo"
-args = ["run", "--bin", "manage", "--", "migrate"]
+args = ["run", "--locked", "--bin", "manage", "--", "migrate"]
 
 [tasks.migrate.env]
 REINHARDT_ENV = "local"
@@ -207,6 +228,7 @@ description = "Generate ReinhardtApp CRD YAML into Helm chart crds/ directory"
 command = "cargo"
 args = [
 	"run",
+	"--locked",
 	"--bin",
 	"reinhardt-cloud",
 	"--quiet",
@@ -237,6 +259,7 @@ command = "cargo"
 args = [
 	"nextest",
 	"run",
+	"--locked",
 	"-p",
 	"reinhardt-cloud-telemetry",
 	"--all-features",


### PR DESCRIPTION
## Summary

This PR addresses:

- **Security patch**: Bumps transitive `rustls-webpki` from 0.103.11 to 0.103.13 in `Cargo.lock` to fix [RUSTSEC-2026-0104](https://rustsec.org/advisories/RUSTSEC-2026-0104) / [GHSA-82j2-j2ch-gfr8](https://github.com/advisories/GHSA-82j2-j2ch-gfr8).
- **CI hardening**: Adds `--locked` to every `cargo` invocation in `Makefile.toml` and the six workflows that call cargo directly, so future lockfile drift cannot silently re-introduce a patched-away vulnerability.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [x] Other: security vulnerability patch

## Motivation and Context

`rustls-webpki <0.103.13` contains a reachable panic in `BorrowedCertRevocationList::from_der` / `OwnedCertRevocationList::from_der` when handling a syntactically valid empty `BIT STRING` in the `onlySomeReasons` CRL extension. The panic fires BEFORE signature verification, so a malicious or malformed CRL can crash the process.

Dependency tree (from `cargo audit`):

```
rustls-webpki 0.103.11
└── rustls-platform-verifier 0.6.2
    └── reqwest 0.13.2
        └── reinhardt-testkit 0.1.0-rc.15
            └── reinhardt-test 0.1.0-rc.15
                ├── reinhardt-web 0.1.0-rc.15 → reinhardt-cloud-dashboard
                ├── reinhardt-cloud-integration-tests
                ├── reinhardt-cloud-grpc → reinhardt-cloud-dashboard
                └── reinhardt-cloud-core → {operator, integration-tests, grpc, dashboard}
```

The advisory was missing from `audit.toml` / `.github/workflows/security-audit.yml`'s `--ignore` allowlist, so it blocked every open PR's `Security Audit` job (observed on #402 Security Audit job 72610765777 with `error: 1 vulnerability found!`). Rather than silencing it, this PR ships the actual patch.

The second commit adds `--locked` defensively. Without `--locked`, `cargo build/check/test/etc.` would silently regenerate `Cargo.lock` if it's missing or stale, which could revert a pinned-away vulnerability like this one. With `--locked` present, Cargo fails loudly if the lockfile drifts — forcing a conscious `cargo update` instead.

Fixes #404

## How Was This Tested?

```bash
# Commit 1: security patch
cargo update -p rustls-webpki@0.103.11 --precise 0.103.13
cargo audit --ignore <existing allowlist>
# → 0 vulnerabilities, 3 allowed warnings (unchanged)
cargo make fmt-check                 # 312 unchanged, 0 errors

# Commit 2: --locked hardening
cargo check --locked -p reinhardt-cloud-core
# → Finished `dev` profile [unoptimized + debuginfo] in 1m 33s
cargo make fmt-check                 # 312 unchanged, 0 errors
```

The upgrade is a semver-compatible lockfile-only change within `^0.103`; no `Cargo.toml` edits, no API surface changes.

## Security Considerations

- No new advisory added to the ignore list — this is an actual fix.
- `--locked` ensures future `cargo update` drift is caught at PR time rather than silently re-opening a patched vulnerability.
- Tasks that must not be locked are deliberately left alone: `cargo clean` (no lock needed), `cargo audit` (cargo-audit does not accept `--locked`), and `reinhardt-admin fmt-*` (not a cargo command).

## Files Changed

**Commit 1** (`fix(deps)`):
- `Cargo.lock` — 2 lines (rustls-webpki version + checksum)

**Commit 2** (`ci(cargo)`):
- `Makefile.toml` — 16 cargo tasks
- `.github/workflows/cross-platform-check.yml`, `bruno-tests.yml`, `unit-test.yml`, `intra-crate-integration-test.yml`, `cross-crate-integration-test.yml`, `build-release-assets.yml`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Unblocks #401, #402, #403, and the in-flight feature/issue-322 / 360-361 / 391 / 392 branches whose Security Audit job fails on the same advisory.

## Labels to Apply

### Type Label
- [x] `bug`

### Scope Label
- [x] `security`
- [x] `dependencies`
- [x] `ci-cd`

### Priority Label
- [x] `high`

---

**Additional Context:**

The 3 remaining allowed warnings (unmaintained `atomic-polyfill`, unsound `yaml-rust`-family, yanked `core2`) are unrelated to this advisory and were already present before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)