### PR TITLE
feat(operator): inject spec.imagePullSecrets into operator-generated PodSpec

### DIFF
--- a/crates/reinhardt-cloud-operator/src/resources/deployment.rs
+++ b/crates/reinhardt-cloud-operator/src/resources/deployment.rs
@@ -317,6 +317,12 @@ pub(crate) fn build_deployment(
 					init_containers: init_containers_opt,
 					containers,
 					volumes: Some(volumes),
+					// Forward spec.imagePullSecrets verbatim so the kubelet can
+					// authenticate to private registries when pulling the main
+					// application container, the migrate init-container, the
+					// collectstatic init-container, and the static-server
+					// sidecar — they all share this PodSpec.
+					image_pull_secrets: app.spec.image_pull_secrets.clone(),
 					..Default::default()
 				}),
 			},
@@ -899,5 +905,110 @@ mod tests {
 		assert_eq!(psc.run_as_non_root, Some(true));
 		let container_sc = pod_spec.containers[0].security_context.as_ref().unwrap();
 		assert_eq!(container_sc.allow_privilege_escalation, Some(false));
+	}
+
+	// ── Image pull secrets tests ───────────────────────────────────────────
+
+	#[rstest]
+	fn test_build_deployment_image_pull_secrets_none_when_unset() {
+		// Arrange
+		let app = make_test_app("web", "web:v1", None);
+
+		// Act
+		let deploy =
+			build_deployment(&app, None, &Platform::Onpremise).expect("build should succeed");
+		let pod_spec = deploy.spec.unwrap().template.spec.unwrap();
+
+		// Assert
+		assert!(pod_spec.image_pull_secrets.is_none());
+	}
+
+	#[rstest]
+	fn test_build_deployment_image_pull_secrets_single_passthrough() {
+		use k8s_openapi::api::core::v1::LocalObjectReference;
+
+		// Arrange
+		let mut app = make_test_app("web", "web:v1", None);
+		app.spec.image_pull_secrets = Some(vec![LocalObjectReference {
+			name: "regcred".to_string(),
+		}]);
+
+		// Act
+		let deploy =
+			build_deployment(&app, None, &Platform::Onpremise).expect("build should succeed");
+		let pod_spec = deploy.spec.unwrap().template.spec.unwrap();
+
+		// Assert
+		let pull_secrets = pod_spec
+			.image_pull_secrets
+			.expect("image_pull_secrets should be set");
+		assert_eq!(pull_secrets.len(), 1);
+		assert_eq!(pull_secrets[0].name, "regcred");
+	}
+
+	#[rstest]
+	fn test_build_deployment_image_pull_secrets_multiple_passthrough() {
+		use k8s_openapi::api::core::v1::LocalObjectReference;
+
+		// Arrange
+		let mut app = make_test_app("web", "web:v1", None);
+		app.spec.image_pull_secrets = Some(vec![
+			LocalObjectReference {
+				name: "regcred-primary".to_string(),
+			},
+			LocalObjectReference {
+				name: "regcred-fallback".to_string(),
+			},
+		]);
+
+		// Act
+		let deploy =
+			build_deployment(&app, None, &Platform::Onpremise).expect("build should succeed");
+		let pod_spec = deploy.spec.unwrap().template.spec.unwrap();
+
+		// Assert
+		let pull_secrets = pod_spec
+			.image_pull_secrets
+			.expect("image_pull_secrets should be set");
+		assert_eq!(pull_secrets.len(), 2);
+		assert_eq!(pull_secrets[0].name, "regcred-primary");
+		assert_eq!(pull_secrets[1].name, "regcred-fallback");
+	}
+
+	#[rstest]
+	fn test_build_deployment_image_pull_secrets_apply_to_pages_pod_spec() {
+		use k8s_openapi::api::core::v1::LocalObjectReference;
+
+		// Arrange — a pages-enabled deployment shares the same PodSpec
+		// across the main container, the static-server sidecar, and the
+		// migrate / collectstatic init-containers, so a single pod-level
+		// imagePullSecrets covers them all.
+		let mut app = make_test_app_with_database();
+		app.spec.image_pull_secrets = Some(vec![LocalObjectReference {
+			name: "regcred".to_string(),
+		}]);
+		let pages = make_default_pages_config();
+
+		// Act
+		let deploy = build_deployment(&app, Some(&pages), &Platform::Onpremise)
+			.expect("build should succeed");
+		let pod_spec = deploy.spec.unwrap().template.spec.unwrap();
+
+		// Assert
+		let pull_secrets = pod_spec
+			.image_pull_secrets
+			.expect("image_pull_secrets should be set");
+		assert_eq!(pull_secrets.len(), 1);
+		assert_eq!(pull_secrets[0].name, "regcred");
+		// Sanity check: the PodSpec really does host the additional containers.
+		let init_containers = pod_spec.init_containers.as_ref().unwrap();
+		assert!(init_containers.iter().any(|c| c.name == "migrate"));
+		assert!(init_containers.iter().any(|c| c.name == "collectstatic"));
+		assert!(
+			pod_spec
+				.containers
+				.iter()
+				.any(|c| c.name == "static-server")
+		);
 	}
 }

--- a/crates/reinhardt-cloud-operator/src/resources/migration.rs
+++ b/crates/reinhardt-cloud-operator/src/resources/migration.rs
@@ -53,6 +53,9 @@ pub(crate) fn build_migration_job(app: &ReinhardtApp) -> Result<Job, Error> {
 						}]),
 						..Default::default()
 					}],
+					// Forward spec.imagePullSecrets so the migration Job can
+					// pull the application image from a private registry.
+					image_pull_secrets: app.spec.image_pull_secrets.clone(),
 					..Default::default()
 				}),
 			},
@@ -152,5 +155,70 @@ mod tests {
 
 		// Assert
 		assert_eq!(job.spec.unwrap().backoff_limit, Some(3));
+	}
+
+	// ── Image pull secrets tests ───────────────────────────────────────────
+
+	#[rstest]
+	fn test_build_migration_job_image_pull_secrets_none_when_unset() {
+		// Arrange
+		let app = test_app("my-app", "my-app:v1");
+
+		// Act
+		let job = build_migration_job(&app).expect("build should succeed");
+		let pod_spec = job.spec.unwrap().template.spec.unwrap();
+
+		// Assert
+		assert!(pod_spec.image_pull_secrets.is_none());
+	}
+
+	#[rstest]
+	fn test_build_migration_job_image_pull_secrets_single_passthrough() {
+		use k8s_openapi::api::core::v1::LocalObjectReference;
+
+		// Arrange
+		let mut app = test_app("my-app", "my-app:v1");
+		app.spec.image_pull_secrets = Some(vec![LocalObjectReference {
+			name: "regcred".to_string(),
+		}]);
+
+		// Act
+		let job = build_migration_job(&app).expect("build should succeed");
+		let pod_spec = job.spec.unwrap().template.spec.unwrap();
+
+		// Assert
+		let pull_secrets = pod_spec
+			.image_pull_secrets
+			.expect("image_pull_secrets should be set");
+		assert_eq!(pull_secrets.len(), 1);
+		assert_eq!(pull_secrets[0].name, "regcred");
+	}
+
+	#[rstest]
+	fn test_build_migration_job_image_pull_secrets_multiple_passthrough() {
+		use k8s_openapi::api::core::v1::LocalObjectReference;
+
+		// Arrange
+		let mut app = test_app("my-app", "my-app:v1");
+		app.spec.image_pull_secrets = Some(vec![
+			LocalObjectReference {
+				name: "regcred-primary".to_string(),
+			},
+			LocalObjectReference {
+				name: "regcred-fallback".to_string(),
+			},
+		]);
+
+		// Act
+		let job = build_migration_job(&app).expect("build should succeed");
+		let pod_spec = job.spec.unwrap().template.spec.unwrap();
+
+		// Assert
+		let pull_secrets = pod_spec
+			.image_pull_secrets
+			.expect("image_pull_secrets should be set");
+		assert_eq!(pull_secrets.len(), 2);
+		assert_eq!(pull_secrets[0].name, "regcred-primary");
+		assert_eq!(pull_secrets[1].name, "regcred-fallback");
 	}
 }

--- a/crates/reinhardt-cloud-operator/src/resources/source.rs
+++ b/crates/reinhardt-cloud-operator/src/resources/source.rs
@@ -148,6 +148,10 @@ pub(crate) fn build_kaniko_job(app: &ReinhardtApp, image_tag: &str) -> Result<Jo
 					} else {
 						Some(volumes)
 					},
+					// Forward spec.imagePullSecrets so clusters that mirror
+					// the Kaniko executor image into a private registry can
+					// authenticate when pulling it for the build Job.
+					image_pull_secrets: app.spec.image_pull_secrets.clone(),
 					..Default::default()
 				}),
 			},
@@ -387,5 +391,70 @@ mod tests {
 		let owner_refs = job.metadata.owner_references.unwrap();
 		assert_eq!(owner_refs.len(), 1);
 		assert_eq!(owner_refs[0].name, "my-app");
+	}
+
+	// ── Image pull secrets tests ───────────────────────────────────────────
+
+	#[rstest]
+	fn test_kaniko_job_image_pull_secrets_none_when_unset() {
+		// Arrange
+		let app = test_app_with_source("my-app");
+
+		// Act
+		let job = build_kaniko_job(&app, "v1").unwrap();
+		let pod_spec = job.spec.unwrap().template.spec.unwrap();
+
+		// Assert
+		assert!(pod_spec.image_pull_secrets.is_none());
+	}
+
+	#[rstest]
+	fn test_kaniko_job_image_pull_secrets_single_passthrough() {
+		use k8s_openapi::api::core::v1::LocalObjectReference;
+
+		// Arrange
+		let mut app = test_app_with_source("my-app");
+		app.spec.image_pull_secrets = Some(vec![LocalObjectReference {
+			name: "regcred".to_string(),
+		}]);
+
+		// Act
+		let job = build_kaniko_job(&app, "v1").unwrap();
+		let pod_spec = job.spec.unwrap().template.spec.unwrap();
+
+		// Assert
+		let pull_secrets = pod_spec
+			.image_pull_secrets
+			.expect("image_pull_secrets should be set");
+		assert_eq!(pull_secrets.len(), 1);
+		assert_eq!(pull_secrets[0].name, "regcred");
+	}
+
+	#[rstest]
+	fn test_kaniko_job_image_pull_secrets_multiple_passthrough() {
+		use k8s_openapi::api::core::v1::LocalObjectReference;
+
+		// Arrange
+		let mut app = test_app_with_source("my-app");
+		app.spec.image_pull_secrets = Some(vec![
+			LocalObjectReference {
+				name: "regcred-primary".to_string(),
+			},
+			LocalObjectReference {
+				name: "regcred-fallback".to_string(),
+			},
+		]);
+
+		// Act
+		let job = build_kaniko_job(&app, "v1").unwrap();
+		let pod_spec = job.spec.unwrap().template.spec.unwrap();
+
+		// Assert
+		let pull_secrets = pod_spec
+			.image_pull_secrets
+			.expect("image_pull_secrets should be set");
+		assert_eq!(pull_secrets.len(), 2);
+		assert_eq!(pull_secrets[0].name, "regcred-primary");
+		assert_eq!(pull_secrets[1].name, "regcred-fallback");
 	}
 }

--- a/crates/reinhardt-cloud-operator/src/resources/worker.rs
+++ b/crates/reinhardt-cloud-operator/src/resources/worker.rs
@@ -91,6 +91,10 @@ pub(crate) fn build_worker_deployment(
 							},
 							..Default::default()
 						}],
+						// Forward spec.imagePullSecrets so the worker
+						// Deployment can pull the application image from a
+						// private registry — same as the main Deployment.
+						image_pull_secrets: app.spec.image_pull_secrets.clone(),
 						..Default::default()
 					})
 				},
@@ -284,5 +288,73 @@ mod tests {
 		assert_eq!(psc.run_as_non_root, Some(true));
 		let container_sc = pod_spec.containers[0].security_context.as_ref().unwrap();
 		assert_eq!(container_sc.allow_privilege_escalation, Some(false));
+	}
+
+	// ── Image pull secrets tests ───────────────────────────────────────────
+
+	#[rstest]
+	fn test_worker_image_pull_secrets_none_when_unset() {
+		// Arrange
+		let app = test_app("myapp", "myapp:v1");
+
+		// Act
+		let deploy = build_worker_deployment(&app, None, &Platform::Onpremise)
+			.expect("build should succeed");
+		let pod_spec = deploy.spec.unwrap().template.spec.unwrap();
+
+		// Assert
+		assert!(pod_spec.image_pull_secrets.is_none());
+	}
+
+	#[rstest]
+	fn test_worker_image_pull_secrets_single_passthrough() {
+		use k8s_openapi::api::core::v1::LocalObjectReference;
+
+		// Arrange
+		let mut app = test_app("myapp", "myapp:v1");
+		app.spec.image_pull_secrets = Some(vec![LocalObjectReference {
+			name: "regcred".to_string(),
+		}]);
+
+		// Act
+		let deploy = build_worker_deployment(&app, None, &Platform::Onpremise)
+			.expect("build should succeed");
+		let pod_spec = deploy.spec.unwrap().template.spec.unwrap();
+
+		// Assert
+		let pull_secrets = pod_spec
+			.image_pull_secrets
+			.expect("image_pull_secrets should be set");
+		assert_eq!(pull_secrets.len(), 1);
+		assert_eq!(pull_secrets[0].name, "regcred");
+	}
+
+	#[rstest]
+	fn test_worker_image_pull_secrets_multiple_passthrough() {
+		use k8s_openapi::api::core::v1::LocalObjectReference;
+
+		// Arrange
+		let mut app = test_app("myapp", "myapp:v1");
+		app.spec.image_pull_secrets = Some(vec![
+			LocalObjectReference {
+				name: "regcred-primary".to_string(),
+			},
+			LocalObjectReference {
+				name: "regcred-fallback".to_string(),
+			},
+		]);
+
+		// Act
+		let deploy = build_worker_deployment(&app, None, &Platform::Onpremise)
+			.expect("build should succeed");
+		let pod_spec = deploy.spec.unwrap().template.spec.unwrap();
+
+		// Assert
+		let pull_secrets = pod_spec
+			.image_pull_secrets
+			.expect("image_pull_secrets should be set");
+		assert_eq!(pull_secrets.len(), 2);
+		assert_eq!(pull_secrets[0].name, "regcred-primary");
+		assert_eq!(pull_secrets[1].name, "regcred-fallback");
 	}
 }


### PR DESCRIPTION
## Summary

Wires the `spec.imagePullSecrets` field (added in #421, merged in #430) into every `PodSpec` the operator materializes from a `ReinhardtApp`. The kubelet can now authenticate to private registries (Google Artifact Registry, AWS ECR, GHCR private, Harbor, etc.) using the `kubernetes.io/dockerconfigjson` Secrets the user references on the CRD.

PodSpec constructors updated:

- `crates/reinhardt-cloud-operator/src/resources/deployment.rs` — main app Deployment. Covers the static-server sidecar and the migrate / collectstatic init-containers via the same shared PodSpec.
- `crates/reinhardt-cloud-operator/src/resources/worker.rs` — worker Deployment (uses the same `app.spec.image`, so it must authenticate against the same private registry).
- `crates/reinhardt-cloud-operator/src/resources/migration.rs` — Migration Job.
- `crates/reinhardt-cloud-operator/src/resources/source.rs` — Kaniko build Job (covers clusters that mirror the Kaniko executor image into a private registry).

Preview environment Deployments are already covered in `preview.rs` by #430 (verified, no duplication).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Motivation and Context

Issue #421 added the `spec.imagePullSecrets` schema-only surface; without operator wiring, the field would be cosmetic. This PR makes it functional. Affected workloads share the same PodSpec, so a single pod-level field applies to every container in that workload (main app, static-server sidecar, migrate / collectstatic init-containers).

When `image_pull_secrets` is `None` on the spec, the resulting PodSpec also sets `image_pull_secrets = None` — identical to the pre-change shape, so existing deployments are unaffected.

## How Was This Tested

- [x] `cargo nextest run -p reinhardt-cloud-operator --all-features` passes (366 tests)
- [x] 13 new `rstest` cases verify the field passes through with `None`, single, and multiple `LocalObjectReference` inputs across `deployment.rs`, `worker.rs`, `migration.rs`, and `source.rs`
- [x] One additional case in `deployment.rs` verifies that a single pod-level setting covers a pages-enabled deployment with multiple containers and init-containers
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy -p reinhardt-cloud-operator --all-features -- -D warnings` clean

## Checklist

- [x] Code follows project style (tab indent, English comments)
- [x] All tests pass
- [x] No new clippy warnings
- [x] No existing tests weakened or removed

## Labels to Apply

- enhancement
- operator

## Related Issues

Fixes #423
Refs #412
Refs #421 (CRD field, merged in #430)

🤖 Generated with [Claude Code](https://claude.com/claude-code)