### PR TITLE
feat(types): add spec.imagePullSecrets field to ReinhardtApp CRD

### DIFF
--- a/charts/reinhardt-cloud-operator/crds/reinhardtapp-crd.yaml
+++ b/charts/reinhardt-cloud-operator/crds/reinhardtapp-crd.yaml
@@ -140,6 +140,25 @@ spec:
               image:
                 description: Docker image to deploy
                 type: string
+              imagePullSecrets:
+                description: |-
+                  References to Kubernetes Secrets in the same namespace that hold
+                  container-registry credentials (type `kubernetes.io/dockerconfigjson`).
+
+                  Mirrors the upstream `corev1.PodSpec.imagePullSecrets` shape so the
+                  operator can copy the references straight into the materialized
+                  PodSpec without re-serializing the user's intent.
+                items:
+                  description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                  properties:
+                    name:
+                      description: 'Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                  required:
+                  - name
+                  type: object
+                nullable: true
+                type: array
               introspect:
                 description: |-
                   Introspect metadata from `manage introspect` output.
@@ -530,8 +549,9 @@ spec:
                       type: integer
                     name:
                       description: |-
-                        Logical name of the plugin, used as an identifier in config and
-                        as the `subPath` for the mounted WASM artifact.
+                        Logical name of the plugin, used as an identifier in the rendered
+                        `dentdelion.toml` and as the basis for the per-plugin Kubernetes
+                        `Volume.name` (sanitized via [`sanitized_volume_suffix`]).
                       type: string
                     plugin_type:
                       description: Extension point the plugin attaches to.

--- a/crates/reinhardt-cloud-operator/src/resources/preview.rs
+++ b/crates/reinhardt-cloud-operator/src/resources/preview.rs
@@ -151,6 +151,9 @@ pub(crate) fn build_preview_spec(
 		// Preview environments do not inherit plugin attachments. If a plugin
 		// is desired in previews, it must be re-declared on the preview spec.
 		plugins: None,
+		// Inherit image-pull secrets from the parent so previews can pull
+		// images from the same private registry.
+		image_pull_secrets: parent_spec.image_pull_secrets.clone(),
 	})
 }
 

--- a/crates/reinhardt-cloud-types/src/crd/spec.rs
+++ b/crates/reinhardt-cloud-types/src/crd/spec.rs
@@ -2,6 +2,7 @@
 
 use std::collections::BTreeMap;
 
+use k8s_openapi::api::core::v1::LocalObjectReference;
 use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -233,6 +234,18 @@ pub struct ReinhardtAppSpec {
 	/// and is mounted into the container via a volume at `wasm_dir`.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub plugins: Option<Vec<PluginSpec>>,
+	/// References to Kubernetes Secrets in the same namespace that hold
+	/// container-registry credentials (type `kubernetes.io/dockerconfigjson`).
+	///
+	/// Mirrors the upstream `corev1.PodSpec.imagePullSecrets` shape so the
+	/// operator can copy the references straight into the materialized
+	/// PodSpec without re-serializing the user's intent.
+	#[serde(
+		rename = "imagePullSecrets",
+		default,
+		skip_serializing_if = "Option::is_none"
+	)]
+	pub image_pull_secrets: Option<Vec<LocalObjectReference>>,
 }
 
 impl ReinhardtAppSpec {
@@ -397,6 +410,7 @@ mod tests {
 			]),
 			introspect: None,
 			plugins: None,
+			image_pull_secrets: None,
 		};
 
 		// Act
@@ -845,6 +859,7 @@ mod tests {
 			isolation: None,
 			source: None,
 			plugins: None,
+			image_pull_secrets: None,
 		};
 
 		// Act
@@ -1330,6 +1345,106 @@ mod tests {
 			e.message
 				.contains("duplicate wasm_dir '/var/lib/dentdelion/shared'")
 		}));
+	}
+
+	#[rstest]
+	fn test_spec_image_pull_secrets_field_backward_compatible() {
+		// Arrange: JSON without imagePullSecrets (pre-existing format).
+		let json = r#"{"image": "legacy-app:v2", "replicas": 3}"#;
+
+		// Act
+		let spec: ReinhardtAppSpec =
+			serde_json::from_str(json).expect("deserialization should succeed");
+
+		// Assert
+		assert_eq!(spec.image, "legacy-app:v2");
+		assert!(spec.image_pull_secrets.is_none());
+	}
+
+	#[rstest]
+	fn test_spec_image_pull_secrets_skipped_in_serialization_when_none() {
+		// Arrange
+		let spec = ReinhardtAppSpec {
+			image: "myapp:v1".to_string(),
+			..Default::default()
+		};
+
+		// Act
+		let json = serde_json::to_string(&spec).unwrap();
+		let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+		// Assert
+		assert!(value.get("imagePullSecrets").is_none());
+	}
+
+	#[rstest]
+	fn test_spec_image_pull_secrets_roundtrip_single_secret() {
+		// Arrange
+		let spec = ReinhardtAppSpec {
+			image: "private-registry.example.com/app:v1".to_string(),
+			image_pull_secrets: Some(vec![LocalObjectReference {
+				name: "regcred".to_string(),
+			}]),
+			..Default::default()
+		};
+
+		// Act
+		let json = serde_json::to_string(&spec).expect("serialization should succeed");
+		let deserialized: ReinhardtAppSpec =
+			serde_json::from_str(&json).expect("deserialization should succeed");
+
+		// Assert
+		let secrets = deserialized
+			.image_pull_secrets
+			.expect("image_pull_secrets should be set");
+		assert_eq!(secrets.len(), 1);
+		assert_eq!(secrets[0].name, "regcred");
+		// The serialized form must use the camelCase wire name.
+		let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+		assert!(value.get("imagePullSecrets").is_some());
+	}
+
+	#[rstest]
+	fn test_spec_image_pull_secrets_roundtrip_multiple_secrets() {
+		// Arrange
+		let spec = ReinhardtAppSpec {
+			image: "private-registry.example.com/app:v1".to_string(),
+			image_pull_secrets: Some(vec![
+				LocalObjectReference {
+					name: "ghcr-pull".to_string(),
+				},
+				LocalObjectReference {
+					name: "ecr-pull".to_string(),
+				},
+				LocalObjectReference {
+					name: "gar-pull".to_string(),
+				},
+			]),
+			..Default::default()
+		};
+
+		// Act
+		let yaml = serde_yaml::to_string(&spec).expect("serialization should succeed");
+		let deserialized: ReinhardtAppSpec =
+			serde_yaml::from_str(&yaml).expect("deserialization should succeed");
+
+		// Assert
+		let secrets = deserialized
+			.image_pull_secrets
+			.expect("image_pull_secrets should be set");
+		assert_eq!(secrets.len(), 3);
+		assert_eq!(secrets[0].name, "ghcr-pull");
+		assert_eq!(secrets[1].name, "ecr-pull");
+		assert_eq!(secrets[2].name, "gar-pull");
+	}
+
+	#[rstest]
+	fn test_spec_image_pull_secrets_default_is_none() {
+		// Arrange & Act
+		let spec = ReinhardtAppSpec::default();
+
+		// Assert
+		assert!(spec.image_pull_secrets.is_none());
 	}
 
 	#[rstest]

--- a/crates/reinhardt-cloud-types/src/reinhardt_cloud_toml.rs
+++ b/crates/reinhardt-cloud-types/src/reinhardt_cloud_toml.rs
@@ -365,6 +365,7 @@ impl ReinhardtCloudToml {
 				}),
 			}),
 			plugins: None,
+			image_pull_secrets: None,
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Adds an optional `spec.imagePullSecrets` field to `ReinhardtAppSpec`, mirroring the upstream Kubernetes `Vec<LocalObjectReference>` shape (camelCase JSON wire name `imagePullSecrets`).
- Preview environments inherit `image_pull_secrets` from their parent so previews can pull the same private-registry images.
- Regenerates the operator chart's `reinhardtapp-crd.yaml` to include the new field.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Motivation and Context

Self-hosters who push images to private registries (Google Artifact Registry, AWS ECR, GHCR private, Harbor, etc.) currently have no `ReinhardtApp` field through which to attach `kubernetes.io/dockerconfigjson` Secrets. The only workaround is patching the namespace's `default` ServiceAccount, which is namespace-wide and does not compose with per-app permission scoping.

This is the schema-only half of the change. Operator wiring (`PodSpec.imagePullSecrets`) is tracked separately in #423.

## How Was This Tested

- [x] `cargo nextest run -p reinhardt-cloud-types --all-features` — 233 tests pass, including 5 new `rstest` cases:
  - `test_spec_image_pull_secrets_field_backward_compatible`
  - `test_spec_image_pull_secrets_skipped_in_serialization_when_none`
  - `test_spec_image_pull_secrets_roundtrip_single_secret`
  - `test_spec_image_pull_secrets_roundtrip_multiple_secrets`
  - `test_spec_image_pull_secrets_default_is_none`
- [x] `cargo nextest run -p reinhardt-cloud-operator --all-features` — 353 tests pass (verifies preview inheritance change is non-breaking)
- [x] `cargo check --workspace --all-features` — clean
- [x] `cargo clippy -p reinhardt-cloud-types -p reinhardt-cloud-operator --all-features -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] CRD manifest regenerated via `cargo run -p reinhardt-cloud-cli -- crd generate -o charts/reinhardt-cloud-operator/crds/reinhardtapp-crd.yaml`

## Checklist

- [x] Code follows project style (tab indent, English comments)
- [x] All tests pass
- [x] No new clippy warnings
- [x] CRD manifest regenerated
- [x] Backward compatibility preserved (existing manifests deserialize unchanged)

## Labels to Apply

- enhancement
- high
- types

## Related Issues

Fixes #421
Refs #412
Refs #423 (operator wiring follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)