### PR TITLE
feat(auth): add SocialAccount model for OAuth provider linking

### DIFF
--- a/dashboard/migrations/auth/0005_add_social_accounts.rs
+++ b/dashboard/migrations/auth/0005_add_social_accounts.rs
@@ -1,0 +1,111 @@
+use reinhardt::db::migrations::FieldType;
+use reinhardt::db::migrations::prelude::*;
+pub fn migration() -> Migration {
+	Migration {
+		app_label: "auth".to_string(),
+		name: "0005_add_social_accounts".to_string(),
+		operations: vec![
+			Operation::CreateTable {
+				name: "auth_social_accounts".to_string(),
+				columns: vec![
+					ColumnDefinition {
+						name: "id".to_string(),
+						type_definition: FieldType::Uuid,
+						not_null: true,
+						unique: false,
+						primary_key: true,
+						auto_increment: true,
+						default: None,
+					},
+					ColumnDefinition {
+						name: "user_id".to_string(),
+						type_definition: FieldType::Uuid,
+						not_null: true,
+						unique: false,
+						primary_key: false,
+						auto_increment: false,
+						default: None,
+					},
+					ColumnDefinition {
+						name: "provider".to_string(),
+						type_definition: FieldType::VarChar(32u32),
+						not_null: true,
+						unique: false,
+						primary_key: false,
+						auto_increment: false,
+						default: None,
+					},
+					ColumnDefinition {
+						name: "provider_user_id".to_string(),
+						type_definition: FieldType::VarChar(255u32),
+						not_null: true,
+						unique: false,
+						primary_key: false,
+						auto_increment: false,
+						default: None,
+					},
+					ColumnDefinition {
+						name: "provider_username".to_string(),
+						type_definition: FieldType::VarChar(255u32),
+						not_null: false,
+						unique: false,
+						primary_key: false,
+						auto_increment: false,
+						default: None,
+					},
+					ColumnDefinition {
+						name: "created_at".to_string(),
+						type_definition: FieldType::TimestampTz,
+						not_null: true,
+						unique: false,
+						primary_key: false,
+						auto_increment: false,
+						default: None,
+					},
+					ColumnDefinition {
+						name: "updated_at".to_string(),
+						type_definition: FieldType::TimestampTz,
+						not_null: true,
+						unique: false,
+						primary_key: false,
+						auto_increment: false,
+						default: None,
+					},
+				],
+				// `(provider, provider_user_id)` is globally unique so the same
+				// external identity cannot be claimed by two local users.
+				constraints: vec![Constraint::Unique {
+					name: "auth_social_account_provider_uid_uniq".to_string(),
+					columns: vec!["provider".to_string(), "provider_user_id".to_string()],
+				}],
+				without_rowid: None,
+				interleave_in_parent: None,
+				partition: None,
+			},
+			// Supporting index for the unlink and "list user's linked
+			// providers" lookups, both of which filter by `user_id`.
+			Operation::CreateIndex {
+				table: "auth_social_accounts".to_string(),
+				columns: vec!["user_id".to_string()],
+				unique: false,
+				index_type: None,
+				where_clause: None,
+				concurrently: false,
+				expressions: None,
+				mysql_options: None,
+				operator_class: None,
+			},
+		],
+		dependencies: vec![(
+			"auth".to_string(),
+			"0004_add_email_verification_tokens".to_string(),
+		)],
+		atomic: true,
+		replaces: vec![],
+		initial: None,
+		state_only: false,
+		database_only: false,
+		swappable_dependencies: vec![],
+		optional_dependencies: vec![],
+	}
+}

--- a/dashboard/src/apps/auth/admin.rs
+++ b/dashboard/src/apps/auth/admin.rs
@@ -1,5 +1,7 @@
 //! Admin module for auth app.
 
+pub mod social_account;
 pub mod user;
 
+pub use social_account::SocialAccountAdmin;
 pub use user::UserAdmin;

--- a/dashboard/src/apps/auth/admin/social_account.rs
+++ b/dashboard/src/apps/auth/admin/social_account.rs
@@ -1,0 +1,18 @@
+//! Admin configuration for SocialAccount model.
+
+use reinhardt::admin;
+
+use crate::apps::auth::models::SocialAccount;
+
+#[admin(model,
+	for = SocialAccount,
+	name = "Social Account",
+	list_display = [id, user_id, provider, provider_username, created_at],
+	list_filter = [provider],
+	search_fields = [provider_user_id, provider_username],
+	ordering = [(created_at, desc)],
+	readonly_fields = [id, provider, provider_user_id, created_at, updated_at],
+	list_per_page = 25,
+	permissions = allow_all
+)]
+pub struct SocialAccountAdmin;

--- a/dashboard/src/apps/auth/models.rs
+++ b/dashboard/src/apps/auth/models.rs
@@ -1,7 +1,9 @@
 //! ORM models for auth app.
 
 pub mod email_verification_token;
+pub mod social_account;
 pub mod user;
 
 pub use email_verification_token::EmailVerificationToken;
+pub use social_account::SocialAccount;
 pub use user::User;

--- a/dashboard/src/apps/auth/models/social_account.rs
+++ b/dashboard/src/apps/auth/models/social_account.rs
@@ -1,0 +1,54 @@
+//! Social account model.
+//!
+//! Links a local `User` to a third-party identity provider (GitHub, GitLab,
+//! ...). One row per (user, provider) link; the same user may link several
+//! providers. The pair `(provider, provider_user_id)` is globally unique so
+//! that the same external identity cannot be claimed by two local users.
+//!
+//! No long-term token is persisted: the OAuth access token is exchanged in
+//! memory during callback, used to fetch user info, then dropped. Refresh
+//! tokens are out of scope until a future "deploy from your repository"
+//! feature explicitly opts in.
+
+use chrono::{DateTime, Utc};
+use reinhardt::prelude::*;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Link between a local `User` and an external OAuth/OIDC provider account.
+///
+/// The `id` is a UUID rather than an auto-increment integer to match the
+/// `reinhardt-auth` `SocialAccountStorage` trait surface (its `delete`
+/// takes `Uuid`), and to keep enumeration of links non-trivial.
+#[derive(Default, Serialize, Deserialize)]
+#[model(app_label = "auth", table_name = "auth_social_accounts")]
+pub struct SocialAccount {
+	/// Primary key (UUID v4, generated on insert).
+	#[field(primary_key = true, include_in_new = false)]
+	pub id: Uuid,
+
+	/// Owning user (foreign key to `auth_users.id`).
+	pub user_id: Uuid,
+
+	/// Provider identifier — `"github"`, `"gitlab"`, etc. Lowercase, stable.
+	#[field(max_length = 32)]
+	pub provider: String,
+
+	/// Stable identifier from the provider (numeric for GitHub/GitLab,
+	/// stored as a string so heterogeneous provider id formats fit).
+	#[field(max_length = 255)]
+	pub provider_user_id: String,
+
+	/// Display name from the provider (login, preferred_username). Optional
+	/// because some providers may not surface it.
+	#[field(max_length = 255, null = true)]
+	pub provider_username: Option<String>,
+
+	/// Creation timestamp.
+	#[field(auto_now_add = true)]
+	pub created_at: DateTime<Utc>,
+
+	/// Last-update timestamp.
+	#[field(auto_now = true)]
+	pub updated_at: DateTime<Utc>,
+}

--- a/dashboard/src/apps/auth/tests.rs
+++ b/dashboard/src/apps/auth/tests.rs
@@ -12,6 +12,7 @@ pub mod unit {
 	pub mod test_jwt;
 	pub mod test_serializer_validation;
 	pub mod test_session_service;
+	pub mod test_social_account_model;
 	pub mod test_token_service;
 	pub mod test_user_model;
 }

--- a/dashboard/src/apps/auth/tests/unit/test_social_account_model.rs
+++ b/dashboard/src/apps/auth/tests/unit/test_social_account_model.rs
@@ -1,0 +1,86 @@
+//! Tests for SocialAccount model construction and serialization.
+
+#[cfg(test)]
+mod tests {
+	use chrono::Utc;
+	use rstest::rstest;
+	use uuid::Uuid;
+
+	use crate::apps::auth::models::SocialAccount;
+
+	fn sample_account() -> SocialAccount {
+		let now = Utc::now();
+		SocialAccount {
+			id: Uuid::new_v4(),
+			user_id: Uuid::new_v4(),
+			provider: "github".to_string(),
+			provider_user_id: "12345".to_string(),
+			provider_username: Some("octocat".to_string()),
+			created_at: now,
+			updated_at: now,
+		}
+	}
+
+	#[rstest]
+	fn test_social_account_default_is_zeroed() {
+		// Arrange & Act
+		let account = SocialAccount::default();
+
+		// Assert
+		assert_eq!(account.id, Uuid::nil());
+		assert_eq!(account.user_id, Uuid::nil());
+		assert!(account.provider.is_empty());
+		assert!(account.provider_user_id.is_empty());
+		assert!(account.provider_username.is_none());
+	}
+
+	#[rstest]
+	fn test_social_account_serialization_roundtrip() {
+		// Arrange
+		let account = sample_account();
+
+		// Act
+		let json = serde_json::to_string(&account).expect("Failed to serialize SocialAccount");
+		let deserialized: SocialAccount =
+			serde_json::from_str(&json).expect("Failed to deserialize SocialAccount");
+
+		// Assert
+		assert_eq!(deserialized.id, account.id);
+		assert_eq!(deserialized.user_id, account.user_id);
+		assert_eq!(deserialized.provider, account.provider);
+		assert_eq!(deserialized.provider_user_id, account.provider_user_id);
+		assert_eq!(deserialized.provider_username, account.provider_username);
+	}
+
+	#[rstest]
+	fn test_social_account_provider_username_optional() {
+		// Arrange
+		let mut account = sample_account();
+		account.provider_username = None;
+
+		// Act
+		let json = serde_json::to_string(&account).expect("Failed to serialize");
+		let deserialized: SocialAccount =
+			serde_json::from_str(&json).expect("Failed to deserialize");
+
+		// Assert
+		assert!(deserialized.provider_username.is_none());
+	}
+
+	#[rstest]
+	#[case("github")]
+	#[case("gitlab")]
+	fn test_social_account_accepts_known_providers(#[case] provider: &str) {
+		// Arrange
+		let mut account = sample_account();
+		account.provider = provider.to_string();
+
+		// Act
+		let json = serde_json::to_string(&account).expect("Failed to serialize");
+		let deserialized: SocialAccount =
+			serde_json::from_str(&json).expect("Failed to deserialize");
+
+		// Assert
+		assert_eq!(deserialized.provider, provider);
+	}
+}


### PR DESCRIPTION
## Summary

This PR addresses:

- Introduces the dashboard-side `SocialAccount` ORM model and migration that the upcoming OAuth start/callback endpoints (Issue #428) will use to persist `(user, provider, provider_user_id)` links.
- Adds `auth_social_accounts` table with a `(provider, provider_user_id)` UNIQUE constraint and a `user_id` supporting index.
- Registers the model with the admin site for diagnostic visibility.
- Adds unit tests covering default state, JSON round-trip, and the optional `provider_username` path.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Motivation and Context

Reinhardt Cloud is a developer-facing PaaS whose evaluators already hold GitHub / GitLab accounts. The first phase of #428 lays the persistence layer so subsequent PRs can wire `reinhardt-auth`'s `SocialAuthBackend`. Without this groundwork the `SocialAccountStorage` trait cannot be implemented against the local database.

The `id` column is a UUID rather than an auto-increment integer to match `reinhardt-auth`'s `SocialAccountStorage` trait surface (its `delete` takes `Uuid`).

Refs #428

## How Was This Tested?

- `cargo check -p reinhardt-cloud-dashboard --all-features`
- `cargo nextest run -p reinhardt-cloud-dashboard --all-features -E 'test(test_social_account_model)'` — 5 tests passed
- `cargo make fmt-check`
- `cargo make clippy-check`
- `cargo make makemigrations` regenerated the migration cleanly with the same shape (further-runs verification deferred to Phase 2 integration tests against a real Postgres)

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Labels to Apply

- `enhancement`
- `dashboard`

🤖 Generated with [Claude Code](https://claude.com/claude-code)