### PR TITLE
ci: add WASM build check for dashboard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,15 @@ jobs:
       runner: ${{ needs.determine-runner.outputs.runner }}
       cargo-build-jobs: ${{ needs.determine-runner.outputs.cargo-build-jobs }}
 
+  wasm-build:
+    name: WASM Build
+    needs: [determine-runner, check-branch-status]
+    if: needs.check-branch-status.outputs.has-conflicts != 'true'
+    uses: ./.github/workflows/wasm-build.yml
+    with:
+      runner: ${{ needs.determine-runner.outputs.runner }}
+      cargo-build-jobs: ${{ needs.determine-runner.outputs.cargo-build-jobs }}
+
   unit-test:
     name: Unit Tests
     needs: [fmt, clippy, determine-runner, check-branch-status]
@@ -246,6 +255,7 @@ jobs:
       - determine-runner
       - fmt
       - clippy
+      - wasm-build
       - unit-test
       - intra-crate-integration-test
       - cross-crate-integration-test
@@ -262,6 +272,7 @@ jobs:
           HAS_CONFLICTS: ${{ needs.check-branch-status.outputs.has-conflicts }}
           FMT_RESULT: ${{ needs.fmt.result }}
           CLIPPY_RESULT: ${{ needs.clippy.result }}
+          WASM_BUILD_RESULT: ${{ needs.wasm-build.result }}
           UNIT_TEST_RESULT: ${{ needs.unit-test.result }}
           INTRA_CRATE_RESULT: ${{ needs.intra-crate-integration-test.result }}
           CROSS_CRATE_RESULT: ${{ needs.cross-crate-integration-test.result }}
@@ -284,6 +295,7 @@ jobs:
           always_required=(
             "fmt:$FMT_RESULT"
             "clippy:$CLIPPY_RESULT"
+            "wasm-build:$WASM_BUILD_RESULT"
             "unit-test:$UNIT_TEST_RESULT"
             "intra-crate-integration-test:$INTRA_CRATE_RESULT"
             "cross-crate-integration-test:$CROSS_CRATE_RESULT"

--- a/.github/workflows/wasm-build.yml
+++ b/.github/workflows/wasm-build.yml
@@ -1,0 +1,61 @@
+name: WASM Build
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        description: 'Runner label JSON. Use "\"ubuntu-latest\"" for GitHub-hosted or "[\"self-hosted\",\"linux\",\"arm64\",\"reinhardt-cloud-ci\"]" for self-hosted.'
+        type: string
+        default: '"ubuntu-latest"'
+      cargo-build-jobs:
+        description: "Parallel cargo build jobs (1=GitHub-hosted OOM safe, 8=self-hosted)"
+        type: string
+        default: "1"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  CARGO_TARGET_DIR: /tmp/cargo_target
+  CARGO_INCREMENTAL: 0
+  CARGO_BUILD_JOBS: ${{ inputs.cargo-build-jobs || '1' }}
+
+jobs:
+  wasm-build:
+    name: WASM Build (dashboard)
+    runs-on: ${{ fromJSON(inputs.runner || '"ubuntu-latest"') }}
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          # Differentiate cache from native-target jobs sharing CARGO_TARGET_DIR.
+          cache-key: wasm32
+
+      # The reusable setup-rust action does not accept a `targets` input,
+      # so add the wasm32 target explicitly after the toolchain is installed.
+      - name: Add wasm32-unknown-unknown target
+        shell: bash
+        run: rustup target add wasm32-unknown-unknown
+
+      # Defensive: clippy.yml installs protoc because some workspace deps
+      # require it. The dashboard's wasm graph excludes tonic/prost via
+      # `cfg(not(target_arch = "wasm32"))`, but cargo may still resolve
+      # build scripts for shared workspace members during metadata
+      # collection, so install protoc to match the rest of CI.
+      - name: Install protoc
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install cargo-make
+        uses: taiki-e/install-action@de6bbd1333b8f331563d54a051e542c7dfef81c3 # v2
+        with:
+          tool: cargo-make
+
+      - name: Build dashboard for wasm32-unknown-unknown
+        working-directory: dashboard
+        run: cargo make wasm-compile-dev


### PR DESCRIPTION
## 🚧 Blocked

**Blocked by the sibling fix PR #451 (`fix/issue-447-wasm-build`)** — that PR must merge first or this CI job will fail. This PR is intentionally opened as a **draft** until #451 merges. After #451 lands, the worktree-based merge strategy (CR-1) will be used to incorporate `main` into this branch, after which it will be marked ready for review.

## Summary

This PR addresses:

- Add a new reusable workflow `.github/workflows/wasm-build.yml` that compiles the dashboard for `wasm32-unknown-unknown` via `cargo make wasm-compile-dev`.
- Wire the new job into `.github/workflows/ci.yml` alongside `fmt` and `clippy`, and add it to the `ci-success` `always_required` aggregator so it must pass for CI to be green.
- Closes the regression-prevention gap that allowed issue #447 (broken WASM build on `main`) to ship undetected.

## Type of Change

- [x] CI/CD changes
- [x] Bug fix (non-breaking change that fixes an issue) — completes the fix for #447 by preventing the regression class

## Motivation and Context

The dashboard ships a wasm frontend in production (`crate-type = ["cdylib", "rlib"]`, with WASM-only deps under `cfg(target_arch = "wasm32")`). However, **no CI workflow built the crate for `wasm32-unknown-unknown`**, so breakages like #447 could land on `main` silently. PR-1 (`fix/issue-447-wasm-build`) restores the build; this PR ensures it stays green.

Fixes #447

## How Was This Tested?

- Inspected each existing reusable workflow (`fmt.yml`, `clippy.yml`, `cross-platform-check.yml`) and modeled `wasm-build.yml` after `clippy.yml` (the closest sibling — uses `protoc`, `CARGO_TARGET_DIR`, `CARGO_INCREMENTAL=0`, `CARGO_BUILD_JOBS`).
- Read `.github/actions/setup-rust/action.yml`: confirmed it does **not** accept a `targets` input. Added an explicit `rustup target add wasm32-unknown-unknown` step after `setup-rust`.
- Read `dashboard/Makefile.toml` to confirm `wasm-compile-dev` is `cargo build --lib --target wasm32-unknown-unknown` (no extra tooling needed for compile-only validation).
- Used a `cache-key: wasm32` suffix on `setup-rust` so the wasm-target build does not collide with native-target jobs sharing `CARGO_TARGET_DIR`.
- Validated YAML syntax of both `wasm-build.yml` and the modified `ci.yml` with `yq` (parses cleanly; new job is present in `.jobs.ci-success.needs`).
- This PR's CI **will fail until #451 merges**, because the wasm build itself is broken on `main` (fixed by #451). That is exactly the bug this gate is designed to catch — see the Blocked notice above.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable) — n/a, CI workflow only
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works — the workflow itself is the regression test
- [ ] New and existing unit tests pass locally with my changes — n/a, no Rust source changed
- [x] I have formatted the code with `cargo make fmt-fix` — n/a, no Rust source changed
- [x] I have checked the code with `cargo make clippy-check` — n/a, no Rust source changed
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

Fixes #447

## Labels to Apply

### Type Label
- [x] `enhancement` — adds a new CI gate

### Scope Label
- [x] `ci-cd` — CI/CD workflow changes

---

**Additional Context:**

- Defensive `protoc` install: the dashboard's wasm dep graph excludes `tonic`/`prost` (gated under `cfg(not(target_arch = "wasm32"))`), but cargo may still resolve build scripts for shared workspace members during metadata collection. Including `protoc` matches `clippy.yml` and avoids surprises.
- The wasm build runs `cargo build --lib --target wasm32-unknown-unknown` only; it does NOT install `wasm-bindgen-cli` or run `wasm-bindgen` (those are part of the dev/release pipelines, not the compile gate). Compile-only is sufficient to catch the breakage class in #447.

🤖 Generated with [Claude Code](https://claude.com/claude-code)