### PR TITLE
feat(auth): GitHub OAuth backend (Phase 3-6 of #428)

### DIFF
--- a/dashboard/src/apps/auth/services/oauth.rs
+++ b/dashboard/src/apps/auth/services/oauth.rs
@@ -6,4 +6,6 @@
 //! account-linking semantics.
 
 #[cfg(not(target_arch = "wasm32"))]
+pub mod config;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod storage;

--- a/dashboard/src/apps/auth/services/oauth.rs
+++ b/dashboard/src/apps/auth/services/oauth.rs
@@ -6,6 +6,8 @@
 //! account-linking semantics.
 
 #[cfg(not(target_arch = "wasm32"))]
+pub mod backend;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod config;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod storage;

--- a/dashboard/src/apps/auth/services/oauth.rs
+++ b/dashboard/src/apps/auth/services/oauth.rs
@@ -10,4 +10,6 @@ pub mod backend;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod config;
 #[cfg(not(target_arch = "wasm32"))]
+pub mod linking;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod storage;

--- a/dashboard/src/apps/auth/services/oauth/backend.rs
+++ b/dashboard/src/apps/auth/services/oauth/backend.rs
@@ -1,0 +1,61 @@
+//! Construction of the framework `SocialAuthBackend`.
+//!
+//! Wires together:
+//!   * the configured providers (today: `GitHubProvider`, see #428); and
+//!   * an `InMemoryStateStore` for OAuth `state` and PKCE verifiers.
+//!
+//! ## State-store choice
+//!
+//! The framework's only `SessionBackend`-backed state store
+//! (`SessionStateStore`) requires a *synchronous* `SessionBackend`, but
+//! the dashboard's `RedisSessionBackend` only implements
+//! `AsyncSessionBackend`. There is no Redis-or-async `StateStore` impl
+//! upstream as of `reinhardt-web@v0.1.0-rc.22`, so we use
+//! `InMemoryStateStore`. Implication: the dashboard is single-instance
+//! for OAuth flow purposes — a user who starts the flow on one pod and
+//! is routed to another for the callback will see `InvalidState`. State
+//! is held for ~10 minutes, so the only steady-state symptom is the
+//! occasional retry; the flow itself remains secure (state + PKCE are
+//! still per-request and CSRF-bound).
+//!
+//! Tracked for follow-up: this should move to a Redis-backed StateStore
+//! once upstream `reinhardt-auth` exposes one (companion to
+//! `kent8192/reinhardt-web#3986`).
+
+use std::sync::Arc;
+
+use reinhardt_auth::social::backend::SocialAuthBackend;
+use reinhardt_auth::social::core::config::ProviderConfig;
+use reinhardt_auth::social::core::error::SocialAuthError;
+use reinhardt_auth::social::flow::state::InMemoryStateStore;
+use reinhardt_auth::social::providers::github::GitHubProvider;
+
+use crate::apps::auth::services::oauth::config::OAuthSettings;
+
+/// Build a fully wired `SocialAuthBackend` from settings.
+///
+/// Returns `Ok(None)` if no providers are configured — callers can use this
+/// to short-circuit endpoint registration when the feature is effectively
+/// disabled.
+pub async fn build_social_auth_backend(
+	settings: &OAuthSettings,
+) -> Result<Option<Arc<SocialAuthBackend>>, SocialAuthError> {
+	if settings.enabled_provider_ids().is_empty() {
+		return Ok(None);
+	}
+
+	let state_store = Arc::new(InMemoryStateStore::new());
+	let mut backend = SocialAuthBackend::with_state_store(state_store);
+
+	if let Some(creds) = &settings.github {
+		let cfg = ProviderConfig::github(
+			creds.client_id.clone(),
+			creds.client_secret.clone(),
+			creds.redirect_uri.clone(),
+		);
+		let provider = GitHubProvider::new(cfg).await?;
+		backend.register_provider(Arc::new(provider));
+	}
+
+	Ok(Some(Arc::new(backend)))
+}

--- a/dashboard/src/apps/auth/services/oauth/config.rs
+++ b/dashboard/src/apps/auth/services/oauth/config.rs
@@ -1,0 +1,75 @@
+//! Provider credentials sourced from environment variables.
+//!
+//! Per `CM-2`, OAuth client credentials are environment-driven so that
+//! deployments never bake provider secrets into TOML or container images.
+//! A provider is considered enabled iff its `CLIENT_ID` and `CLIENT_SECRET`
+//! are both set; partial configuration disables the provider entirely so
+//! that the login UI does not present a button that cannot complete the
+//! flow.
+
+use std::env;
+
+/// Credentials for a single OAuth provider, populated from env vars.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderCredentials {
+	pub client_id: String,
+	pub client_secret: String,
+	pub redirect_uri: String,
+}
+
+/// All OAuth provider credentials known to the dashboard.
+///
+/// Today only `github` is shipped (see #428). Additional providers (GitLab,
+/// etc.) will land via separate feature flags / follow-up issues — see
+/// `kent8192/reinhardt-cloud#440`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct OAuthSettings {
+	pub github: Option<ProviderCredentials>,
+}
+
+impl OAuthSettings {
+	/// Reads provider credentials from the process environment.
+	///
+	/// For each provider, all three env vars (`CLIENT_ID`, `CLIENT_SECRET`,
+	/// `REDIRECT_URI`) must be present and non-empty for the provider to be
+	/// enabled. If any of them is missing, the provider entry is `None` and
+	/// the corresponding REST endpoints will return 404 / the login button
+	/// will not appear.
+	pub fn from_env() -> Self {
+		Self {
+			github: read_provider("GITHUB"),
+		}
+	}
+
+	/// Lookup credentials by provider id (lowercase, e.g. `"github"`).
+	pub fn get(&self, provider: &str) -> Option<&ProviderCredentials> {
+		match provider {
+			"github" => self.github.as_ref(),
+			_ => None,
+		}
+	}
+
+	/// List the ids of providers that are currently enabled.
+	pub fn enabled_provider_ids(&self) -> Vec<&'static str> {
+		let mut out = Vec::new();
+		if self.github.is_some() {
+			out.push("github");
+		}
+		out
+	}
+}
+
+fn read_provider(suffix: &str) -> Option<ProviderCredentials> {
+	let client_id = non_empty_env(&format!("REINHARDT_CLOUD_OAUTH_{suffix}_CLIENT_ID"))?;
+	let client_secret = non_empty_env(&format!("REINHARDT_CLOUD_OAUTH_{suffix}_CLIENT_SECRET"))?;
+	let redirect_uri = non_empty_env(&format!("REINHARDT_CLOUD_OAUTH_{suffix}_REDIRECT_URI"))?;
+	Some(ProviderCredentials {
+		client_id,
+		client_secret,
+		redirect_uri,
+	})
+}
+
+fn non_empty_env(key: &str) -> Option<String> {
+	env::var(key).ok().filter(|v| !v.is_empty())
+}

--- a/dashboard/src/apps/auth/services/oauth/linking.rs
+++ b/dashboard/src/apps/auth/services/oauth/linking.rs
@@ -1,0 +1,224 @@
+//! Account-linking semantics for completed OAuth callbacks.
+//!
+//! Resolves a `(provider, claims)` pair into a local `User` row, creating
+//! a fresh user when needed. Implements the four-way decision tree from
+//! issue #428:
+//!
+//!   (a) Already-linked   — return the user pointed to by the existing
+//!       social-account row.
+//!   (b) Authenticated    — caller is logged in; attach the new provider
+//!       link to the current session's user.
+//!   (c) Email-match      — provider asserted `email_verified == true`
+//!       AND a local user with the same email already exists; attach.
+//!   (d) New user         — none of the above; create a brand-new user
+//!       with `password = None` (OAuth-only) and link it.
+//!
+//! `email_verified == None` (e.g. GitHub when the API does not surface
+//! verification state) is treated the same as `Some(false)` — strictly
+//! safer, since it forbids automatically merging into an existing local
+//! account that the OAuth user might not actually own.
+
+use chrono::Utc;
+use reinhardt::db::orm::{FilterOperator, FilterValue, Model};
+use reinhardt_auth::social::core::claims::StandardClaims;
+use reinhardt_auth::social::storage::{SocialAccount, SocialAccountStorage};
+use uuid::Uuid;
+
+use crate::apps::auth::models::User;
+
+/// Errors that can surface from `link_or_create_user`.
+#[derive(Debug, thiserror::Error)]
+pub enum LinkError {
+	/// The OAuth provider returned claims missing a field we require.
+	#[error("provider claims missing required field: {0}")]
+	MissingClaim(&'static str),
+	/// The `SocialAccountStorage` returned an error.
+	#[error("social-account storage error: {0}")]
+	Storage(String),
+	/// The user-table lookup or insert failed.
+	#[error("user database error: {0}")]
+	Database(String),
+}
+
+/// Resolve OAuth claims into a local `User`, linking or creating as needed.
+///
+/// `current_user` carries the already-authenticated session user when the
+/// caller is initiating a *link* flow (route (b)); pass `None` for plain
+/// social login.
+pub async fn link_or_create_user(
+	storage: &dyn SocialAccountStorage,
+	provider: &str,
+	claims: &StandardClaims,
+	current_user: Option<User>,
+) -> Result<User, LinkError> {
+	if claims.sub.is_empty() {
+		return Err(LinkError::MissingClaim("sub"));
+	}
+
+	// (a) Already linked.
+	if let Some(link) = storage
+		.find_by_provider_and_uid(provider, &claims.sub)
+		.await
+		.map_err(|e| LinkError::Storage(e.to_string()))?
+	{
+		return load_user_by_id(link.user_id).await;
+	}
+
+	// (b) Authenticated link.
+	if let Some(user) = current_user {
+		let user_id = user.id;
+		create_link(storage, provider, claims, user_id).await?;
+		return Ok(user);
+	}
+
+	// (c) Email match (only when provider asserts email_verified).
+	if claims.email_verified == Some(true)
+		&& let Some(email) = claims.email.as_ref()
+	{
+		let normalized = email.to_lowercase();
+		let existing = User::objects()
+			.filter(
+				User::field_email(),
+				FilterOperator::Eq,
+				FilterValue::String(normalized),
+			)
+			.first()
+			.await
+			.map_err(|e| LinkError::Database(e.to_string()))?;
+		if let Some(user) = existing {
+			let user_id = user.id;
+			create_link(storage, provider, claims, user_id).await?;
+			return Ok(user);
+		}
+	}
+
+	// (d) New user.
+	let username = generate_unique_username(claims).await?;
+	let email = claims.email.clone().unwrap_or_default().to_lowercase();
+	let new_user = User::new(
+		username,
+		email,
+		claims.given_name.clone().unwrap_or_default(),
+		claims.family_name.clone().unwrap_or_default(),
+		None,  // password_hash: OAuth-only user has no usable password
+		true,  // is_active
+		false, // is_staff
+		false, // is_superuser
+	);
+	let created = User::objects()
+		.create(&new_user)
+		.await
+		.map_err(|e| LinkError::Database(e.to_string()))?;
+	let user_id = created.id;
+	create_link(storage, provider, claims, user_id).await?;
+	Ok(created)
+}
+
+async fn load_user_by_id(user_id: Uuid) -> Result<User, LinkError> {
+	User::objects()
+		.filter(
+			User::field_id(),
+			FilterOperator::Eq,
+			FilterValue::String(user_id.to_string()),
+		)
+		.first()
+		.await
+		.map_err(|e| LinkError::Database(e.to_string()))?
+		.ok_or_else(|| LinkError::Database(format!("orphaned social link to user {user_id}")))
+}
+
+async fn create_link(
+	storage: &dyn SocialAccountStorage,
+	provider: &str,
+	claims: &StandardClaims,
+	user_id: Uuid,
+) -> Result<(), LinkError> {
+	let now = Utc::now();
+	let acc = SocialAccount {
+		id: Uuid::now_v7(),
+		user_id,
+		provider: provider.to_string(),
+		provider_user_id: claims.sub.clone(),
+		// Token-bearing fields are dropped on the way through
+		// `OrmSocialAccountStorage` per SEC E1, but we still send the
+		// available metadata so an in-memory storage in tests can
+		// observe the inputs.
+		email: claims.email.clone(),
+		display_name: display_name_from_claims(claims),
+		picture: claims.picture.clone(),
+		access_token: String::new(),
+		refresh_token: None,
+		token_expires_at: now,
+		scopes: Vec::new(),
+		created_at: now,
+		updated_at: now,
+	};
+	storage
+		.create(acc)
+		.await
+		.map_err(|e| LinkError::Storage(e.to_string()))?;
+	Ok(())
+}
+
+fn display_name_from_claims(claims: &StandardClaims) -> Option<String> {
+	if let Some(login) = claims
+		.additional_claims
+		.get("login")
+		.and_then(|v| v.as_str())
+	{
+		return Some(login.to_string());
+	}
+	claims.name.clone()
+}
+
+async fn generate_unique_username(claims: &StandardClaims) -> Result<String, LinkError> {
+	let raw = display_name_from_claims(claims).unwrap_or_else(|| claims.sub.clone());
+	let base = sanitize_username(&raw);
+	if !username_exists(&base).await? {
+		return Ok(base);
+	}
+	for i in 1..10_000 {
+		let candidate = truncate_username(&format!("{base}_{i}"));
+		if !username_exists(&candidate).await? {
+			return Ok(candidate);
+		}
+	}
+	Err(LinkError::Database(
+		"could not generate a unique username after 10000 attempts".to_string(),
+	))
+}
+
+async fn username_exists(name: &str) -> Result<bool, LinkError> {
+	let hit = User::objects()
+		.filter(
+			User::field_username(),
+			FilterOperator::Eq,
+			FilterValue::String(name.to_string()),
+		)
+		.first()
+		.await
+		.map_err(|e| LinkError::Database(e.to_string()))?;
+	Ok(hit.is_some())
+}
+
+/// Strip characters that the dashboard does not allow in usernames and
+/// truncate to the column limit (150).
+fn sanitize_username(input: &str) -> String {
+	let cleaned: String = input
+		.chars()
+		.map(|c| {
+			if c.is_alphanumeric() || c == '-' || c == '_' || c == '.' {
+				c
+			} else {
+				'_'
+			}
+		})
+		.collect();
+	let trimmed = cleaned.trim_matches(['_', '.', '-'].as_ref());
+	let final_str = if trimmed.is_empty() { "user" } else { trimmed };
+	truncate_username(final_str)
+}
+
+fn truncate_username(s: &str) -> String {
+	s.chars().take(150).collect()
+}

--- a/dashboard/src/apps/auth/services/oauth/linking.rs
+++ b/dashboard/src/apps/auth/services/oauth/linking.rs
@@ -38,6 +38,14 @@ pub enum LinkError {
 	/// The user-table lookup or insert failed.
 	#[error("user database error: {0}")]
 	Database(String),
+	/// An account with this email already exists, but we cannot auto-link
+	/// it (the provider did not assert email_verified == true). Caller must
+	/// sign in with the existing account first and link from there.
+	#[error(
+		"an account with email {email} already exists; sign in with your \
+		 existing account first and link {provider} from your profile"
+	)]
+	EmailConflict { email: String, provider: String },
 }
 
 /// Resolve OAuth claims into a local `User`, linking or creating as needed.
@@ -95,6 +103,30 @@ pub async fn link_or_create_user(
 	// (d) New user.
 	let username = generate_unique_username(claims).await?;
 	let email = claims.email.clone().unwrap_or_default().to_lowercase();
+
+	// Defensive: if a user with this email already exists, we got here
+	// only because path (c) declined to merge (provider did not assert
+	// email_verified == true). Refuse rather than crash on the unique
+	// constraint, and surface a message that guides the user to the
+	// link-from-existing-account flow.
+	if !email.is_empty() {
+		let conflict = User::objects()
+			.filter(
+				User::field_email(),
+				FilterOperator::Eq,
+				FilterValue::String(email.clone()),
+			)
+			.first()
+			.await
+			.map_err(|e| LinkError::Database(e.to_string()))?;
+		if conflict.is_some() {
+			return Err(LinkError::EmailConflict {
+				email,
+				provider: provider.to_string(),
+			});
+		}
+	}
+
 	let new_user = User::new(
 		username,
 		email,

--- a/dashboard/src/apps/auth/tests.rs
+++ b/dashboard/src/apps/auth/tests.rs
@@ -10,6 +10,7 @@ pub mod unit {
 	pub mod test_auth_property;
 	pub mod test_email_verification;
 	pub mod test_jwt;
+	pub mod test_oauth_providers_view;
 	pub mod test_oauth_settings;
 	pub mod test_serializer_validation;
 	pub mod test_session_service;

--- a/dashboard/src/apps/auth/tests.rs
+++ b/dashboard/src/apps/auth/tests.rs
@@ -10,6 +10,7 @@ pub mod unit {
 	pub mod test_auth_property;
 	pub mod test_email_verification;
 	pub mod test_jwt;
+	pub mod test_oauth_settings;
 	pub mod test_serializer_validation;
 	pub mod test_session_service;
 	pub mod test_social_account_model;

--- a/dashboard/src/apps/auth/tests.rs
+++ b/dashboard/src/apps/auth/tests.rs
@@ -10,6 +10,7 @@ pub mod unit {
 	pub mod test_auth_property;
 	pub mod test_email_verification;
 	pub mod test_jwt;
+	pub mod test_oauth_backend;
 	pub mod test_oauth_providers_view;
 	pub mod test_oauth_settings;
 	pub mod test_serializer_validation;

--- a/dashboard/src/apps/auth/tests.rs
+++ b/dashboard/src/apps/auth/tests.rs
@@ -19,5 +19,6 @@ pub mod unit {
 }
 pub mod integration {
 	pub mod test_credential_service;
+	pub mod test_oauth_linking;
 	pub mod test_oauth_storage;
 }

--- a/dashboard/src/apps/auth/tests/integration/test_oauth_linking.rs
+++ b/dashboard/src/apps/auth/tests/integration/test_oauth_linking.rs
@@ -23,7 +23,7 @@ mod tests {
 	use std::collections::HashMap;
 
 	use crate::apps::auth::models::User;
-	use crate::apps::auth::services::oauth::linking::link_or_create_user;
+	use crate::apps::auth::services::oauth::linking::{LinkError, link_or_create_user};
 	use crate::config::test_helpers::{ResolvedUrls, test_app};
 
 	#[fixture]
@@ -186,7 +186,7 @@ mod tests {
 	#[rstest]
 	#[tokio::test(flavor = "multi_thread")]
 	#[serial(database)]
-	async fn test_email_unverified_does_not_link_existing_user(
+	async fn test_email_unverified_collision_returns_email_conflict(
 		#[future] db: (
 			ContainerAsync<GenericImage>,
 			Arc<DatabaseConnection>,
@@ -194,26 +194,31 @@ mod tests {
 			ResolvedUrls,
 		),
 	) {
-		// Arrange
+		// Arrange — an existing local user owns the email, and the OAuth
+		// provider returns the same email but does NOT assert verification
+		// (email_verified = None mirrors GitHub's surface).
 		let (_c, _conn, _cli, _urls) = db.await;
 		let existing_id = seed_user("link_unverified", "unverified@example.com").await;
 		let storage = InMemorySocialAccountStorage::new();
-		// email_verified = None mirrors the GitHub case where verification
-		// state is not surfaced. Must NOT auto-merge into the existing user.
 		let claims = github_claims("gh_unv_1", Some("unverified@example.com"), None);
 
 		// Act
-		let user = link_or_create_user(&storage, "github", &claims, None)
-			.await
-			.expect("new-user creation should succeed");
+		let result = link_or_create_user(&storage, "github", &claims, None).await;
 
-		// Assert — a new user was created instead of merging.
-		assert_ne!(user.id, existing_id);
-		let new_links = storage.find_by_user(user.id).await.unwrap();
-		assert_eq!(new_links.len(), 1);
-		// Existing user has no link.
-		let old_links = storage.find_by_user(existing_id).await.unwrap();
-		assert!(old_links.is_empty());
+		// Assert — must NOT silently auto-merge (path (c) requires
+		// verified=true) and must NOT create a duplicate-email user. The
+		// caller gets a structured EmailConflict error so the UI can
+		// surface a "sign in with your existing account first" message.
+		match result {
+			Err(LinkError::EmailConflict { email, provider }) => {
+				assert_eq!(email, "unverified@example.com");
+				assert_eq!(provider, "github");
+			}
+			other => panic!("expected EmailConflict, got {other:?}"),
+		}
+		// Existing user is untouched.
+		let links = storage.find_by_user(existing_id).await.unwrap();
+		assert!(links.is_empty(), "existing user must not be auto-linked");
 	}
 
 	#[rstest]

--- a/dashboard/src/apps/auth/tests/integration/test_oauth_linking.rs
+++ b/dashboard/src/apps/auth/tests/integration/test_oauth_linking.rs
@@ -1,0 +1,278 @@
+//! Integration tests for `link_or_create_user`.
+//!
+//! Covers the four-way decision tree from #428: already-linked,
+//! authenticated link, email-verified email match, and new-user creation.
+//! `email_verified == None` (the GitHub case) is also covered to confirm
+//! the safe-by-default behavior of declining to merge into an existing
+//! local account when the provider does not assert verification.
+
+#[cfg(test)]
+mod tests {
+	use std::sync::Arc;
+
+	use reinhardt::BaseUser;
+	use reinhardt::db::orm::{FilterOperator, FilterValue, Model};
+	use reinhardt::prelude::DatabaseConnection;
+	use reinhardt::test::APIClient;
+	use reinhardt::test::fixtures::postgres_with_migrations_from_dir;
+	use reinhardt::test::fixtures::{ContainerAsync, GenericImage};
+	use reinhardt_auth::social::core::claims::StandardClaims;
+	use reinhardt_auth::social::storage::{InMemorySocialAccountStorage, SocialAccountStorage};
+	use rstest::*;
+	use serial_test::serial;
+	use std::collections::HashMap;
+
+	use crate::apps::auth::models::User;
+	use crate::apps::auth::services::oauth::linking::link_or_create_user;
+	use crate::config::test_helpers::{ResolvedUrls, test_app};
+
+	#[fixture]
+	async fn db(
+		test_app: (APIClient, ResolvedUrls),
+	) -> (
+		ContainerAsync<GenericImage>,
+		Arc<DatabaseConnection>,
+		APIClient,
+		ResolvedUrls,
+	) {
+		let (client, urls) = test_app;
+		let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
+		let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
+			.await
+			.expect("Failed to start PostgreSQL with migrations");
+		(container, conn, client, urls)
+	}
+
+	fn github_claims(
+		sub: &str,
+		email: Option<&str>,
+		email_verified: Option<bool>,
+	) -> StandardClaims {
+		let mut additional = HashMap::new();
+		additional.insert(
+			"login".to_string(),
+			serde_json::Value::String(format!("user_{sub}")),
+		);
+		StandardClaims {
+			sub: sub.to_string(),
+			email: email.map(String::from),
+			email_verified,
+			name: Some(format!("User {sub}")),
+			given_name: None,
+			family_name: None,
+			picture: None,
+			locale: None,
+			additional_claims: additional,
+		}
+	}
+
+	async fn seed_user(username: &str, email: &str) -> uuid::Uuid {
+		let mut user = User::new(
+			username.to_string(),
+			email.to_lowercase(),
+			String::new(),
+			String::new(),
+			None,
+			true,
+			false,
+			false,
+		);
+		user.set_password("test-password-1234").unwrap();
+		User::objects().create(&user).await.expect("seed user").id
+	}
+
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_already_linked_returns_existing_user(
+		#[future] db: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			APIClient,
+			ResolvedUrls,
+		),
+	) {
+		// Arrange
+		let (_c, _conn, _cli, _urls) = db.await;
+		let user_id = seed_user("link_existing", "existing@example.com").await;
+		let storage = InMemorySocialAccountStorage::new();
+		let claims = github_claims("gh_99", Some("existing@example.com"), Some(true));
+		// Pre-existing link
+		link_or_create_user(&storage, "github", &claims, None)
+			.await
+			.expect("first call creates the link via path (c)");
+
+		// Act — second call hits path (a)
+		let user = link_or_create_user(&storage, "github", &claims, None)
+			.await
+			.expect("second call should return the linked user");
+
+		// Assert
+		assert_eq!(user.id, user_id);
+		// No second link was created — find_by_provider returns just one.
+		let links = storage.find_by_user(user_id).await.unwrap();
+		assert_eq!(links.len(), 1);
+	}
+
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_authenticated_link_attaches_to_current_user(
+		#[future] db: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			APIClient,
+			ResolvedUrls,
+		),
+	) {
+		// Arrange
+		let (_c, _conn, _cli, _urls) = db.await;
+		let user_id = seed_user("link_authed", "authed@example.com").await;
+		let current = User::objects()
+			.filter(
+				User::field_id(),
+				FilterOperator::Eq,
+				FilterValue::String(user_id.to_string()),
+			)
+			.first()
+			.await
+			.unwrap()
+			.unwrap();
+		let storage = InMemorySocialAccountStorage::new();
+		// Claims have a *different* email and unverified state — would fall
+		// through to a new-user branch if not for the authenticated link.
+		let claims = github_claims("gh_authed_42", Some("not-authed@example.com"), None);
+
+		// Act
+		let user = link_or_create_user(&storage, "github", &claims, Some(current))
+			.await
+			.expect("authed link should succeed");
+
+		// Assert
+		assert_eq!(user.id, user_id);
+		let links = storage.find_by_user(user_id).await.unwrap();
+		assert_eq!(links.len(), 1);
+		assert_eq!(links[0].provider_user_id, "gh_authed_42");
+	}
+
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_email_verified_match_links_existing_user(
+		#[future] db: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			APIClient,
+			ResolvedUrls,
+		),
+	) {
+		// Arrange
+		let (_c, _conn, _cli, _urls) = db.await;
+		let user_id = seed_user("link_emailmatch", "match@example.com").await;
+		let storage = InMemorySocialAccountStorage::new();
+		let claims = github_claims("gh_match_1", Some("match@example.com"), Some(true));
+
+		// Act
+		let user = link_or_create_user(&storage, "github", &claims, None)
+			.await
+			.expect("email-match link should succeed");
+
+		// Assert
+		assert_eq!(user.id, user_id);
+		let links = storage.find_by_user(user_id).await.unwrap();
+		assert_eq!(links.len(), 1);
+	}
+
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_email_unverified_does_not_link_existing_user(
+		#[future] db: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			APIClient,
+			ResolvedUrls,
+		),
+	) {
+		// Arrange
+		let (_c, _conn, _cli, _urls) = db.await;
+		let existing_id = seed_user("link_unverified", "unverified@example.com").await;
+		let storage = InMemorySocialAccountStorage::new();
+		// email_verified = None mirrors the GitHub case where verification
+		// state is not surfaced. Must NOT auto-merge into the existing user.
+		let claims = github_claims("gh_unv_1", Some("unverified@example.com"), None);
+
+		// Act
+		let user = link_or_create_user(&storage, "github", &claims, None)
+			.await
+			.expect("new-user creation should succeed");
+
+		// Assert — a new user was created instead of merging.
+		assert_ne!(user.id, existing_id);
+		let new_links = storage.find_by_user(user.id).await.unwrap();
+		assert_eq!(new_links.len(), 1);
+		// Existing user has no link.
+		let old_links = storage.find_by_user(existing_id).await.unwrap();
+		assert!(old_links.is_empty());
+	}
+
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_new_user_created_with_no_password(
+		#[future] db: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			APIClient,
+			ResolvedUrls,
+		),
+	) {
+		// Arrange
+		let (_c, _conn, _cli, _urls) = db.await;
+		let storage = InMemorySocialAccountStorage::new();
+		let claims = github_claims("gh_new_777", Some("brand-new@example.com"), Some(true));
+
+		// Act
+		let user = link_or_create_user(&storage, "github", &claims, None)
+			.await
+			.expect("new-user creation should succeed");
+
+		// Assert
+		assert!(user.password_hash.is_none(), "OAuth user has no password");
+		assert!(user.is_active(), "new OAuth user is active by default");
+		assert!(!user.is_staff);
+		assert!(!user.is_superuser);
+		assert_eq!(user.email, "brand-new@example.com");
+		// Username is derived from the `login` additional claim and sanitized.
+		assert_eq!(user.get_username(), "user_gh_new_777");
+		let links = storage.find_by_user(user.id).await.unwrap();
+		assert_eq!(links.len(), 1);
+		assert_eq!(links[0].provider, "github");
+	}
+
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_username_collision_appends_suffix(
+		#[future] db: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			APIClient,
+			ResolvedUrls,
+		),
+	) {
+		// Arrange — existing user already has the candidate username.
+		let (_c, _conn, _cli, _urls) = db.await;
+		seed_user("user_gh_collide", "existing-collide@example.com").await;
+		let storage = InMemorySocialAccountStorage::new();
+		let claims = github_claims("gh_collide", Some("oauth-collide@example.com"), Some(true));
+
+		// Act
+		let user = link_or_create_user(&storage, "github", &claims, None)
+			.await
+			.expect("new-user creation should succeed even on collision");
+
+		// Assert
+		assert_eq!(user.get_username(), "user_gh_collide_1");
+	}
+}

--- a/dashboard/src/apps/auth/tests/unit/test_oauth_backend.rs
+++ b/dashboard/src/apps/auth/tests/unit/test_oauth_backend.rs
@@ -1,0 +1,59 @@
+//! Tests for `build_social_auth_backend`.
+//!
+//! These cover the dashboard's wiring of `reinhardt-auth`'s
+//! `SocialAuthBackend` — specifically the contract that:
+//!   * an empty `OAuthSettings` (no providers configured) returns `None`,
+//!     so callers can short-circuit endpoint dispatch instead of building
+//!     a backend with no registered providers; and
+//!   * a populated `OAuthSettings` returns `Some(Arc<...>)` so views can
+//!     immediately call `begin_auth` / `handle_callback`.
+
+#[cfg(test)]
+mod tests {
+	use rstest::rstest;
+
+	use crate::apps::auth::services::oauth::backend::build_social_auth_backend;
+	use crate::apps::auth::services::oauth::config::{OAuthSettings, ProviderCredentials};
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_build_returns_none_when_no_providers_configured() {
+		// Arrange
+		let settings = OAuthSettings::default();
+
+		// Act
+		let result = build_social_auth_backend(&settings)
+			.await
+			.expect("build should not error");
+
+		// Assert
+		assert!(
+			result.is_none(),
+			"with no providers, factory must return None to let callers short-circuit"
+		);
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_build_returns_backend_when_github_configured() {
+		// Arrange
+		let settings = OAuthSettings {
+			github: Some(ProviderCredentials {
+				client_id: "test-id".to_string(),
+				client_secret: "test-secret".to_string(),
+				redirect_uri: "https://example.test/cb".to_string(),
+			}),
+		};
+
+		// Act
+		let result = build_social_auth_backend(&settings)
+			.await
+			.expect("build should succeed with valid github creds");
+
+		// Assert
+		assert!(
+			result.is_some(),
+			"with github configured, factory must return a backend"
+		);
+	}
+}

--- a/dashboard/src/apps/auth/tests/unit/test_oauth_providers_view.rs
+++ b/dashboard/src/apps/auth/tests/unit/test_oauth_providers_view.rs
@@ -1,0 +1,92 @@
+//! Tests for the `oauth_providers` discovery endpoint helpers.
+//!
+//! The discovery endpoint MUST NOT leak provider secrets, redirect URIs,
+//! or client IDs into the response body — only the public-facing `id` and
+//! human-readable `label` per provider. These tests pin that contract on
+//! the response struct itself so a future field added to `ProviderEntry`
+//! cannot silently start exposing secrets.
+
+#[cfg(test)]
+mod tests {
+	use rstest::rstest;
+	use serde_json::Value;
+
+	use crate::apps::auth::views::oauth::providers::{ProviderEntry, ProvidersResponse, label_for};
+
+	#[rstest]
+	fn test_provider_entry_serializes_only_id_and_label() {
+		// Arrange
+		let entry = ProviderEntry {
+			id: "github",
+			label: "GitHub",
+		};
+
+		// Act
+		let json = serde_json::to_value(&entry).expect("serialize entry");
+
+		// Assert — the object has exactly the two public fields and nothing
+		// else. If a future change adds a credential-bearing field, this
+		// assertion fails.
+		let obj = json.as_object().expect("entry is object");
+		assert_eq!(
+			obj.len(),
+			2,
+			"ProviderEntry must serialize to exactly 2 fields, got {}: {json:?}",
+			obj.len()
+		);
+		assert_eq!(obj.get("id").and_then(Value::as_str), Some("github"));
+		assert_eq!(obj.get("label").and_then(Value::as_str), Some("GitHub"));
+	}
+
+	#[rstest]
+	fn test_providers_response_does_not_contain_secret_keywords() {
+		// Arrange — populate with one entry to mirror the runtime shape.
+		let resp = ProvidersResponse {
+			providers: vec![ProviderEntry {
+				id: "github",
+				label: "GitHub",
+			}],
+		};
+
+		// Act
+		let json = serde_json::to_string(&resp).expect("serialize response");
+		let lowered = json.to_lowercase();
+
+		// Assert — none of the well-known secret tokens appear anywhere in
+		// the response body.
+		for forbidden in [
+			"client_id",
+			"client_secret",
+			"redirect_uri",
+			"secret",
+			"token",
+			"password",
+		] {
+			assert!(
+				!lowered.contains(forbidden),
+				"providers response leaked '{forbidden}': {json}"
+			);
+		}
+	}
+
+	#[rstest]
+	#[case("github", "GitHub")]
+	#[case("unknown", "OAuth")]
+	#[case("", "OAuth")]
+	fn test_label_for_maps_known_ids(#[case] id: &str, #[case] expected: &str) {
+		// Act / Assert
+		assert_eq!(label_for(id), expected);
+	}
+
+	#[rstest]
+	fn test_empty_providers_response_serializes_to_empty_array() {
+		// Arrange
+		let resp = ProvidersResponse { providers: vec![] };
+
+		// Act
+		let json = serde_json::to_value(&resp).expect("serialize empty");
+
+		// Assert
+		assert_eq!(json["providers"], Value::Array(vec![]));
+	}
+}

--- a/dashboard/src/apps/auth/tests/unit/test_oauth_settings.rs
+++ b/dashboard/src/apps/auth/tests/unit/test_oauth_settings.rs
@@ -1,0 +1,152 @@
+//! Tests for `OAuthSettings::from_env`.
+//!
+//! Verifies that a provider is enabled iff all three of its credential env
+//! vars (`CLIENT_ID`, `CLIENT_SECRET`, `REDIRECT_URI`) are present and
+//! non-empty. Partial configuration disables the provider rather than
+//! half-enabling it, so the login UI never offers a button that cannot
+//! complete the flow.
+
+#[cfg(test)]
+mod tests {
+	use rstest::rstest;
+	use serial_test::serial;
+
+	use crate::apps::auth::services::oauth::config::OAuthSettings;
+
+	const KEY_ID: &str = "REINHARDT_CLOUD_OAUTH_GITHUB_CLIENT_ID";
+	const KEY_SECRET: &str = "REINHARDT_CLOUD_OAUTH_GITHUB_CLIENT_SECRET";
+	const KEY_REDIRECT: &str = "REINHARDT_CLOUD_OAUTH_GITHUB_REDIRECT_URI";
+
+	/// RAII guard that restores OAuth env vars on drop. Mirrors the pattern
+	/// used by the e2e mailer tests so behavior under `serial` is identical.
+	struct EnvGuard {
+		saved: Vec<(String, Option<String>)>,
+	}
+
+	impl EnvGuard {
+		fn set(vars: Vec<(&str, Option<&str>)>) -> Self {
+			let mut saved = Vec::new();
+			for (key, new_val) in &vars {
+				saved.push((key.to_string(), std::env::var(key).ok()));
+				// SAFETY: called in a serial test before any parallel tasks read these vars.
+				unsafe {
+					match new_val {
+						Some(v) => std::env::set_var(key, v),
+						None => std::env::remove_var(key),
+					}
+				}
+			}
+			Self { saved }
+		}
+	}
+
+	impl Drop for EnvGuard {
+		fn drop(&mut self) {
+			for (key, old_val) in &self.saved {
+				// SAFETY: restoring env vars in serial test teardown.
+				unsafe {
+					match old_val {
+						Some(v) => std::env::set_var(key, v),
+						None => std::env::remove_var(key),
+					}
+				}
+			}
+		}
+	}
+
+	#[rstest]
+	#[serial(env_oauth)]
+	fn test_github_enabled_when_all_three_env_vars_set() {
+		// Arrange
+		let _g = EnvGuard::set(vec![
+			(KEY_ID, Some("github-client-id")),
+			(KEY_SECRET, Some("github-client-secret")),
+			(KEY_REDIRECT, Some("https://example.test/cb")),
+		]);
+
+		// Act
+		let settings = OAuthSettings::from_env();
+
+		// Assert
+		let creds = settings.github.as_ref().expect("github should be enabled");
+		assert_eq!(creds.client_id, "github-client-id");
+		assert_eq!(creds.client_secret, "github-client-secret");
+		assert_eq!(creds.redirect_uri, "https://example.test/cb");
+		assert_eq!(settings.enabled_provider_ids(), vec!["github"]);
+		assert!(settings.get("github").is_some());
+		assert!(settings.get("gitlab").is_none());
+	}
+
+	#[rstest]
+	#[serial(env_oauth)]
+	fn test_github_disabled_when_secret_missing() {
+		// Arrange
+		let _g = EnvGuard::set(vec![
+			(KEY_ID, Some("id-only")),
+			(KEY_SECRET, None),
+			(KEY_REDIRECT, Some("https://example.test/cb")),
+		]);
+
+		// Act
+		let settings = OAuthSettings::from_env();
+
+		// Assert
+		assert!(settings.github.is_none());
+		assert!(settings.enabled_provider_ids().is_empty());
+	}
+
+	#[rstest]
+	#[serial(env_oauth)]
+	fn test_github_disabled_when_client_id_missing() {
+		// Arrange
+		let _g = EnvGuard::set(vec![
+			(KEY_ID, None),
+			(KEY_SECRET, Some("secret-only")),
+			(KEY_REDIRECT, Some("https://example.test/cb")),
+		]);
+
+		// Act
+		let settings = OAuthSettings::from_env();
+
+		// Assert
+		assert!(settings.github.is_none());
+	}
+
+	#[rstest]
+	#[serial(env_oauth)]
+	fn test_github_disabled_when_all_missing() {
+		// Arrange
+		let _g = EnvGuard::set(vec![
+			(KEY_ID, None),
+			(KEY_SECRET, None),
+			(KEY_REDIRECT, None),
+		]);
+
+		// Act
+		let settings = OAuthSettings::from_env();
+
+		// Assert
+		assert!(settings.github.is_none());
+		assert!(settings.enabled_provider_ids().is_empty());
+		assert!(settings.get("github").is_none());
+	}
+
+	#[rstest]
+	#[serial(env_oauth)]
+	fn test_empty_string_treated_as_unset() {
+		// Arrange — partial configuration with empty values must disable the
+		// provider just like absence does, otherwise an exported-but-empty
+		// CLIENT_SECRET would silently fail at OAuth-exchange time.
+		let _g = EnvGuard::set(vec![
+			(KEY_ID, Some("")),
+			(KEY_SECRET, Some("secret")),
+			(KEY_REDIRECT, Some("https://example.test/cb")),
+		]);
+
+		// Act
+		let settings = OAuthSettings::from_env();
+
+		// Assert
+		assert!(settings.github.is_none());
+	}
+}

--- a/dashboard/src/apps/auth/urls.rs
+++ b/dashboard/src/apps/auth/urls.rs
@@ -21,4 +21,8 @@ pub fn server_url_patterns() -> ServerRouter {
 		.endpoint(views::profile_update)
 		.endpoint(views::change_password)
 		.endpoint(views::verify_email_change)
+		.endpoint(views::oauth_start)
+		.endpoint(views::oauth_callback)
+		.endpoint(views::oauth_unlink)
+		.endpoint(views::oauth_providers)
 }

--- a/dashboard/src/apps/auth/views.rs
+++ b/dashboard/src/apps/auth/views.rs
@@ -6,6 +6,7 @@ flatten_imports! {
 	pub mod change_password;
 	pub mod forgot_password;
 	pub mod login;
+	pub mod oauth;
 	pub mod profile;
 	pub mod register;
 	pub mod reset_password;

--- a/dashboard/src/apps/auth/views/oauth.rs
+++ b/dashboard/src/apps/auth/views/oauth.rs
@@ -1,0 +1,10 @@
+//! OAuth/social login view aggregator.
+
+use reinhardt::flatten_imports;
+
+flatten_imports! {
+	pub mod callback;
+	pub mod providers;
+	pub mod start;
+	pub mod unlink;
+}

--- a/dashboard/src/apps/auth/views/oauth/callback.rs
+++ b/dashboard/src/apps/auth/views/oauth/callback.rs
@@ -22,7 +22,7 @@ use tracing::error;
 
 use crate::apps::auth::services::oauth::backend::build_social_auth_backend;
 use crate::apps::auth::services::oauth::config::OAuthSettings;
-use crate::apps::auth::services::oauth::linking::link_or_create_user;
+use crate::apps::auth::services::oauth::linking::{LinkError, link_or_create_user};
 use crate::apps::auth::services::oauth::storage::OrmSocialAccountStorage;
 use crate::apps::auth::services::session::create_session;
 
@@ -74,7 +74,13 @@ pub async fn oauth_callback(
 		.await
 		.map_err(|e| {
 			error!("OAuth linking for {provider} failed: {e}");
-			AppError::Internal("account linking failed".to_string())
+			match e {
+				// Surface the actionable conflict message to the client so
+				// the UI can prompt for "sign in with your existing account
+				// first and link from there".
+				LinkError::EmailConflict { .. } => AppError::Validation(e.to_string()),
+				_ => AppError::Internal("account linking failed".to_string()),
+			}
 		})?;
 
 	let session_id = create_session(&user).await.map_err(|e| {

--- a/dashboard/src/apps/auth/views/oauth/callback.rs
+++ b/dashboard/src/apps/auth/views/oauth/callback.rs
@@ -1,0 +1,93 @@
+//! `GET /oauth/{provider}/callback/?code=&state=` — finish the OAuth flow.
+//!
+//! `handle_callback` validates state, exchanges code for an access token,
+//! fetches user-info from the provider, and returns `StandardClaims`.
+//! Those claims are then resolved into a local `User` by
+//! `link_or_create_user` (see `services::oauth::linking`). On success a
+//! Reinhardt session is created and a `sessionid` cookie is issued so the
+//! freshly-authenticated browser is logged in for subsequent requests.
+//!
+//! Path (b) "authenticated link" from #428 is intentionally not wired here
+//! yet — we always pass `None` for `current_user`, which means an already
+//! logged-in user who initiates an OAuth start will end up with a *new*
+//! login under the OAuth identity rather than a link onto their existing
+//! account. The "logged-in link" UX requires reading the current session
+//! cookie inside this view and is left as a follow-up.
+
+use reinhardt::core::exception::Error as AppError;
+use reinhardt::http::ViewResult;
+use reinhardt::{Path, Query, Response, StatusCode, get};
+use serde::Deserialize;
+use tracing::error;
+
+use crate::apps::auth::services::oauth::backend::build_social_auth_backend;
+use crate::apps::auth::services::oauth::config::OAuthSettings;
+use crate::apps::auth::services::oauth::linking::link_or_create_user;
+use crate::apps::auth::services::oauth::storage::OrmSocialAccountStorage;
+use crate::apps::auth::services::session::create_session;
+
+/// `?code=...&state=...` query parameters as returned by the provider.
+#[derive(Debug, Deserialize)]
+pub struct OAuthCallbackQuery {
+	pub code: String,
+	pub state: String,
+}
+
+#[get("/oauth/{provider}/callback/", name = "oauth_callback")]
+pub async fn oauth_callback(
+	Path(provider): Path<String>,
+	Query(q): Query<OAuthCallbackQuery>,
+) -> ViewResult<Response> {
+	let settings = OAuthSettings::from_env();
+	if settings.get(&provider).is_none() {
+		return Err(AppError::NotFound(format!(
+			"OAuth provider not enabled: {provider}"
+		)));
+	}
+
+	let backend = build_social_auth_backend(&settings)
+		.await
+		.map_err(|e| {
+			error!("OAuth backend init failed: {e}");
+			AppError::Internal("OAuth not available".to_string())
+		})?
+		.ok_or_else(|| AppError::NotFound("OAuth not configured".to_string()))?;
+
+	let cb = backend
+		.handle_callback(&provider, &q.code, &q.state)
+		.await
+		.map_err(|e| {
+			// Reuse a single generic message so an attacker cannot
+			// discriminate "invalid state" from "code exchange failure"
+			// from logs / response bodies.
+			error!("handle_callback({provider}) failed: {e}");
+			AppError::Authentication("OAuth flow failed".to_string())
+		})?;
+
+	let claims = cb.claims.ok_or_else(|| {
+		error!("provider {provider} returned no user-info claims");
+		AppError::Internal("provider returned no user info".to_string())
+	})?;
+
+	let storage = OrmSocialAccountStorage::new();
+	let user = link_or_create_user(&storage, &provider, &claims, None)
+		.await
+		.map_err(|e| {
+			error!("OAuth linking for {provider} failed: {e}");
+			AppError::Internal("account linking failed".to_string())
+		})?;
+
+	let session_id = create_session(&user).await.map_err(|e| {
+		error!("session creation after OAuth failed: {e}");
+		AppError::Internal("session creation failed".to_string())
+	})?;
+
+	let is_debug = crate::config::settings::get_settings().core.debug;
+	let secure_flag = if is_debug { "" } else { "; Secure" };
+	let cookie =
+		format!("sessionid={session_id}; HttpOnly; SameSite=Lax; Path=/{secure_flag}; Max-Age=86400");
+
+	Ok(Response::new(StatusCode::FOUND)
+		.with_header("Location", "/")
+		.with_header("Set-Cookie", &cookie))
+}

--- a/dashboard/src/apps/auth/views/oauth/providers.rs
+++ b/dashboard/src/apps/auth/views/oauth/providers.rs
@@ -1,0 +1,52 @@
+//! `GET /oauth/providers/` — discovery endpoint.
+//!
+//! Returns a JSON list of currently-enabled OAuth providers so the WASM
+//! client can render only the buttons that have credentials configured.
+//! Crucially, this endpoint MUST NOT leak any provider secrets, redirect
+//! URIs, or client IDs into the response — it ships only `id` (lowercase
+//! provider slug) and `label` (the human-readable button text).
+
+use reinhardt::core::exception::Error as AppError;
+use reinhardt::core::serde::json;
+use reinhardt::http::ViewResult;
+use reinhardt::{Response, StatusCode, get};
+use serde::Serialize;
+
+use crate::apps::auth::services::oauth::config::OAuthSettings;
+
+#[derive(Debug, Serialize)]
+pub struct ProviderEntry {
+	pub id: &'static str,
+	pub label: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProvidersResponse {
+	pub providers: Vec<ProviderEntry>,
+}
+
+/// Map a provider id to its human label. Lowercase ids only — the slug is
+/// the canonical identifier used in URLs.
+pub fn label_for(id: &str) -> &'static str {
+	match id {
+		"github" => "GitHub",
+		_ => "OAuth",
+	}
+}
+
+#[get("/oauth/providers/", name = "oauth_providers")]
+pub async fn oauth_providers() -> ViewResult<Response> {
+	let settings = OAuthSettings::from_env();
+	let providers: Vec<ProviderEntry> = settings
+		.enabled_provider_ids()
+		.into_iter()
+		.map(|id| ProviderEntry {
+			id,
+			label: label_for(id),
+		})
+		.collect();
+	let resp = ProvidersResponse { providers };
+	Ok(Response::new(StatusCode::OK)
+		.with_header("Content-Type", "application/json")
+		.with_body(json::to_vec(&resp).map_err(AppError::from)?))
+}

--- a/dashboard/src/apps/auth/views/oauth/start.rs
+++ b/dashboard/src/apps/auth/views/oauth/start.rs
@@ -1,0 +1,47 @@
+//! `GET /oauth/{provider}/start/` — kick off the OAuth authorization flow.
+//!
+//! Builds the provider's authorization URL via `SocialAuthBackend::begin_auth`
+//! (which generates a fresh `state`, persists it with PKCE verifier in the
+//! state store, and returns the URL to redirect the browser to). Replies
+//! with a `302 Found` to that URL.
+//!
+//! `provider` is rejected as 404 when not enabled in `OAuthSettings`,
+//! preventing requests for `/oauth/twitter/start/` etc. from reaching the
+//! framework's provider registry where they would surface as a 500.
+
+use reinhardt::core::exception::Error as AppError;
+use reinhardt::http::ViewResult;
+use reinhardt::{Path, Response, StatusCode, get};
+use tracing::error;
+
+use crate::apps::auth::services::oauth::backend::build_social_auth_backend;
+use crate::apps::auth::services::oauth::config::OAuthSettings;
+
+#[get("/oauth/{provider}/start/", name = "oauth_start")]
+pub async fn oauth_start(Path(provider): Path<String>) -> ViewResult<Response> {
+	let settings = OAuthSettings::from_env();
+	if settings.get(&provider).is_none() {
+		return Err(AppError::NotFound(format!(
+			"OAuth provider not enabled: {provider}"
+		)));
+	}
+
+	let backend = build_social_auth_backend(&settings)
+		.await
+		.map_err(|e| {
+			error!("OAuth backend init failed: {e}");
+			AppError::Internal("OAuth not available".to_string())
+		})?
+		.ok_or_else(|| AppError::NotFound("OAuth not configured".to_string()))?;
+
+	// `begin_auth` with `None`/`None` lets reinhardt-auth generate a fresh
+	// state (cryptographically random) and a PKCE verifier internally. The
+	// verifier is persisted into the state store keyed by state and is
+	// transparently consumed by `handle_callback`.
+	let result = backend.begin_auth(&provider, None, None).await.map_err(|e| {
+		error!("begin_auth({provider}) failed: {e}");
+		AppError::Internal("OAuth start failed".to_string())
+	})?;
+
+	Ok(Response::new(StatusCode::FOUND).with_header("Location", &result.authorization_url))
+}

--- a/dashboard/src/apps/auth/views/oauth/unlink.rs
+++ b/dashboard/src/apps/auth/views/oauth/unlink.rs
@@ -1,0 +1,73 @@
+//! `POST /oauth/{provider}/unlink/` — remove the link to a social provider.
+//!
+//! Authentication is required (caller must already be logged in via session
+//! cookie or JWT). Lockout protection: if the user has no usable password
+//! AND this is their last social link, the request is rejected with 422 so
+//! the user cannot accidentally make their account unreachable.
+
+use reinhardt::core::exception::Error as AppError;
+use reinhardt::core::serde::json;
+use reinhardt::db::orm::{FilterOperator, FilterValue, Model};
+use reinhardt::http::ViewResult;
+use reinhardt::{AuthInfo, Path, Response, StatusCode, post};
+use reinhardt_auth::social::storage::SocialAccountStorage;
+use tracing::error;
+use uuid::Uuid;
+
+use crate::apps::auth::models::User;
+use crate::apps::auth::services::oauth::storage::OrmSocialAccountStorage;
+
+#[post("/oauth/{provider}/unlink/", name = "oauth_unlink")]
+pub async fn oauth_unlink(
+	Path(provider): Path<String>,
+	#[inject] AuthInfo(state): AuthInfo,
+) -> ViewResult<Response> {
+	let user_id = Uuid::parse_str(state.user_id())
+		.map_err(|e| AppError::Authentication(format!("invalid user_id in token: {e}")))?;
+
+	let user = User::objects()
+		.filter(
+			User::field_id(),
+			FilterOperator::Eq,
+			FilterValue::String(user_id.to_string()),
+		)
+		.first()
+		.await
+		.map_err(|e| {
+			error!("user lookup failed during unlink: {e}");
+			AppError::Internal("user lookup failed".to_string())
+		})?
+		.ok_or_else(|| AppError::NotFound("user not found".to_string()))?;
+
+	let storage = OrmSocialAccountStorage::new();
+	let links = storage.find_by_user(user_id).await.map_err(|e| {
+		error!("storage list failed during unlink: {e}");
+		AppError::Internal("storage list failed".to_string())
+	})?;
+
+	let target = links
+		.iter()
+		.find(|l| l.provider == provider)
+		.ok_or_else(|| AppError::NotFound(format!("no link to provider: {provider}")))?;
+
+	// Lockout protection: if the user has no usable password AND this is
+	// their only social link, deleting it would lock them out of the
+	// account. Refuse with a 422 so the client can prompt them to set a
+	// password first.
+	if user.password_hash.is_none() && links.len() == 1 {
+		return Err(AppError::Validation(
+			"cannot unlink the last sign-in method; set a password before unlinking"
+				.to_string(),
+		));
+	}
+
+	storage.delete(target.id).await.map_err(|e| {
+		error!("storage delete failed during unlink: {e}");
+		AppError::Internal("storage delete failed".to_string())
+	})?;
+
+	let body = json::to_vec(&serde_json::json!({"success": true, "provider": provider}))?;
+	Ok(Response::new(StatusCode::OK)
+		.with_header("Content-Type", "application/json")
+		.with_body(body))
+}


### PR DESCRIPTION
## Summary

Implements the backend half of GitHub social login from #428: env-driven
provider configuration, the `SocialAuthBackend` factory, account-linking
semantics, and four REST endpoints (`start`, `callback`, `unlink`,
`providers` discovery).

GitLab support has been moved to follow-up issue #440 — `reinhardt-auth
v0.1.0-rc.22` ships only GitHub/Google/Apple/Microsoft providers and
no `GenericOidcProvider`, so GitLab cannot be wired without an upstream
change (tracked as `kent8192/reinhardt-web#3986` and Reinhardt Cloud
tracking issue #439).

The WASM client UI and end-to-end OAuth tests land in a separate PR
(PR-B). This PR alone does not yet close #428; it ships the Rust-side
contract.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Motivation and Context

Reinhardt Cloud is a developer-facing PaaS whose evaluators already hold
GitHub accounts. The first phase of #428 (PRs #437 and #438) shipped
the persistence layer (`SocialAccount` ORM model + `OrmSocialAccountStorage`).
This PR fills in the remaining backend layers so the next PR can wire
the buttons in the WASM login UI.

Per the implementation plan in
`/Users/kent8192/.claude/plans/phase-indexed-stallman.md`:

- Settings: `REINHARDT_CLOUD_OAUTH_GITHUB_{CLIENT_ID,CLIENT_SECRET,REDIRECT_URI}`
- StateStore: `InMemoryStateStore` (production-grade Redis StateStore
  blocked on the upstream issue mentioned above; symptoms are limited
  to occasional `InvalidState` retries in multi-pod deployments while
  the framework only ships a synchronous `SessionBackend`-bound
  `SessionStateStore` and `RedisSessionBackend` is async-only)
- Linking: four-way decision tree from #428 (already-linked /
  authenticated link / email-verified match / new user) plus a
  defensive `EmailConflict` branch for the unverified-email-collision
  case
- Endpoints: 4 routes registered under `/api/auth/oauth/...`

## How Was This Tested?

- `cargo make fmt-check`
- `cargo make clippy-check`
- `cargo nextest run -p reinhardt-cloud-dashboard test_oauth_settings` — 5/5 passed
- `cargo nextest run -p reinhardt-cloud-dashboard test_oauth_providers_view` — 6/6 passed
- `cargo nextest run -p reinhardt-cloud-dashboard test_oauth_backend` — 2/2 passed
- Integration tests for `link_or_create_user` (Postgres TestContainer):
  6 scenarios covering already-linked, authenticated link, email-verified
  match, email-unverified collision (refused with `EmailConflict`),
  new-user creation, and username-collision suffixing — running in CI
  (last local run interrupted by competing nextest processes; the
  email-collision crash that triggered the d3a3909d fix has been
  re-tested in isolation)

## Checklist

- [x] Code follows project style guidelines (rustfmt + clippy clean with
      `-D warnings` workspace-wide)
- [x] Self-reviewed
- [x] No new warnings
- [x] Tests added covering the new contracts (settings parsing, factory
      short-circuit, account-linking decision tree, providers discovery
      no-leak)
- [x] All existing unit tests pass locally
- [x] Dependent changes merged: #437 (SocialAccount model) and #438
      (OrmSocialAccountStorage) both on `main`
- [x] OAuth env-vars documented inline in `services/oauth/config.rs`
      rustdoc

## Labels to Apply

- `enhancement`
- `documentation`
- `dashboard`

## Related Issues

Refs #428 (this PR delivers Phase 3-6 of the GitHub-only scope; PR-B
will close it once the WASM UI and e2e tests land).
Refs #440 (GitLab follow-up — out of scope here).
Refs #439 (upstream tracking — out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)