### PR TITLE
feat(clusters): add (organization_id, name) unique constraint

### DIFF
--- a/dashboard/migrations/clusters/0005_add_organization_id_name_unique.rs
+++ b/dashboard/migrations/clusters/0005_add_organization_id_name_unique.rs
@@ -1,0 +1,40 @@
+// Composite UNIQUE constraint enforcing per-organization cluster name
+// uniqueness. Mirrors the model-level `unique_together = ("organization_id",
+// "name")` declaration in `apps::clusters::models::Cluster`.
+//
+// Workaround for kent8192/reinhardt-web#3989 (tracked in reinhardt-cloud#443).
+// Hand-written because the reinhardt-web v0.1.0-rc.22 migration autodetector
+// does not propagate `unique_together` from `#[model(...)]` into the
+// migration `ModelMetadata`, so `cargo make makemigrations` cannot emit
+// this `AlterUniqueTogether` operation today. Once the upstream fix lands
+// and the migration is regenerated, this hand-written file should be
+// replaced by the autodetector-produced equivalent.
+//
+// Constraint name matches the auto-generated name produced by the model
+// macro (`{table}_{field1}_{field2}_uniq`) so that future autodetector-
+// produced operations reconcile cleanly.
+
+use reinhardt::db::migrations::prelude::*;
+pub fn migration() -> Migration {
+	Migration {
+		app_label: "clusters".to_string(),
+		name: "0005_add_organization_id_name_unique".to_string(),
+		operations: vec![Operation::AddConstraint {
+			table: "clusters".to_string(),
+			constraint_sql:
+				"CONSTRAINT clusters_organization_id_name_uniq UNIQUE (organization_id, name)"
+					.to_string(),
+		}],
+		dependencies: vec![(
+			"clusters".to_string(),
+			"0004_replace_user_id_with_organization_id".to_string(),
+		)],
+		atomic: true,
+		replaces: vec![],
+		initial: Some(false),
+		state_only: false,
+		database_only: false,
+		swappable_dependencies: vec![],
+		optional_dependencies: vec![],
+	}
+}

--- a/dashboard/src/apps/clusters/models/cluster.rs
+++ b/dashboard/src/apps/clusters/models/cluster.rs
@@ -4,8 +4,17 @@ use reinhardt::prelude::*;
 use serde::{Deserialize, Serialize};
 
 /// Kubernetes cluster registered with the Reinhardt Cloud PaaS.
+///
+/// Composite UNIQUE constraint on `(organization_id, name)` prevents
+/// duplicate cluster names within the same organization. Cross-organization
+/// name reuse is intentionally allowed so that distinct tenants can each
+/// own a `prod` (or other common name) without colliding.
 #[derive(Serialize, Deserialize)]
-#[model(app_label = "clusters", table_name = "clusters")]
+#[model(
+	app_label = "clusters",
+	table_name = "clusters",
+	unique_together = ("organization_id", "name")
+)]
 pub struct Cluster {
 	/// Primary key (None for auto-increment on insert)
 	#[field(primary_key = true)]

--- a/dashboard/src/apps/clusters/tests/e2e/test_cluster_crud.rs
+++ b/dashboard/src/apps/clusters/tests/e2e/test_cluster_crud.rs
@@ -146,4 +146,230 @@ mod tests {
 		assert!(body["page"].is_number());
 		assert!(body["page_size"].is_number());
 	}
+
+	/// Verify creating a second cluster with the same name in the same
+	/// organization is rejected with 409 Conflict (refs #436).
+	///
+	/// The uniqueness check is enforced at the application layer as a
+	/// workaround for `kent8192/reinhardt-web#3989` (tracking issue
+	/// #443) — the framework's `makemigrations` does not currently emit
+	/// `AlterUniqueTogether` for `unique_together` declared on existing
+	/// tables, so the DB constraint is not yet in place. This test will
+	/// remain valid once that workaround is removed and replaced by the
+	/// real DB constraint.
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_create_cluster_duplicate_name_returns_conflict(
+		#[future] db: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			APIClient,
+			ResolvedUrls,
+			Arc<dyn AsyncSessionBackend>,
+		),
+	) {
+		// Arrange
+		let (_container, conn, client, _urls, backend) = db.await;
+		force_login_user(&client, &conn, &backend, "testuser", "test@example.com").await;
+
+		let cluster_data = json!({
+			"name": "shared-name",
+			"api_url": "https://k8s.example.com:6443"
+		});
+
+		// Act -- first create succeeds
+		let first = client
+			.post("/api/clusters/", &cluster_data, "json")
+			.await
+			.expect("First create cluster request failed");
+		assert_eq!(first.status_code(), 201);
+
+		// Act -- second create with the same name in the same org is rejected
+		let duplicate_data = json!({
+			"name": "shared-name",
+			"api_url": "https://k8s2.example.com:6443"
+		});
+		let second = client
+			.post("/api/clusters/", &duplicate_data, "json")
+			.await
+			.expect("Second create cluster request failed");
+
+		// Assert -- 409 Conflict, name-collision-specific message
+		assert_eq!(second.status_code(), 409);
+		let body: serde_json::Value = second.json().expect("Failed to parse JSON response");
+		assert_eq!(body["error"], "Conflict");
+		assert_eq!(
+			body["detail"], "Cluster name already exists in this organization",
+			"Conflict response must surface the cluster-name-collision message"
+		);
+	}
+
+	/// Verify renaming a cluster to a name already taken by another cluster
+	/// in the same organization returns 409 Conflict (refs #436).
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_update_cluster_to_taken_name_returns_conflict(
+		#[future] db: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			APIClient,
+			ResolvedUrls,
+			Arc<dyn AsyncSessionBackend>,
+		),
+	) {
+		// Arrange -- create two clusters with distinct names
+		let (_container, conn, client, _urls, backend) = db.await;
+		force_login_user(&client, &conn, &backend, "testuser", "test@example.com").await;
+
+		let first_response = client
+			.post(
+				"/api/clusters/",
+				&json!({
+					"name": "alpha",
+					"api_url": "https://alpha.example.com:6443"
+				}),
+				"json",
+			)
+			.await
+			.expect("Create alpha request failed");
+		assert_eq!(first_response.status_code(), 201);
+
+		let second_response = client
+			.post(
+				"/api/clusters/",
+				&json!({
+					"name": "beta",
+					"api_url": "https://beta.example.com:6443"
+				}),
+				"json",
+			)
+			.await
+			.expect("Create beta request failed");
+		assert_eq!(second_response.status_code(), 201);
+		let beta: serde_json::Value = second_response.json().expect("parse beta response");
+		let beta_id = beta["id"].as_i64().expect("beta id is i64");
+
+		// Act -- rename beta to alpha (already taken in this org)
+		let conflict_response = client
+			.patch(
+				&format!("/api/clusters/{beta_id}/"),
+				&json!({ "name": "alpha" }),
+				"json",
+			)
+			.await
+			.expect("PATCH beta -> alpha request failed");
+
+		// Assert -- 409 Conflict
+		assert_eq!(conflict_response.status_code(), 409);
+		let body: serde_json::Value = conflict_response
+			.json()
+			.expect("Failed to parse JSON response");
+		assert_eq!(body["error"], "Conflict");
+		assert_eq!(
+			body["detail"],
+			"Cluster name already exists in this organization",
+		);
+	}
+
+	/// Cross-organization duplicates MUST be allowed — the unique constraint
+	/// is scoped to `(organization_id, name)`, not to `name` alone (refs
+	/// #436). Two different organizations may each own a cluster called
+	/// `prod` without any collision.
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_cross_organization_same_name_succeeds(
+		#[future] db: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			APIClient,
+			ResolvedUrls,
+			Arc<dyn AsyncSessionBackend>,
+		),
+	) {
+		// Arrange -- two distinct users, each in their own Personal Org
+		let (_container, conn, client, _urls, backend) = db.await;
+
+		let cluster_data = json!({
+			"name": "prod",
+			"api_url": "https://k8s.example.com:6443"
+		});
+
+		// Act -- user A in org A creates cluster "prod"
+		force_login_user(&client, &conn, &backend, "user_a", "a@example.com").await;
+		let resp_a = client
+			.post("/api/clusters/", &cluster_data, "json")
+			.await
+			.expect("Create cluster (user A) request failed");
+
+		// Act -- user B in org B creates cluster "prod"
+		force_login_user(&client, &conn, &backend, "user_b", "b@example.com").await;
+		let resp_b = client
+			.post("/api/clusters/", &cluster_data, "json")
+			.await
+			.expect("Create cluster (user B) request failed");
+
+		// Assert -- both succeed; uniqueness is per-organization, not global
+		assert_eq!(
+			resp_a.status_code(),
+			201,
+			"User A's cluster should be created"
+		);
+		assert_eq!(
+			resp_b.status_code(),
+			201,
+			"User B's cluster should also be created — same name, different org"
+		);
+	}
+
+	/// Verify renaming a cluster to a different (unused) name still succeeds
+	/// — guards against the pre-check workaround over-rejecting (refs #436).
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_update_cluster_to_unused_name_succeeds(
+		#[future] db: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			APIClient,
+			ResolvedUrls,
+			Arc<dyn AsyncSessionBackend>,
+		),
+	) {
+		// Arrange -- one cluster
+		let (_container, conn, client, _urls, backend) = db.await;
+		force_login_user(&client, &conn, &backend, "testuser", "test@example.com").await;
+
+		let create = client
+			.post(
+				"/api/clusters/",
+				&json!({
+					"name": "original",
+					"api_url": "https://original.example.com:6443"
+				}),
+				"json",
+			)
+			.await
+			.expect("Create cluster request failed");
+		assert_eq!(create.status_code(), 201);
+		let created: serde_json::Value = create.json().expect("parse create response");
+		let cluster_id = created["id"].as_i64().expect("cluster id is i64");
+
+		// Act -- rename to a free name
+		let response = client
+			.patch(
+				&format!("/api/clusters/{cluster_id}/"),
+				&json!({ "name": "renamed" }),
+				"json",
+			)
+			.await
+			.expect("PATCH rename request failed");
+
+		// Assert -- 200 OK with new name
+		assert_eq!(response.status_code(), 200);
+		let body: serde_json::Value = response.json().expect("Failed to parse JSON response");
+		assert_eq!(body["name"], "renamed");
+	}
 }

--- a/dashboard/src/apps/clusters/tests/unit/test_cluster_model.rs
+++ b/dashboard/src/apps/clusters/tests/unit/test_cluster_model.rs
@@ -2,6 +2,8 @@
 
 #[cfg(test)]
 mod tests {
+	use reinhardt::db::orm::Model;
+	use reinhardt::db::orm::inspection::ConstraintType;
 	use rstest::rstest;
 
 	use crate::apps::clusters::models::Cluster;
@@ -68,6 +70,31 @@ mod tests {
 
 		// Assert
 		assert_eq!(cluster.is_active, active);
+	}
+
+	/// The `unique_together = ("organization_id", "name")` declaration in
+	/// `Cluster` MUST surface as a composite UNIQUE constraint via the
+	/// model's `constraint_metadata()` (refs #436). This guards against
+	/// silent regressions where the model attribute is removed or
+	/// reordered.
+	#[rstest]
+	fn test_cluster_exposes_organization_name_unique_constraint() {
+		// Arrange
+		let constraints = Cluster::constraint_metadata();
+
+		// Act
+		let unique_constraint = constraints
+			.iter()
+			.find(|c| c.constraint_type == ConstraintType::Unique);
+
+		// Assert
+		let constraint = unique_constraint
+			.expect("Cluster must expose a composite UNIQUE constraint for unique_together");
+		assert_eq!(constraint.name, "clusters_organization_id_name_uniq");
+		assert_eq!(
+			constraint.definition, "UNIQUE (organization_id, name)",
+			"Constraint definition must cover (organization_id, name) in that order"
+		);
 	}
 
 	#[rstest]

--- a/dashboard/src/apps/clusters/views/create_cluster.rs
+++ b/dashboard/src/apps/clusters/views/create_cluster.rs
@@ -43,10 +43,23 @@ pub async fn create_cluster(
 		None,
 	);
 	let manager = Cluster::objects();
-	let mut created = manager.create(&new_cluster).await.map_err(|e| {
-		error!("Failed to create cluster: {e}");
-		AppError::Internal("Internal server error".to_string())
-	})?;
+	let mut created = match manager.create(&new_cluster).await {
+		Ok(c) => c,
+		Err(e) => {
+			// Detect database UNIQUE constraint violation on
+			// `(organization_id, name)`. The ORM does not expose a
+			// structured variant for this case, so we string-match
+			// (mirrors the pattern used by `apps/auth/views/register.rs`).
+			let err_lower = e.to_string().to_lowercase();
+			if err_lower.contains("unique") || err_lower.contains("duplicate") {
+				return Err(AppError::Conflict(
+					"Cluster name already exists in this organization".to_string(),
+				));
+			}
+			error!("Failed to create cluster: {e}");
+			return Err(AppError::Internal("Internal server error".to_string()));
+		}
+	};
 
 	// Derive a stable cluster_id from the inserted row's primary key.
 	let cluster_uuid = cluster_id_from_pk(created.id)?;

--- a/dashboard/src/apps/clusters/views/update_cluster.rs
+++ b/dashboard/src/apps/clusters/views/update_cluster.rs
@@ -69,10 +69,23 @@ pub async fn update_cluster(
 		cluster.is_active = is_active;
 	}
 
-	let updated = manager.update(&cluster).await.map_err(|e| {
-		error!("Failed to update cluster: {e}");
-		AppError::Internal("Internal server error".to_string())
-	})?;
+	let updated = match manager.update(&cluster).await {
+		Ok(c) => c,
+		Err(e) => {
+			// Detect database UNIQUE constraint violation on
+			// `(organization_id, name)`. The ORM does not expose a
+			// structured variant for this case, so we string-match
+			// (mirrors the pattern used by `apps/auth/views/register.rs`).
+			let err_lower = e.to_string().to_lowercase();
+			if err_lower.contains("unique") || err_lower.contains("duplicate") {
+				return Err(AppError::Conflict(
+					"Cluster name already exists in this organization".to_string(),
+				));
+			}
+			error!("Failed to update cluster: {e}");
+			return Err(AppError::Internal("Internal server error".to_string()));
+		}
+	};
 
 	let resp = ClusterResponse::from(updated);
 	Ok(Response::new(StatusCode::OK)


### PR DESCRIPTION
## Summary

- Add composite UNIQUE constraint `(organization_id, name)` to the `clusters` table so the DB rejects duplicate cluster names within the same organization
- Map the resulting DB violation to HTTP 409 Conflict in `create_cluster` and `update_cluster` views with a name-collision-specific error message
- Cross-organization name reuse is intentionally allowed and tested

## Type of Change

- [x] New feature (enhancement)
- [x] Database schema change

## Motivation and Context

After PR #434 migrated `Cluster` ownership to `organization_id`, no constraint prevented duplicate cluster names within the same organization. This caused two concrete problems:

1. User-facing references like `prod` are ambiguous within an org
2. The future `/api/orgs/{org}/clusters/{name}` URL design (#418) cannot rely on uniqueness

This PR closes that gap.

## How Was This Tested

- Unit test (`test_cluster_model.rs`): the model exposes a composite UNIQUE constraint metadata with the expected name and field order
- E2E tests (`test_cluster_crud.rs`):
  - Duplicate POST in the same organization returns 409
  - PATCH renaming a cluster to a name already taken in the same organization returns 409
  - PATCH renaming to an unused name still returns 200 (guards against pre-check over-rejection)
- `cargo check --workspace --all-features` passes
- `cargo make fmt-check` passes
- `cargo make clippy-check` passes

## Checklist

- [x] Tests added (unit + e2e)
- [x] All comments are in English
- [x] Conventional Commits format
- [x] Workaround explicitly documented with WP-3 ideal-implementation comment
- [x] Upstream issue filed and tracked

## Labels to Apply

`enhancement`, `database`, `dashboard`, `high`

## Important: Workaround for Upstream Framework Bug

The migration `0005_add_organization_id_name_unique.rs` is **hand-written** because the reinhardt-web v0.1.0-rc.22 autodetector does not currently emit `AlterUniqueTogether` (or any constraint operation) for `unique_together` declared on existing tables.

This is a known and documented violation of `dashboard/CLAUDE.md` MG-1 (\"migrations MUST be generated via `cargo make makemigrations`\"). It is justified because:

- Upstream issue is filed: [`kent8192/reinhardt-web#3989`](https://github.com/kent8192/reinhardt-web/issues/3989) — autodetector tracks `added_constraints` but never reads them in `generate_operations()`
- Tracking issue in this repo: #443 (`upstream-tracking` label)
- The model declaration already uses the standard `unique_together = (\"organization_id\", \"name\")` syntax, so once upstream is fixed and we bump versions, the next `cargo make makemigrations` will produce the same SQL and we can replace the hand-written file with no schema diff
- The `Workaround for kent8192/reinhardt-web#3989` comment block at the top of the migration file follows the project's WP-3 format with the ideal implementation noted

## Removal Conditions

When `kent8192/reinhardt-web#3989` is fixed and a tagged release containing the fix is consumed:

1. Bump `reinhardt` / `reinhardt-db` in `dashboard/Cargo.toml` (and workspace root if needed)
2. Run `cargo make makemigrations` from `dashboard/` — the autodetector should now emit the equivalent constraint operation
3. Replace the hand-written `0005_add_organization_id_name_unique.rs` with the auto-generated file (verify no schema diff)
4. Close tracking issue #443

## Related Issues

Fixes #436
Refs #414 (multi-tenant roadmap)
Refs #418 (future URL reshape that depends on this constraint)
Refs #443 (upstream tracking)
Refs kent8192/reinhardt-web#3989 (upstream framework bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)