### PR TITLE
feat(operator): create per-app ServiceAccount and wire serviceAccountName

### DIFF
--- a/charts/reinhardt-cloud-operator/templates/clusterrole.yaml
+++ b/charts/reinhardt-cloud-operator/templates/clusterrole.yaml
@@ -23,6 +23,12 @@ rules:
   - apiGroups: [""]
     resources: ["services", "configmaps", "secrets"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Base: ServiceAccount management — used for the storage IAM KSA
+  # ({name}-storage) and the per-app workload identity KSA ({name}-app)
+  # that carries Workload Identity / IRSA bindings.
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   # Base: Event creation (always required)
   - apiGroups: [""]
     resources: ["events"]

--- a/crates/reinhardt-cloud-operator/src/reconciler.rs
+++ b/crates/reinhardt-cloud-operator/src/reconciler.rs
@@ -245,6 +245,14 @@ async fn apply(app: Arc<ReinhardtApp>, ctx: &Context, namespace: &str) -> Result
 	// Resolve pages configuration (explicit spec.pages > introspect signals > disabled)
 	let pages_config = resolve_pages_config(&app);
 
+	// Reconcile per-app workload `ServiceAccount` before the Deployment so
+	// the KSA exists when the Pod is admitted. Only materializes when
+	// `spec.service_account.create == true`; otherwise the user is
+	// pre-creating the KSA themselves.
+	if let Some(workload_sa) = resources::service_account::build_service_account(&app)? {
+		reconcile_app_service_account(&ctx.client, namespace, &workload_sa).await?;
+	}
+
 	// Reconcile owned Deployment via server-side apply
 	let deployments: Api<Deployment> = Api::namespaced(ctx.client.clone(), namespace);
 	let desired_deployment = build_deployment(&app, pages_config.as_ref(), &ctx.platform.platform)?;
@@ -653,6 +661,15 @@ async fn cleanup(app: Arc<ReinhardtApp>, ctx: &Context, namespace: &str) -> Resu
 
 	// Storage ServiceAccount (stateless — always clean up)
 	delete_if_exists::<ServiceAccount>(&ctx.client, namespace, &format!("{name}-storage")).await?;
+
+	// Per-app workload ServiceAccount (stateless — always clean up).
+	// Owner references would also handle this on parent deletion, but the
+	// explicit deletion mirrors the storage SA pattern and covers the case
+	// where the user previously set `spec.service_account.name` to a
+	// non-default value: the operator only ever creates the `{name}-app`
+	// variant, and a user-supplied custom name was created by the user
+	// themselves (we never owned it, so we do not delete it here).
+	delete_if_exists::<ServiceAccount>(&ctx.client, namespace, &format!("{name}-app")).await?;
 
 	// i18n ConfigMap (stateless — always clean up)
 	delete_if_exists::<ConfigMap>(&ctx.client, namespace, &format!("{name}-locales")).await?;
@@ -1273,6 +1290,32 @@ async fn reconcile_storage_sa(
 		.await
 		.map_err(Error::Kube)?;
 	info!("Reconciled storage ServiceAccount {namespace}/{name}");
+	Ok(())
+}
+
+/// Reconciles the per-app workload `ServiceAccount` via server-side apply.
+///
+/// Distinct from [`reconcile_storage_sa`]: this SA carries Workload Identity
+/// or IRSA bindings for cloud-API access from the application pods, while
+/// the storage SA grants access to the storage backend specifically.
+async fn reconcile_app_service_account(
+	client: &Client,
+	namespace: &str,
+	sa: &ServiceAccount,
+) -> Result<(), Error> {
+	let name = sa
+		.metadata
+		.name
+		.as_ref()
+		.cloned()
+		.expect("workload SA always has a name set by build_service_account");
+	let ssapply = PatchParams::apply("reinhardt-cloud-operator").force();
+	let sa_api: Api<ServiceAccount> = Api::namespaced(client.clone(), namespace);
+	sa_api
+		.patch(&name, &ssapply, &Patch::Apply(sa))
+		.await
+		.map_err(Error::Kube)?;
+	info!("Reconciled workload ServiceAccount {namespace}/{name}");
 	Ok(())
 }
 

--- a/crates/reinhardt-cloud-operator/src/resources.rs
+++ b/crates/reinhardt-cloud-operator/src/resources.rs
@@ -14,6 +14,7 @@ pub(crate) mod plugins;
 pub(crate) mod preview;
 pub(crate) mod security;
 pub(crate) mod service;
+pub(crate) mod service_account;
 pub(crate) mod source;
 pub(crate) mod storage;
 pub(crate) mod worker;

--- a/crates/reinhardt-cloud-operator/src/resources/deployment.rs
+++ b/crates/reinhardt-cloud-operator/src/resources/deployment.rs
@@ -317,6 +317,11 @@ pub(crate) fn build_deployment(
 					init_containers: init_containers_opt,
 					containers,
 					volumes: Some(volumes),
+					// Bind the workload to a per-app KSA when configured.
+					// The name resolution is centralized in
+					// `service_account::resolved_sa_name` so the SA builder
+					// and the PodSpec wiring can never disagree.
+					service_account_name: super::service_account::resolved_sa_name(app),
 					..Default::default()
 				}),
 			},
@@ -899,5 +904,104 @@ mod tests {
 		assert_eq!(psc.run_as_non_root, Some(true));
 		let container_sc = pod_spec.containers[0].security_context.as_ref().unwrap();
 		assert_eq!(container_sc.allow_privilege_escalation, Some(false));
+	}
+
+	// --- service_account_name wiring ---
+
+	#[rstest]
+	fn test_pod_spec_service_account_name_unset_when_spec_none() {
+		// Arrange — no spec.service_account configured
+		let app = make_test_app("web", "web:latest", None);
+
+		// Act
+		let deploy =
+			build_deployment(&app, None, &Platform::Onpremise).expect("build should succeed");
+		let pod_spec = deploy.spec.unwrap().template.spec.unwrap();
+
+		// Assert — existing behavior preserved
+		assert_eq!(pod_spec.service_account_name, None);
+	}
+
+	#[rstest]
+	fn test_pod_spec_service_account_name_default_when_create_true() {
+		// Arrange — create=true, no explicit name
+		use reinhardt_cloud_types::crd::service_account::ServiceAccountSpec;
+		let mut app = make_test_app("web", "web:latest", None);
+		app.spec.service_account = Some(ServiceAccountSpec {
+			create: true,
+			name: None,
+			annotations: BTreeMap::new(),
+		});
+
+		// Act
+		let deploy =
+			build_deployment(&app, None, &Platform::Onpremise).expect("build should succeed");
+		let pod_spec = deploy.spec.unwrap().template.spec.unwrap();
+
+		// Assert — `{app}-app` default name is wired in
+		assert_eq!(pod_spec.service_account_name.as_deref(), Some("web-app"));
+	}
+
+	#[rstest]
+	fn test_pod_spec_service_account_name_explicit_when_create_true() {
+		// Arrange — create=true with explicit name
+		use reinhardt_cloud_types::crd::service_account::ServiceAccountSpec;
+		let mut app = make_test_app("web", "web:latest", None);
+		app.spec.service_account = Some(ServiceAccountSpec {
+			create: true,
+			name: Some("my-sa".to_string()),
+			annotations: BTreeMap::new(),
+		});
+
+		// Act
+		let deploy =
+			build_deployment(&app, None, &Platform::Onpremise).expect("build should succeed");
+		let pod_spec = deploy.spec.unwrap().template.spec.unwrap();
+
+		// Assert
+		assert_eq!(pod_spec.service_account_name.as_deref(), Some("my-sa"));
+	}
+
+	#[rstest]
+	fn test_pod_spec_service_account_name_explicit_when_create_false() {
+		// Arrange — user pre-created the KSA themselves and supplied the name
+		use reinhardt_cloud_types::crd::service_account::ServiceAccountSpec;
+		let mut app = make_test_app("web", "web:latest", None);
+		app.spec.service_account = Some(ServiceAccountSpec {
+			create: false,
+			name: Some("user-managed".to_string()),
+			annotations: BTreeMap::new(),
+		});
+
+		// Act
+		let deploy =
+			build_deployment(&app, None, &Platform::Onpremise).expect("build should succeed");
+		let pod_spec = deploy.spec.unwrap().template.spec.unwrap();
+
+		// Assert — the supplied name is used; the operator does not create the SA
+		assert_eq!(
+			pod_spec.service_account_name.as_deref(),
+			Some("user-managed")
+		);
+	}
+
+	#[rstest]
+	fn test_pod_spec_service_account_name_unset_when_create_false_and_no_name() {
+		// Arrange — ambiguous: don't create, no name → fall back to namespace default SA
+		use reinhardt_cloud_types::crd::service_account::ServiceAccountSpec;
+		let mut app = make_test_app("web", "web:latest", None);
+		app.spec.service_account = Some(ServiceAccountSpec {
+			create: false,
+			name: None,
+			annotations: BTreeMap::new(),
+		});
+
+		// Act
+		let deploy =
+			build_deployment(&app, None, &Platform::Onpremise).expect("build should succeed");
+		let pod_spec = deploy.spec.unwrap().template.spec.unwrap();
+
+		// Assert
+		assert_eq!(pod_spec.service_account_name, None);
 	}
 }

--- a/crates/reinhardt-cloud-operator/src/resources/service_account.rs
+++ b/crates/reinhardt-cloud-operator/src/resources/service_account.rs
@@ -1,0 +1,405 @@
+//! Per-app workload `ServiceAccount` builder.
+//!
+//! Distinct from the operator-managed `{app-name}-storage` KSA used for
+//! storage-backend access. This builder constructs the workload's own KSA,
+//! which carries Workload Identity / IRSA annotations granting the
+//! application pods cloud-API access (e.g. publishing to Pub/Sub, reading
+//! from a Secret Manager, calling cloud KMS).
+//!
+//! Naming:
+//! - When `spec.service_account.name` is set, that exact name is used.
+//! - When `spec.service_account.name` is `None` and `create == true`, the
+//!   operator-managed KSA is named `{app-name}-app`. The `-app` suffix
+//!   keeps the workload KSA distinct from the existing `{app-name}-storage`
+//!   KSA and from a user-managed KSA that happens to share the bare app
+//!   name.
+//! - When `create == false` and `name` is set, the user has pre-created
+//!   their own KSA under that name; this builder returns `None` and only
+//!   the PodSpec wiring uses the supplied name.
+
+use std::collections::BTreeMap;
+
+use k8s_openapi::api::core::v1::ServiceAccount;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use kube::ResourceExt;
+use reinhardt_cloud_types::crd::ReinhardtApp;
+
+use super::labels::{Component, owner_reference, standard_labels};
+use crate::error::Error;
+
+/// Resolves the name the per-app workload `ServiceAccount` should use.
+///
+/// Returns:
+/// - `None` when `spec.service_account` is unset.
+/// - `Some(name)` when the spec explicitly sets a name (used for both
+///   operator-managed and pre-existing KSAs).
+/// - `Some("{app}-app")` when `create == true` and no name was supplied.
+/// - `None` when `create == false` and no name was supplied — the user
+///   intends to rely on a KSA managed elsewhere but did not tell us its
+///   name, so we leave the PodSpec's `serviceAccountName` unset (the pod
+///   then falls back to the namespace `default` SA).
+pub(crate) fn resolved_sa_name(app: &ReinhardtApp) -> Option<String> {
+	let spec = app.spec.service_account.as_ref()?;
+
+	if let Some(name) = spec.name.as_ref() {
+		return Some(name.clone());
+	}
+
+	if spec.create {
+		Some(format!("{}-app", app.name_any()))
+	} else {
+		None
+	}
+}
+
+/// Builds a per-app workload `ServiceAccount` resource.
+///
+/// Returns `Ok(None)` when:
+/// - `spec.service_account` is unset, or
+/// - `spec.service_account.create == false` (the user is pre-creating the
+///   KSA themselves; the operator only wires `serviceAccountName` into
+///   the PodSpec).
+///
+/// When `create == true`, returns the SA with:
+/// - `metadata.name` per [`resolved_sa_name`]
+/// - `metadata.annotations` carrying user-supplied Workload Identity /
+///   IRSA bindings (or `None` when the annotations map is empty)
+/// - `metadata.labels` set to the standard operator labels (web component)
+/// - `metadata.owner_references` pointing at the owning `ReinhardtApp`
+///   so deletion of the parent cascades to this KSA
+pub(crate) fn build_service_account(app: &ReinhardtApp) -> Result<Option<ServiceAccount>, Error> {
+	let Some(spec) = app.spec.service_account.as_ref() else {
+		return Ok(None);
+	};
+
+	if !spec.create {
+		return Ok(None);
+	}
+
+	// `resolved_sa_name` only returns `None` when `spec.service_account`
+	// is `None`, which we already handled above. When `create == true`
+	// we always get back either the explicit name or the `{app}-app`
+	// fallback, so unwrapping here is safe — but we use `expect` to make
+	// the invariant explicit in case the resolution rule changes later.
+	let name = resolved_sa_name(app)
+		.expect("resolved_sa_name returns Some when service_account is Some and create is true");
+
+	let annotations: Option<BTreeMap<String, String>> = if spec.annotations.is_empty() {
+		None
+	} else {
+		Some(spec.annotations.clone())
+	};
+
+	let namespace = super::require_namespace(app)?;
+	let owner_ref = owner_reference(app)?;
+	let labels = standard_labels(app, Component::Web);
+
+	Ok(Some(ServiceAccount {
+		metadata: ObjectMeta {
+			name: Some(name),
+			namespace: Some(namespace),
+			labels: Some(labels),
+			annotations,
+			owner_references: Some(vec![owner_ref]),
+			..Default::default()
+		},
+		..Default::default()
+	}))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use kube::api::ObjectMeta;
+	use reinhardt_cloud_types::crd::ReinhardtAppSpec;
+	use reinhardt_cloud_types::crd::service_account::ServiceAccountSpec;
+	use rstest::rstest;
+
+	fn make_test_app(name: &str) -> ReinhardtApp {
+		ReinhardtApp {
+			metadata: ObjectMeta {
+				name: Some(name.to_string()),
+				namespace: Some("default".to_string()),
+				uid: Some("test-uid-12345".to_string()),
+				..Default::default()
+			},
+			spec: ReinhardtAppSpec {
+				image: "img:v1".to_string(),
+				..Default::default()
+			},
+			status: None,
+		}
+	}
+
+	#[rstest]
+	fn test_build_service_account_returns_none_when_spec_unset() {
+		// Arrange
+		let app = make_test_app("myapp");
+
+		// Act
+		let result = build_service_account(&app).expect("build should succeed");
+
+		// Assert
+		assert!(
+			result.is_none(),
+			"no spec.service_account → no SA materialized"
+		);
+	}
+
+	#[rstest]
+	fn test_build_service_account_returns_none_when_create_false() {
+		// Arrange
+		let mut app = make_test_app("myapp");
+		app.spec.service_account = Some(ServiceAccountSpec {
+			create: false,
+			name: Some("user-managed-sa".to_string()),
+			annotations: BTreeMap::new(),
+		});
+
+		// Act
+		let result = build_service_account(&app).expect("build should succeed");
+
+		// Assert
+		assert!(
+			result.is_none(),
+			"create=false → user pre-creates the KSA; operator builds none"
+		);
+	}
+
+	#[rstest]
+	fn test_build_service_account_default_name_is_app_suffix() {
+		// Arrange
+		let mut app = make_test_app("myapp");
+		app.spec.service_account = Some(ServiceAccountSpec {
+			create: true,
+			name: None,
+			annotations: BTreeMap::new(),
+		});
+
+		// Act
+		let sa = build_service_account(&app)
+			.expect("build should succeed")
+			.expect("create=true → SA materialized");
+
+		// Assert
+		assert_eq!(
+			sa.metadata.name.as_deref(),
+			Some("myapp-app"),
+			"default name disambiguates from {{app}}-storage and from a user-managed KSA \
+			 named after the app"
+		);
+	}
+
+	#[rstest]
+	fn test_build_service_account_uses_explicit_name() {
+		// Arrange
+		let mut app = make_test_app("myapp");
+		app.spec.service_account = Some(ServiceAccountSpec {
+			create: true,
+			name: Some("custom-sa".to_string()),
+			annotations: BTreeMap::new(),
+		});
+
+		// Act
+		let sa = build_service_account(&app)
+			.expect("build should succeed")
+			.expect("create=true → SA materialized");
+
+		// Assert
+		assert_eq!(sa.metadata.name.as_deref(), Some("custom-sa"));
+	}
+
+	#[rstest]
+	fn test_build_service_account_propagates_annotations() {
+		// Arrange
+		let mut app = make_test_app("myapp");
+		let annotations = BTreeMap::from([
+			(
+				"iam.gke.io/gcp-service-account".to_string(),
+				"myapp@project.iam.gserviceaccount.com".to_string(),
+			),
+			(
+				"eks.amazonaws.com/role-arn".to_string(),
+				"arn:aws:iam::123456789012:role/myapp".to_string(),
+			),
+		]);
+		app.spec.service_account = Some(ServiceAccountSpec {
+			create: true,
+			name: None,
+			annotations: annotations.clone(),
+		});
+
+		// Act
+		let sa = build_service_account(&app)
+			.expect("build should succeed")
+			.expect("create=true → SA materialized");
+
+		// Assert
+		let actual_annotations = sa
+			.metadata
+			.annotations
+			.as_ref()
+			.expect("annotations should propagate");
+		assert_eq!(actual_annotations.len(), 2);
+		assert_eq!(
+			actual_annotations
+				.get("iam.gke.io/gcp-service-account")
+				.map(String::as_str),
+			Some("myapp@project.iam.gserviceaccount.com"),
+		);
+		assert_eq!(
+			actual_annotations
+				.get("eks.amazonaws.com/role-arn")
+				.map(String::as_str),
+			Some("arn:aws:iam::123456789012:role/myapp"),
+		);
+	}
+
+	#[rstest]
+	fn test_build_service_account_owner_reference_present() {
+		// Arrange
+		let mut app = make_test_app("myapp");
+		app.spec.service_account = Some(ServiceAccountSpec {
+			create: true,
+			name: None,
+			annotations: BTreeMap::new(),
+		});
+
+		// Act
+		let sa = build_service_account(&app)
+			.expect("build should succeed")
+			.expect("create=true → SA materialized");
+
+		// Assert
+		let owner_refs = sa
+			.metadata
+			.owner_references
+			.as_ref()
+			.expect("owner reference should be set so deletion cascades");
+		assert_eq!(owner_refs.len(), 1);
+		assert_eq!(owner_refs[0].kind, "ReinhardtApp");
+		assert_eq!(owner_refs[0].name, "myapp");
+	}
+
+	#[rstest]
+	fn test_build_service_account_standard_labels_present() {
+		// Arrange
+		let mut app = make_test_app("myapp");
+		app.spec.service_account = Some(ServiceAccountSpec {
+			create: true,
+			name: None,
+			annotations: BTreeMap::new(),
+		});
+
+		// Act
+		let sa = build_service_account(&app)
+			.expect("build should succeed")
+			.expect("create=true → SA materialized");
+
+		// Assert
+		let labels = sa.metadata.labels.as_ref().expect("standard labels");
+		assert_eq!(
+			labels.get("app.kubernetes.io/name").map(String::as_str),
+			Some("myapp")
+		);
+		assert_eq!(
+			labels
+				.get("app.kubernetes.io/managed-by")
+				.map(String::as_str),
+			Some("reinhardt-cloud-operator"),
+		);
+		assert_eq!(
+			labels.get("app.kubernetes.io/instance").map(String::as_str),
+			Some("myapp"),
+		);
+	}
+
+	#[rstest]
+	fn test_build_service_account_empty_annotations_yields_none() {
+		// Arrange
+		let mut app = make_test_app("myapp");
+		app.spec.service_account = Some(ServiceAccountSpec {
+			create: true,
+			name: None,
+			annotations: BTreeMap::new(),
+		});
+
+		// Act
+		let sa = build_service_account(&app)
+			.expect("build should succeed")
+			.expect("create=true → SA materialized");
+
+		// Assert
+		assert!(
+			sa.metadata.annotations.is_none(),
+			"empty annotations BTreeMap → metadata.annotations should be None \
+			 (omit the field rather than serialize an empty object)"
+		);
+	}
+
+	#[rstest]
+	fn test_resolved_sa_name_returns_none_when_spec_unset() {
+		// Arrange
+		let app = make_test_app("myapp");
+
+		// Act / Assert
+		assert_eq!(resolved_sa_name(&app), None);
+	}
+
+	#[rstest]
+	fn test_resolved_sa_name_explicit_name_create_true() {
+		// Arrange
+		let mut app = make_test_app("myapp");
+		app.spec.service_account = Some(ServiceAccountSpec {
+			create: true,
+			name: Some("foo".to_string()),
+			annotations: BTreeMap::new(),
+		});
+
+		// Act / Assert
+		assert_eq!(resolved_sa_name(&app), Some("foo".to_string()));
+	}
+
+	#[rstest]
+	fn test_resolved_sa_name_explicit_name_create_false() {
+		// Arrange — user pre-created a KSA, told us its name
+		let mut app = make_test_app("myapp");
+		app.spec.service_account = Some(ServiceAccountSpec {
+			create: false,
+			name: Some("user-sa".to_string()),
+			annotations: BTreeMap::new(),
+		});
+
+		// Act / Assert
+		assert_eq!(resolved_sa_name(&app), Some("user-sa".to_string()));
+	}
+
+	#[rstest]
+	fn test_resolved_sa_name_default_name_create_true() {
+		// Arrange
+		let mut app = make_test_app("myapp");
+		app.spec.service_account = Some(ServiceAccountSpec {
+			create: true,
+			name: None,
+			annotations: BTreeMap::new(),
+		});
+
+		// Act / Assert
+		assert_eq!(resolved_sa_name(&app), Some("myapp-app".to_string()));
+	}
+
+	#[rstest]
+	fn test_resolved_sa_name_returns_none_when_create_false_and_no_name() {
+		// Arrange — ambiguous case: user said "don't create", but didn't tell us
+		// what name to bind to. The PodSpec falls back to the namespace default SA.
+		let mut app = make_test_app("myapp");
+		app.spec.service_account = Some(ServiceAccountSpec {
+			create: false,
+			name: None,
+			annotations: BTreeMap::new(),
+		});
+
+		// Act / Assert
+		assert_eq!(resolved_sa_name(&app), None);
+	}
+}


### PR DESCRIPTION
## Summary

Adds operator wiring for the `spec.serviceAccount` CRD field merged in #429 / issue #422:

- New `resources/service_account.rs` builder that materializes a per-app KSA with user-supplied annotations (Workload Identity / IRSA bindings)
- Reconciler applies the KSA before the Deployment so SSA ordering is correct
- `pod_spec.service_account_name` resolved from the spec via a centralized `resolved_sa_name()` helper, falling back to `{app}-app` to avoid colliding with the existing `{app}-storage` KSA
- Owner reference + standard labels per the project's KUBERNETES_PATTERNS conventions (CS-2)
- ClusterRole gains `serviceaccounts` verbs (was implicitly missing for the existing storage SA flow too)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Motivation and Context

Per-app workload identity is the recommended cloud-native pattern for granting application pods cloud-API access. The schema-only half landed in #429; this PR makes it functional. Distinct from the storage KSA — apps that don't use storage now have a workload-identity surface too.

The `{app}-app` default name was chosen over the bare app name to:
1. Avoid colliding with the existing `{app}-storage` KSA naming family.
2. Avoid colliding with a user-managed KSA that the user might create under the app's bare name.

## How Was This Tested

- [x] `cargo nextest run -p reinhardt-cloud-operator --all-features` — 371 passed, 0 skipped
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy -p reinhardt-cloud-operator --all-features -- -D warnings` clean
- [x] 12 rstest cases for the SA builder cover defaults, naming, annotations (including empty), owner ref, labels
- [x] 5 rstest cases for `serviceAccountName` propagation cover all four `(create, name)` combinations plus the spec-unset baseline

## Checklist

- [x] Code follows project style (tab indent, English comments)
- [x] All tests pass
- [x] No new clippy warnings
- [x] Naming convention documented (`{app}-app` default, separate from `{app}-storage`)
- [x] Owner reference + standard labels per KUBERNETES_PATTERNS.md (CS-2)
- [x] RBAC updated to grant operator the SA management verbs

## Labels to Apply

- enhancement

## Related Issues

Fixes #424
Refs #412
Refs #422 (CRD field, merged in #429)

🤖 Generated with [Claude Code](https://claude.com/claude-code)