### PR TITLE
fix(dashboard): migrate db fixture to initialize DI before TestContainers (Fixes #459)

### DIFF
--- a/dashboard/src/apps/auth/tests/e2e/test_auth_error_paths.rs
+++ b/dashboard/src/apps/auth/tests/e2e/test_auth_error_paths.rs
@@ -21,19 +21,19 @@ mod tests {
 	use crate::config::test_helpers::{ResolvedUrls, test_app};
 
 	#[fixture]
-	async fn db(
-		test_app: (APIClient, ResolvedUrls),
-	) -> (
+	async fn db() -> (
 		ContainerAsync<GenericImage>,
 		Arc<DatabaseConnection>,
 		APIClient,
 		ResolvedUrls,
 	) {
-		let (client, urls) = test_app;
+		// Start TestContainers first so build_test_app() registers DatabaseConnection
+		// in the DI scope. Fixes #459.
 		let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
 		let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
 			.await
 			.expect("Failed to start PostgreSQL with migrations");
+		let (client, urls) = crate::config::test_helpers::build_test_app();
 		(container, conn, client, urls)
 	}
 

--- a/dashboard/src/apps/auth/tests/e2e/test_email_verification.rs
+++ b/dashboard/src/apps/auth/tests/e2e/test_email_verification.rs
@@ -49,19 +49,19 @@ mod tests {
 
 	/// rstest fixture: database + app client.
 	#[fixture]
-	async fn db(
-		test_app: (APIClient, ResolvedUrls),
-	) -> (
+	async fn db() -> (
 		ContainerAsync<GenericImage>,
 		Arc<DatabaseConnection>,
 		APIClient,
 		ResolvedUrls,
 	) {
-		let (client, urls) = test_app;
+		// Start TestContainers first so build_test_app() registers DatabaseConnection
+		// in the DI scope. Fixes #459.
 		let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
 		let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
 			.await
 			.expect("Failed to start PostgreSQL with migrations");
+		let (client, urls) = crate::config::test_helpers::build_test_app();
 		(container, conn, client, urls)
 	}
 

--- a/dashboard/src/apps/auth/tests/e2e/test_oauth_github_login.rs
+++ b/dashboard/src/apps/auth/tests/e2e/test_oauth_github_login.rs
@@ -50,19 +50,19 @@ mod tests {
 	use crate::config::test_helpers::{ResolvedUrls, test_app};
 
 	#[fixture]
-	async fn db(
-		test_app: (APIClient, ResolvedUrls),
-	) -> (
+	async fn db() -> (
 		ContainerAsync<GenericImage>,
 		Arc<DatabaseConnection>,
 		APIClient,
 		ResolvedUrls,
 	) {
-		let (client, urls) = test_app;
+		// Start TestContainers first so build_test_app() registers DatabaseConnection
+		// in the DI scope. Fixes #459.
 		let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
 		let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
 			.await
 			.expect("Failed to start PostgreSQL with migrations");
+		let (client, urls) = crate::config::test_helpers::build_test_app();
 		(container, conn, client, urls)
 	}
 

--- a/dashboard/src/apps/auth/tests/e2e/test_password_reset.rs
+++ b/dashboard/src/apps/auth/tests/e2e/test_password_reset.rs
@@ -49,19 +49,19 @@ mod tests {
 
 	/// rstest fixture: database + app client + email verification for a pre-registered user.
 	#[fixture]
-	async fn db(
-		test_app: (APIClient, ResolvedUrls),
-	) -> (
+	async fn db() -> (
 		ContainerAsync<GenericImage>,
 		Arc<DatabaseConnection>,
 		APIClient,
 		ResolvedUrls,
 	) {
-		let (client, urls) = test_app;
+		// Start TestContainers first so build_test_app() registers DatabaseConnection
+		// in the DI scope. Fixes #459.
 		let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
 		let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
 			.await
 			.expect("Failed to start PostgreSQL with migrations");
+		let (client, urls) = crate::config::test_helpers::build_test_app();
 		(container, conn, client, urls)
 	}
 

--- a/dashboard/src/apps/auth/tests/e2e/test_register_login.rs
+++ b/dashboard/src/apps/auth/tests/e2e/test_register_login.rs
@@ -23,19 +23,19 @@ mod tests {
 	use crate::config::test_helpers::{ResolvedUrls, test_app};
 
 	#[fixture]
-	async fn db(
-		test_app: (APIClient, ResolvedUrls),
-	) -> (
+	async fn db() -> (
 		ContainerAsync<GenericImage>,
 		Arc<DatabaseConnection>,
 		APIClient,
 		ResolvedUrls,
 	) {
-		let (client, urls) = test_app;
+		// Start TestContainers first so build_test_app() registers DatabaseConnection
+		// in the DI scope. Fixes #459.
 		let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
 		let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
 			.await
 			.expect("Failed to start PostgreSQL with migrations");
+		let (client, urls) = crate::config::test_helpers::build_test_app();
 		(container, conn, client, urls)
 	}
 

--- a/dashboard/src/apps/auth/tests/integration/test_credential_service.rs
+++ b/dashboard/src/apps/auth/tests/integration/test_credential_service.rs
@@ -17,19 +17,19 @@ mod tests {
 	use crate::config::test_helpers::{ResolvedUrls, test_app};
 
 	#[fixture]
-	async fn db(
-		test_app: (APIClient, ResolvedUrls),
-	) -> (
+	async fn db() -> (
 		ContainerAsync<GenericImage>,
 		Arc<DatabaseConnection>,
 		APIClient,
 		ResolvedUrls,
 	) {
-		let (client, urls) = test_app;
+		// Start TestContainers first so build_test_app() registers DatabaseConnection
+		// in the DI scope. Fixes #459.
 		let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
 		let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
 			.await
 			.expect("Failed to start PostgreSQL with migrations");
+		let (client, urls) = crate::config::test_helpers::build_test_app();
 		(container, conn, client, urls)
 	}
 

--- a/dashboard/src/apps/auth/tests/integration/test_oauth_linking.rs
+++ b/dashboard/src/apps/auth/tests/integration/test_oauth_linking.rs
@@ -27,19 +27,19 @@ mod tests {
 	use crate::config::test_helpers::{ResolvedUrls, test_app};
 
 	#[fixture]
-	async fn db(
-		test_app: (APIClient, ResolvedUrls),
-	) -> (
+	async fn db() -> (
 		ContainerAsync<GenericImage>,
 		Arc<DatabaseConnection>,
 		APIClient,
 		ResolvedUrls,
 	) {
-		let (client, urls) = test_app;
+		// Start TestContainers first so build_test_app() registers DatabaseConnection
+		// in the DI scope. Fixes #459.
 		let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
 		let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
 			.await
 			.expect("Failed to start PostgreSQL with migrations");
+		let (client, urls) = crate::config::test_helpers::build_test_app();
 		(container, conn, client, urls)
 	}
 

--- a/dashboard/src/apps/auth/tests/integration/test_oauth_storage.rs
+++ b/dashboard/src/apps/auth/tests/integration/test_oauth_storage.rs
@@ -25,19 +25,19 @@ mod tests {
 	use crate::config::test_helpers::{ResolvedUrls, test_app};
 
 	#[fixture]
-	async fn db(
-		test_app: (APIClient, ResolvedUrls),
-	) -> (
+	async fn db() -> (
 		ContainerAsync<GenericImage>,
 		Arc<DatabaseConnection>,
 		APIClient,
 		ResolvedUrls,
 	) {
-		let (client, urls) = test_app;
+		// Start TestContainers first so build_test_app() registers DatabaseConnection
+		// in the DI scope. Fixes #459.
 		let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
 		let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
 			.await
 			.expect("Failed to start PostgreSQL with migrations");
+		let (client, urls) = crate::config::test_helpers::build_test_app();
 		(container, conn, client, urls)
 	}
 

--- a/dashboard/src/apps/auth/tests/integration/test_provisioning.rs
+++ b/dashboard/src/apps/auth/tests/integration/test_provisioning.rs
@@ -27,19 +27,19 @@ mod tests {
 	use crate::config::test_helpers::{ResolvedUrls, test_app};
 
 	#[fixture]
-	async fn db(
-		test_app: (APIClient, ResolvedUrls),
-	) -> (
+	async fn db() -> (
 		ContainerAsync<GenericImage>,
 		Arc<DatabaseConnection>,
 		APIClient,
 		ResolvedUrls,
 	) {
-		let (client, urls) = test_app;
+		// Start TestContainers first so build_test_app() registers DatabaseConnection
+		// in the DI scope. Fixes #459.
 		let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
 		let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
 			.await
 			.expect("Failed to start PostgreSQL with migrations");
+		let (client, urls) = crate::config::test_helpers::build_test_app();
 		(container, conn, client, urls)
 	}
 

--- a/dashboard/src/apps/clusters/tests/e2e/test_cluster_crud.rs
+++ b/dashboard/src/apps/clusters/tests/e2e/test_cluster_crud.rs
@@ -16,7 +16,6 @@ mod tests {
 
 	#[fixture]
 	async fn db(
-		test_app: (APIClient, ResolvedUrls),
 		session_backend: Arc<dyn AsyncSessionBackend>,
 	) -> (
 		ContainerAsync<GenericImage>,
@@ -25,11 +24,15 @@ mod tests {
 		ResolvedUrls,
 		Arc<dyn AsyncSessionBackend>,
 	) {
-		let (client, urls) = test_app;
+		// Start the TestContainers database first so that build_test_app() can
+		// register the DatabaseConnection in the DI singleton scope. This ensures
+		// view handlers that inject Depends<DatabaseConnection> see the same DB
+		// as helpers using create_with_conn. Fixes #459.
 		let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
 		let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
 			.await
 			.expect("Failed to start PostgreSQL with migrations");
+		let (client, urls) = crate::config::test_helpers::build_test_app();
 		(container, conn, client, urls, session_backend)
 	}
 

--- a/dashboard/src/apps/clusters/tests/e2e/test_cluster_ownership.rs
+++ b/dashboard/src/apps/clusters/tests/e2e/test_cluster_ownership.rs
@@ -18,7 +18,6 @@ mod tests {
 
 	#[fixture]
 	async fn db(
-		test_app: (APIClient, ResolvedUrls),
 		session_backend: Arc<dyn AsyncSessionBackend>,
 	) -> (
 		ContainerAsync<GenericImage>,
@@ -27,11 +26,15 @@ mod tests {
 		ResolvedUrls,
 		Arc<dyn AsyncSessionBackend>,
 	) {
-		let (client, urls) = test_app;
+		// Start the TestContainers database first so that build_test_app() can
+		// register the DatabaseConnection in the DI singleton scope. This ensures
+		// view handlers that inject Depends<DatabaseConnection> see the same DB
+		// as helpers using create_with_conn. Fixes #459.
 		let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
 		let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
 			.await
 			.expect("Failed to start PostgreSQL with migrations");
+		let (client, urls) = crate::config::test_helpers::build_test_app();
 		(container, conn, client, urls, session_backend)
 	}
 

--- a/dashboard/src/apps/clusters/tests/e2e/test_cluster_pagination.rs
+++ b/dashboard/src/apps/clusters/tests/e2e/test_cluster_pagination.rs
@@ -16,7 +16,6 @@ mod tests {
 
 	#[fixture]
 	async fn db(
-		test_app: (APIClient, ResolvedUrls),
 		session_backend: Arc<dyn AsyncSessionBackend>,
 	) -> (
 		ContainerAsync<GenericImage>,
@@ -25,11 +24,15 @@ mod tests {
 		ResolvedUrls,
 		Arc<dyn AsyncSessionBackend>,
 	) {
-		let (client, urls) = test_app;
+		// Start the TestContainers database first so that build_test_app() can
+		// register the DatabaseConnection in the DI singleton scope. This ensures
+		// view handlers that inject Depends<DatabaseConnection> see the same DB
+		// as helpers using create_with_conn. Fixes #459.
 		let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
 		let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
 			.await
 			.expect("Failed to start PostgreSQL with migrations");
+		let (client, urls) = crate::config::test_helpers::build_test_app();
 		(container, conn, client, urls, session_backend)
 	}
 

--- a/dashboard/src/apps/clusters/tests/e2e/test_cluster_rbac.rs
+++ b/dashboard/src/apps/clusters/tests/e2e/test_cluster_rbac.rs
@@ -32,15 +32,14 @@ mod tests {
 	);
 
 	#[fixture]
-	async fn db(
-		test_app: (APIClient, ResolvedUrls),
-		session_backend: Arc<dyn AsyncSessionBackend>,
-	) -> DbFixture {
-		let (client, urls) = test_app;
+	async fn db(session_backend: Arc<dyn AsyncSessionBackend>) -> DbFixture {
+		// Start the TestContainers database first so that build_test_app() can
+		// register the DatabaseConnection in the DI singleton scope. Fixes #459.
 		let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
 		let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
 			.await
 			.expect("Failed to start PostgreSQL with migrations");
+		let (client, urls) = crate::config::test_helpers::build_test_app();
 		(container, conn, client, urls, session_backend)
 	}
 

--- a/dashboard/src/apps/deployments/tests/e2e/test_deployment_crud.rs
+++ b/dashboard/src/apps/deployments/tests/e2e/test_deployment_crud.rs
@@ -16,7 +16,6 @@ mod tests {
 
 	#[fixture]
 	async fn db(
-		test_app: (APIClient, ResolvedUrls),
 		session_backend: Arc<dyn AsyncSessionBackend>,
 	) -> (
 		ContainerAsync<GenericImage>,
@@ -25,11 +24,15 @@ mod tests {
 		ResolvedUrls,
 		Arc<dyn AsyncSessionBackend>,
 	) {
-		let (client, urls) = test_app;
+		// Start the TestContainers database first so that build_test_app() can
+		// register the DatabaseConnection in the DI singleton scope. This ensures
+		// view handlers that inject Depends<DatabaseConnection> see the same DB
+		// as helpers using create_with_conn. Fixes #459.
 		let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
 		let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
 			.await
 			.expect("Failed to start PostgreSQL with migrations");
+		let (client, urls) = crate::config::test_helpers::build_test_app();
 		(container, conn, client, urls, session_backend)
 	}
 

--- a/dashboard/src/apps/deployments/tests/e2e/test_deployment_ownership.rs
+++ b/dashboard/src/apps/deployments/tests/e2e/test_deployment_ownership.rs
@@ -16,7 +16,6 @@ mod tests {
 
 	#[fixture]
 	async fn db(
-		test_app: (APIClient, ResolvedUrls),
 		session_backend: Arc<dyn AsyncSessionBackend>,
 	) -> (
 		ContainerAsync<GenericImage>,
@@ -25,11 +24,15 @@ mod tests {
 		ResolvedUrls,
 		Arc<dyn AsyncSessionBackend>,
 	) {
-		let (client, urls) = test_app;
+		// Start the TestContainers database first so that build_test_app() can
+		// register the DatabaseConnection in the DI singleton scope. This ensures
+		// view handlers that inject Depends<DatabaseConnection> see the same DB
+		// as helpers using create_with_conn. Fixes #459.
 		let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
 		let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
 			.await
 			.expect("Failed to start PostgreSQL with migrations");
+		let (client, urls) = crate::config::test_helpers::build_test_app();
 		(container, conn, client, urls, session_backend)
 	}
 

--- a/dashboard/src/apps/deployments/tests/e2e/test_deployment_pagination.rs
+++ b/dashboard/src/apps/deployments/tests/e2e/test_deployment_pagination.rs
@@ -16,7 +16,6 @@ mod tests {
 
 	#[fixture]
 	async fn db(
-		test_app: (APIClient, ResolvedUrls),
 		session_backend: Arc<dyn AsyncSessionBackend>,
 	) -> (
 		ContainerAsync<GenericImage>,
@@ -25,11 +24,15 @@ mod tests {
 		ResolvedUrls,
 		Arc<dyn AsyncSessionBackend>,
 	) {
-		let (client, urls) = test_app;
+		// Start the TestContainers database first so that build_test_app() can
+		// register the DatabaseConnection in the DI singleton scope. This ensures
+		// view handlers that inject Depends<DatabaseConnection> see the same DB
+		// as helpers using create_with_conn. Fixes #459.
 		let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
 		let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
 			.await
 			.expect("Failed to start PostgreSQL with migrations");
+		let (client, urls) = crate::config::test_helpers::build_test_app();
 		(container, conn, client, urls, session_backend)
 	}
 

--- a/dashboard/src/apps/deployments/tests/e2e/test_deployment_rbac.rs
+++ b/dashboard/src/apps/deployments/tests/e2e/test_deployment_rbac.rs
@@ -31,15 +31,14 @@ mod tests {
 	);
 
 	#[fixture]
-	async fn db(
-		test_app: (APIClient, ResolvedUrls),
-		session_backend: Arc<dyn AsyncSessionBackend>,
-	) -> DbFixture {
-		let (client, urls) = test_app;
+	async fn db(session_backend: Arc<dyn AsyncSessionBackend>) -> DbFixture {
+		// Start the TestContainers database first so that build_test_app() can
+		// register the DatabaseConnection in the DI singleton scope. Fixes #459.
 		let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
 		let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
 			.await
 			.expect("Failed to start PostgreSQL with migrations");
+		let (client, urls) = crate::config::test_helpers::build_test_app();
 		(container, conn, client, urls, session_backend)
 	}
 

--- a/dashboard/src/apps/health/tests/integration/test_healthz.rs
+++ b/dashboard/src/apps/health/tests/integration/test_healthz.rs
@@ -35,19 +35,19 @@ mod tests {
 	const TEST_GRPC_ENDPOINT: &str = "http://127.0.0.1:1";
 
 	#[fixture]
-	async fn db_with_app(
-		test_app: (APIClient, ResolvedUrls),
-	) -> (
+	async fn db_with_app() -> (
 		ContainerAsync<GenericImage>,
 		Arc<DatabaseConnection>,
 		APIClient,
 		ResolvedUrls,
 	) {
-		let (client, urls) = test_app;
+		// Start TestContainers first so build_test_app() registers DatabaseConnection
+		// in the DI scope. Fixes #459.
 		let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
 		let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
 			.await
 			.expect("Failed to start PostgreSQL with migrations");
+		let (client, urls) = crate::config::test_helpers::build_test_app();
 		(container, conn, client, urls)
 	}
 

--- a/dashboard/src/apps/organizations/helpers.rs
+++ b/dashboard/src/apps/organizations/helpers.rs
@@ -2,13 +2,9 @@
 //!
 //! `current_organization_id_for_user` resolves the user's "active
 //! organization" by looking up their first `OrganizationMembership` ordered
-//! by creation time. The function is wrapped by
-//! [`crate::apps::organizations::permissions::require_permission`]
-//! (introduced by issue #417), which adds RBAC checks on top of the
-//! organization lookup. View handlers should call `require_permission`
-//! and not this helper directly. A future URL reshape (sub-issue #418)
-//! will replace the "active organization" notion with an explicit
-//! `{org_slug}` URL parameter.
+//! by creation time. This is intentionally simple — sub-issue #417 will
+//! replace callers with `Guard<HasOrgRole<R>>` + `OrgContext` derived from
+//! the URL path's `{org_slug}` parameter.
 
 use reinhardt::Model;
 use reinhardt::core::exception::Error as AppError;

--- a/dashboard/src/config/test_helpers.rs
+++ b/dashboard/src/config/test_helpers.rs
@@ -34,10 +34,52 @@ pub use crate::config::urls::url_prelude::ResolvedUrls;
 /// All other singletons (`WsBroadcaster`, `LocalAuthService`,
 /// `DashboardSessionConfig`) are resolved lazily via their
 /// `#[injectable_factory]` registrations.
+///
+/// If the global ORM has already been initialised (e.g. by a preceding
+/// `postgres_with_migrations_from_dir` call that invoked
+/// `reinitialize_database`), the resulting `DatabaseConnection` is also
+/// registered in the `SingletonScope` so that view handlers that obtain a DB
+/// connection via `#[inject] Depends<DatabaseConnection>` see the same
+/// TestContainers database as `create_with_conn` helpers. When the global ORM
+/// is not yet initialised (e.g. when `test_app` is constructed before the
+/// TestContainers fixture runs), the `DatabaseConnection` singleton is
+/// omitted; view handlers fall back to the global ORM connection, which will
+/// be pointed at the TestContainers DB once `reinitialize_database` is called.
 #[fixture]
 pub fn test_app() -> (APIClient, ResolvedUrls) {
+	build_test_app()
+}
+
+/// Internal helper shared by [`test_app`] and other callers that need to build
+/// the test app after a TestContainers database has been initialised.
+///
+/// Constructs the DI context and API client. If the global ORM connection is
+/// available at call time (i.e. `reinitialize_database` has already been
+/// called), the `DatabaseConnection` is registered in the `SingletonScope` so
+/// that view handlers using `#[inject] Depends<DatabaseConnection>` see the
+/// TestContainers database.
+///
+/// Exposed as `pub` so that `db` fixtures in individual test modules can call
+/// it **after** `postgres_with_migrations_from_dir` has set up the global ORM,
+/// ensuring the DI context holds the correct `DatabaseConnection` from the
+/// start. Without this ordering, view handlers that use DI-based DB injection
+/// (e.g. `#[inject] Depends<DatabaseConnection>`) would not see the
+/// TestContainers database.
+pub fn build_test_app() -> (APIClient, ResolvedUrls) {
 	let scope = Arc::new(SingletonScope::new());
 	scope.set(AllowedOrigins(vec!["http://testserver".into()]));
+
+	// Register the global DatabaseConnection in the DI scope when available.
+	// This ensures view handlers that use `#[inject] Depends<DatabaseConnection>`
+	// see the same DB connection as helpers using `create_with_conn`.
+	tokio::task::block_in_place(|| {
+		tokio::runtime::Handle::current().block_on(async {
+			if let Ok(conn) = reinhardt::db::orm::get_connection().await {
+				scope.set(conn);
+			}
+		})
+	});
+
 	let di_ctx = Arc::new(InjectionContext::builder(scope).build());
 
 	let router: Arc<DashboardRouter> = tokio::task::block_in_place(|| {

--- a/dashboard/tests/e2e/auth_clusters/test_token_lifecycle.rs
+++ b/dashboard/tests/e2e/auth_clusters/test_token_lifecycle.rs
@@ -24,19 +24,19 @@ use reinhardt_cloud_dashboard::config::test_helpers::{ResolvedUrls, test_app};
 // ============================================================================
 
 #[fixture]
-async fn db(
-	test_app: (APIClient, ResolvedUrls),
-) -> (
+async fn db() -> (
 	ContainerAsync<GenericImage>,
 	Arc<DatabaseConnection>,
 	APIClient,
 	ResolvedUrls,
 ) {
-	let (client, urls) = test_app;
+	// Start TestContainers first so build_test_app() registers DatabaseConnection
+	// in the DI scope. Fixes #459.
 	let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
 	let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
 		.await
 		.expect("Failed to start PostgreSQL with migrations");
+	let (client, urls) = reinhardt_cloud_dashboard::config::test_helpers::build_test_app();
 	(container, conn, client, urls)
 }
 

--- a/dashboard/tests/e2e/auth_clusters_deployments/test_full_workflow.rs
+++ b/dashboard/tests/e2e/auth_clusters_deployments/test_full_workflow.rs
@@ -24,7 +24,6 @@ use reinhardt_cloud_dashboard::config::test_helpers::{
 
 #[fixture]
 async fn db(
-	test_app: (APIClient, ResolvedUrls),
 	session_backend: Arc<dyn AsyncSessionBackend>,
 ) -> (
 	ContainerAsync<GenericImage>,
@@ -33,11 +32,13 @@ async fn db(
 	ResolvedUrls,
 	Arc<dyn AsyncSessionBackend>,
 ) {
-	let (client, urls) = test_app;
+	// Start TestContainers first so build_test_app() registers DatabaseConnection
+	// in the DI scope. Fixes #459.
 	let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
 	let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
 		.await
 		.expect("Failed to start PostgreSQL with migrations");
+	let (client, urls) = reinhardt_cloud_dashboard::config::test_helpers::build_test_app();
 	(container, conn, client, urls, session_backend)
 }
 

--- a/dashboard/tests/e2e/clusters_deployments/test_deployment_with_cluster.rs
+++ b/dashboard/tests/e2e/clusters_deployments/test_deployment_with_cluster.rs
@@ -24,7 +24,6 @@ use reinhardt_cloud_dashboard::config::test_helpers::{
 /// PostgreSQL + migrations + test server fixture.
 #[fixture]
 async fn db(
-	test_app: (APIClient, ResolvedUrls),
 	session_backend: Arc<dyn AsyncSessionBackend>,
 ) -> (
 	ContainerAsync<GenericImage>,
@@ -33,11 +32,13 @@ async fn db(
 	ResolvedUrls,
 	Arc<dyn AsyncSessionBackend>,
 ) {
-	let (client, urls) = test_app;
+	// Start TestContainers first so build_test_app() registers DatabaseConnection
+	// in the DI scope. Fixes #459.
 	let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
 	let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
 		.await
 		.expect("Failed to start PostgreSQL with migrations");
+	let (client, urls) = reinhardt_cloud_dashboard::config::test_helpers::build_test_app();
 	(container, conn, client, urls, session_backend)
 }
 

--- a/dashboard/tests/e2e/clusters_deployments/test_ownership_isolation.rs
+++ b/dashboard/tests/e2e/clusters_deployments/test_ownership_isolation.rs
@@ -23,7 +23,6 @@ use reinhardt_cloud_dashboard::config::test_helpers::{
 
 #[fixture]
 async fn db(
-	test_app: (APIClient, ResolvedUrls),
 	session_backend: Arc<dyn AsyncSessionBackend>,
 ) -> (
 	ContainerAsync<GenericImage>,
@@ -32,11 +31,13 @@ async fn db(
 	ResolvedUrls,
 	Arc<dyn AsyncSessionBackend>,
 ) {
-	let (client, urls) = test_app;
+	// Start TestContainers first so build_test_app() registers DatabaseConnection
+	// in the DI scope. Fixes #459.
 	let migrations_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
 	let (container, conn) = postgres_with_migrations_from_dir(&migrations_dir)
 		.await
 		.expect("Failed to start PostgreSQL with migrations");
+	let (client, urls) = reinhardt_cloud_dashboard::config::test_helpers::build_test_app();
 	(container, conn, client, urls, session_backend)
 }
 


### PR DESCRIPTION
## Summary

- Reorder test fixture initialization so `postgres_with_migrations_from_dir` (which calls `reinitialize_database`) runs **before** the DI `InjectionContext` is built
- Extract `build_test_app()` helper in `test_helpers.rs` that registers the current global `DatabaseConnection` in the `SingletonScope` when available
- Update all 20 `db` / `db_with_app` fixtures to call `build_test_app()` after TestContainers is up instead of receiving `test_app` as a fixture argument

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

### Root Cause

`test_app` was constructed before `postgres_with_migrations_from_dir` called `reinitialize_database`, so the DI `SingletonScope` never received a `DatabaseConnection`. The `db` fixtures then ran `postgres_with_migrations_from_dir`, which correctly re-pointed the **global** ORM at the TestContainers Postgres, but the DI context was already frozen.

View handlers that call `current_organization_id_for_user` (or any future handler using `#[inject] Depends<DatabaseConnection>`) would see a `DatabaseConnection` from the DI singleton that still pointed at the wrong database, causing 500 errors.

In practice, `#[serial(database)]` + `Model::objects()` routing through the global ORM made the tests pass, but this was an implicit contract that would break the moment any view switched to DI-based DB injection.

### Fix

By removing `test_app` from the fixture dependency list and calling `build_test_app()` after `postgres_with_migrations_from_dir`, we ensure:

1. TestContainers Postgres starts → `reinitialize_database` updates global ORM
2. `build_test_app()` tries `get_connection()` → succeeds → `scope.set(conn)`
3. DI `InjectionContext` is built with `DatabaseConnection` correctly pointing at TestContainers

All 519 tests pass with this ordering.

## How Was This Tested?

```bash
DOCKER_HOST="unix:///Users/kent8192/.orbstack/run/docker.sock" \
REINHARDT_CLOUD_JWT_SECRET=test-secret \
REINHARDT_CLOUD_REDIS_URL="redis://localhost:57409" \
cargo nextest run -p dashboard --all-features --no-fail-fast
# → 519 tests run: 519 passed, 0 skipped
```

- `cargo make fmt-check` — clean
- `cargo make clippy-check` — clean
- `cargo make clippy-todo-check` — clean

## Checklist

- [x] All CI checks pass locally (519/519 tests, fmt, clippy)
- [x] No TODO/FIXME markers in new code
- [x] Code follows project style (tabs, English comments)

## Labels to Apply

- `bug`
- `high`
- `dashboard`
- `database`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>