### PR TITLE
refactor(dashboard): adopt reinhardt::pages::ClientLauncher in WASM entry

### DIFF
--- a/dashboard/src/client.rs
+++ b/dashboard/src/client.rs
@@ -1,11 +1,16 @@
 //! WASM client entry point for the Reinhardt Cloud dashboard.
 //!
-//! Renders the current route reactively into the `#app` element using
-//! the reinhardt-pages Router and Effect system. SPA navigation is
-//! handled entirely in WASM — no inline JavaScript is required.
+//! Bootstraps the SPA via `reinhardt::pages::ClientLauncher`, which
+//! handles router initialization, history listener wiring, the DOM
+//! mount on `#app`, and the reactive re-render Effect. Dashboard-
+//! specific concerns (link interception, app state, toast container,
+//! WebSocket bootstrap) are layered on top before and after
+//! `launch()`.
 
 pub mod components;
 pub mod layout;
+#[cfg(wasm)]
+pub mod link_interception;
 pub mod pages;
 #[cfg(wasm)]
 pub mod router;
@@ -14,42 +19,43 @@ pub mod ws;
 
 #[cfg(wasm)]
 mod wasm_entry {
-	use wasm_bindgen::JsCast;
-	use wasm_bindgen::closure::Closure;
 	use wasm_bindgen::prelude::*;
 
 	use reinhardt::pages::reactive::Effect;
+	use reinhardt::pages::{ClientLauncher, with_router};
 
 	use super::*;
 
-	/// WASM entry point — called automatically when the module loads.
+	/// WASM entry point — invoked automatically when the module loads.
 	#[wasm_bindgen(start)]
 	pub fn main() -> Result<(), JsValue> {
+		// Hedge: ClientLauncher installs the panic hook when its feature
+		// is enabled; calling set_once twice is harmless.
 		console_error_panic_hook::set_once();
+
 		state::init_app_state();
 
-		// Initialize the SPA router and register browser history listener
-		router::init_global_router();
-		router::with_router(|r| r.setup_history_listener());
+		// Install the SPA link interceptor before launch so the very
+		// first click is captured. ClientLauncher does not register one.
+		let document = web_sys::window()
+			.and_then(|w| w.document())
+			.expect("no document");
+		link_interception::setup_link_interception(&document);
 
-		let window = web_sys::window().expect("no global window");
-		let document = window.document().expect("no document");
+		// Hand router init, history listener, DOM mount and the
+		// reactive re-render Effect to ClientLauncher.
+		ClientLauncher::new("#app")
+			.router(router::init_router)
+			.launch()?;
 
-		// Set up global click handler for SPA link interception
-		setup_link_interception(&document);
-
-		// Set up reactive rendering — re-renders #app when route changes
-		let path_signal = router::with_router(|r| r.current_path().clone());
+		// Path-driven side effects: ensure the toast container exists
+		// and open the notifications WebSocket whenever the user is on
+		// the authenticated root route. Subscribes to the same
+		// current_path Signal as the launcher's render Effect.
+		let path_signal = with_router(|r| r.current_path().clone());
 		let doc = document.clone();
 		let effect = Effect::new(move || {
-			// Subscribe to path signal to trigger re-render on route change
 			let path = path_signal.get();
-			let app = doc.get_element_by_id("app").expect("no #app element");
-			let page = router::with_router(|r| r.render_current());
-			app.set_inner_html(&page.render_to_string());
-
-			// Initialize toast container and WebSocket on authenticated pages.
-			// Guard against duplicates across re-renders by checking for existing elements.
 			if path == "/" {
 				if doc.get_element_by_id("toast-container").is_none() {
 					let toast_html = components::toast::toast_container().render_to_string();
@@ -62,54 +68,9 @@ mod wasm_entry {
 				ws::connect_notifications();
 			}
 		});
-		// Keep the effect alive for the lifetime of the page
+		// Intentional leak: must persist for the WASM module's lifetime.
 		std::mem::forget(effect);
 
 		Ok(())
-	}
-
-	/// Intercept clicks on internal `<a>` tags and route them through the SPA router
-	/// instead of triggering full page reloads.
-	fn setup_link_interception(document: &web_sys::Document) {
-		let closure = Closure::wrap(Box::new(move |event: web_sys::MouseEvent| {
-			let target = match event.target() {
-				Some(t) => t,
-				None => return,
-			};
-
-			// Walk up the DOM tree to find the closest <a> element
-			let mut el: Option<web_sys::Element> = target.dyn_ref::<web_sys::Element>().cloned();
-			while let Some(ref element) = el {
-				if element.tag_name().eq_ignore_ascii_case("A") {
-					break;
-				}
-				el = element.parent_element();
-			}
-
-			let Some(anchor) = el else { return };
-
-			// Only intercept internal links (starting with "/")
-			let Some(href) = anchor.get_attribute("href") else {
-				return;
-			};
-			if !href.starts_with('/') {
-				return;
-			}
-
-			// Skip external links marked with data-external or target="_blank"
-			if anchor.get_attribute("target").as_deref() == Some("_blank") {
-				return;
-			}
-
-			event.prevent_default();
-			router::with_router(|r| {
-				let _ = r.push(&href);
-			});
-		}) as Box<dyn FnMut(_)>);
-
-		document
-			.add_event_listener_with_callback("click", closure.as_ref().unchecked_ref())
-			.expect("failed to add click listener");
-		closure.forget();
 	}
 }

--- a/dashboard/src/client/link_interception.rs
+++ b/dashboard/src/client/link_interception.rs
@@ -1,0 +1,51 @@
+//! SPA link interception for the WASM client.
+//!
+//! `ClientLauncher` does not install link interception in
+//! reinhardt-web v0.1.0-rc.22, so the dashboard owns this concern.
+//! Remove this module once `reinhardt-pages` exposes a built-in
+//! equivalent.
+
+use reinhardt::pages::with_router;
+use wasm_bindgen::JsCast;
+use wasm_bindgen::closure::Closure;
+
+/// Attach a single global click listener that routes internal `<a>`
+/// clicks through the SPA router instead of triggering full page
+/// reloads. External links and `target="_blank"` anchors are left
+/// untouched so the browser handles them normally.
+pub fn setup_link_interception(document: &web_sys::Document) {
+	let closure = Closure::wrap(Box::new(move |event: web_sys::MouseEvent| {
+		let Some(target) = event.target() else { return };
+
+		// Walk up the DOM tree to find the closest <a> ancestor.
+		let mut el: Option<web_sys::Element> = target.dyn_ref::<web_sys::Element>().cloned();
+		while let Some(ref element) = el {
+			if element.tag_name().eq_ignore_ascii_case("A") {
+				break;
+			}
+			el = element.parent_element();
+		}
+		let Some(anchor) = el else { return };
+
+		// Only intercept internal links (those starting with "/").
+		let Some(href) = anchor.get_attribute("href") else {
+			return;
+		};
+		if !href.starts_with('/') {
+			return;
+		}
+		if anchor.get_attribute("target").as_deref() == Some("_blank") {
+			return;
+		}
+
+		event.prevent_default();
+		with_router(|r| {
+			let _ = r.push(&href);
+		});
+	}) as Box<dyn FnMut(_)>);
+
+	document
+		.add_event_listener_with_callback("click", closure.as_ref().unchecked_ref())
+		.expect("failed to add click listener");
+	closure.forget();
+}

--- a/dashboard/src/client/router.rs
+++ b/dashboard/src/client/router.rs
@@ -1,9 +1,9 @@
 //! SPA router configuration for the Reinhardt Cloud WASM client.
 //!
-//! Defines client-side routes and provides global router access via
-//! `thread_local!` storage following the reinhardt-pages pattern.
-
-use std::cell::RefCell;
+//! Routes are declared as a pure function returning a `Router`. Global
+//! access at runtime is provided by `reinhardt::pages::with_router`,
+//! which is installed by `ClientLauncher::launch()`. This module no
+//! longer owns a thread-local instance.
 
 use reinhardt::pages::router::Router;
 
@@ -12,35 +12,10 @@ use crate::apps::auth::client::pages::{login_page, register_page};
 use super::layout::dashboard_shell;
 use super::pages::not_found_page;
 
-thread_local! {
-	static ROUTER: RefCell<Option<Router>> = const { RefCell::new(None) };
-}
-
-/// Initialize the global router instance. Must be called once at startup.
-pub fn init_global_router() {
-	ROUTER.with(|r| {
-		*r.borrow_mut() = Some(init_router());
-	});
-}
-
-/// Access the global router within a closure.
-///
-/// # Panics
-///
-/// Panics if `init_global_router` has not been called.
-pub fn with_router<F, R>(f: F) -> R
-where
-	F: FnOnce(&Router) -> R,
-{
-	ROUTER.with(|r| {
-		f(r.borrow()
-			.as_ref()
-			.expect("Router not initialized. Call init_global_router() first."))
-	})
-}
-
 /// Build the router with all application routes.
-fn init_router() -> Router {
+///
+/// Passed to `ClientLauncher::router(init_router)` from `client.rs`.
+pub fn init_router() -> Router {
 	Router::new()
 		.route("/", || dashboard_shell())
 		.route("/login", || login_page())


### PR DESCRIPTION
## Summary

This PR addresses:

- Replaces the hand-rolled WASM bootstrap in `dashboard/src/client.rs` with `reinhardt::pages::ClientLauncher`, which already handles panic hook, reactive scheduler, router init, history listener, DOM mount on `#app`, and the reactive re-render Effect.
- Drops the duplicated `thread_local! ROUTER` plus `init_global_router` / `with_router` helpers from `dashboard/src/client/router.rs` and routes runtime access through `reinhardt::pages::with_router`, eliminating the two-router footgun.
- Extracts SPA `<a>` click delegation into a dedicated `dashboard/src/client/link_interception.rs` module so each file owns exactly one concern, in line with the dashboard's MF-1 (aggregator-only) and one-component-per-file conventions.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

`reinhardt-web` exposes `reinhardt::pages::ClientLauncher` since v0.1.0-rc.18, and the dashboard pins v0.1.0-rc.22 — yet `dashboard/src/client.rs` still hand-rolls the same boilerplate that the launcher provides (panic hook, reactive scheduler, router init, history listener, DOM mount, re-render Effect). On top of that, `dashboard/src/client/router.rs` keeps its own `thread_local! ROUTER` + `init_global_router` / `with_router`, duplicating what the launcher manages internally in `APP_ROUTER`. The duplication makes upstream upgrades risky and prevents the dashboard from picking up improvements (mount semantics, scheduler fixes) that land in `reinhardt-pages`.

Fixes #442

## How Was This Tested?

Local verification on the worktree (host machine, macOS):

- `cargo make fmt-check` — pass.
- `cargo check --workspace --all --all-features` — finished in 10m 52s with 0 errors / 0 warnings.
- `cargo make clippy-check` (workspace, `-D warnings`) — finished in 2m 50s with 0 errors / 0 warnings.
- `cargo nextest run -p reinhardt-cloud-dashboard --lib --all-features` — 8 unit tests passed; 14 tests under `apps::auth::tests::e2e::*` failed with `Failed to start PostgreSQL container: SocketNotFoundError("/var/run/docker.sock")`. The failures are environmental: on the local machine `/var/run/docker.sock` is a symlink pointing at a missing `~/.docker/run/docker.sock`, and the auth E2E suite uses TestContainers via that socket. Every change in this PR sits behind `#[cfg(wasm)]`, so it is not compiled into the native test build and cannot affect those E2E tests.

The dashboard `cargo make wasm-compile-dev` command currently fails on `main` (and therefore on this branch as well) with 18 unrelated errors in `apps/auth/server/{login,register}.rs`, `apps/organizations/...`, and `apps/deployments/...`. The error counts and locations are identical to `main`, so this PR introduces no new WASM regression. The repository's CI does not run a WASM build, which is how that breakage went unnoticed; tracking that separately is out of scope for this PR.

Manual SPA verification (run server + browser DevTools) is recommended before merging:

- `<a>` clicks on internal links go through SPA navigation (no full reload).
- Browser back/forward (popstate) updates the rendered page.
- `#toast-container` is added to `<body>` only on `/` and is not duplicated across navigations.
- The notifications WebSocket opens on `/` only.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

<!-- ⚠️ CI CONTROL CHECKBOX - DO NOT EDIT MANUALLY ⚠️ -->
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

Fixes #442

## Labels to Apply

### Type Label (select one)
- [ ] `bug`
- [x] `enhancement`
- [ ] `documentation`
- [ ] `performance`
- [x] `refactoring`
- [ ] `code-quality`
- [ ] `breaking-change`

### Scope Label (select all that apply)
- [x] `dashboard`

### Priority Label (for maintainers)
- [ ] `critical`
- [ ] `high`
- [x] `medium`
- [ ] `low`

---

**Additional Context:**

The `link_interception.rs` module's doc comment notes that the file should be removed once `reinhardt-pages` exposes a built-in equivalent — `ClientLauncher` does not install link interception in v0.1.0-rc.22, so the dashboard owns it for now. The toast container insert and `ws::connect_notifications` remain as a path-driven side-effect Effect created after `launch()`, preserving the current behaviour where authenticated routes (`/`) bring up notifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)