### PR TITLE
fix(dashboard): register URL router before launching RunServerCommand directly

### DIFF
--- a/dashboard/src/lib.rs
+++ b/dashboard/src/lib.rs
@@ -20,6 +20,8 @@ pub mod apps;
 pub mod client;
 #[cfg(native)]
 pub mod config;
+#[cfg(native)]
+pub mod server;
 pub mod shared;
 #[cfg(native)]
 pub mod utils;

--- a/dashboard/src/main.rs
+++ b/dashboard/src/main.rs
@@ -17,9 +17,6 @@
 #[cfg(not(target_arch = "wasm32"))]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-	use reinhardt::commands::{BaseCommand, CommandContext, RunServerCommand};
-	use reinhardt_cloud_dashboard as _;
-
 	// SAFETY: invoked at program start before any spawned tasks read
 	// environment variables. Mirrors `src/bin/manage.rs`.
 	unsafe {
@@ -30,13 +27,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 	}
 
 	// Bind to all interfaces so the Kubernetes Service can route to us.
-	// `RunServerCommand`'s positional argument is the bind address.
-	let ctx = CommandContext::new(vec!["0.0.0.0:8000".to_string()]);
-	let cmd = RunServerCommand;
-	cmd.execute(&ctx).await.map_err(|e| {
-		eprintln!("dashboard server failed: {e}");
-		Box::<dyn std::error::Error>::from(e.to_string())
-	})
+	// `server::run` registers the router from the inventory before
+	// invoking `RunServerCommand::execute` — without that step the
+	// server binary fails immediately with "No router registered"
+	// (see kent8192/reinhardt-cloud#478).
+	reinhardt_cloud_dashboard::server::run("0.0.0.0:8000")
+		.await
+		.map_err(|e| {
+			eprintln!("dashboard server failed: {e}");
+			e
+		})
 }
 
 /// On `wasm32` the dashboard ships only its `[lib]` (cdylib) artifact.

--- a/dashboard/src/server.rs
+++ b/dashboard/src/server.rs
@@ -1,0 +1,96 @@
+//! Server entrypoint helpers shared between the production binary
+//! (`src/main.rs`) and integration tests under `tests/`.
+//!
+//! The functions here boot the HTTP server the same way the production
+//! container does: register the URL router from the `#[routes]`
+//! inventory, then drive `RunServerCommand::execute`. Sharing this code
+//! lets tests assert that the binary's startup path actually wires up a
+//! router instead of duplicating reconnaissance into a parallel
+//! implementation that drifts from production.
+
+use std::error::Error;
+
+use reinhardt::commands::{BaseCommand, CommandContext, RunServerCommand};
+use reinhardt::urls::routers::{UrlPatternsRegistration, register_router_arc};
+
+/// Walk the `#[routes]` inventory and register the (single) discovered
+/// router into the global slot that `RunServerCommand::execute` reads.
+///
+/// This function is the [WP-3] workaround replicating
+/// `reinhardt-commands`'s private `auto_register_router`. Keep the
+/// error messages aligned with the upstream copy so debugging guidance
+/// stays consistent across both call paths (CLI vs. direct binary).
+///
+// Workaround for kent8192/reinhardt-web#4055
+//   (tracked in reinhardt-cloud#479)
+//
+// `RunServerCommand::execute()` does not auto-register the URL router because
+// the `auto_register_router` helper is private to reinhardt-commands. Until
+// the upstream exposes a public auto-register or `start_server(addr)` helper,
+// we replicate the inventory walk here so direct `RunServerCommand::execute()`
+// callers also boot a usable router.
+//
+// Ideal implementation (without workaround):
+//   reinhardt::urls::routers::auto_register_router().await?;
+//   RunServerCommand.execute(&ctx).await?;
+pub async fn register_router_from_inventory() -> Result<(), Box<dyn Error>> {
+	// Collect every `#[routes]` registration the linker preserved.
+	let registrations: Vec<&UrlPatternsRegistration> =
+		inventory::iter::<UrlPatternsRegistration>().collect();
+
+	match registrations.len() {
+		0 => {
+			return Err("No URL patterns registered.\n\
+				 Add the `#[routes]` attribute to your routes function in src/config/urls.rs:\n\n\
+				 #[routes]\n\
+				 pub fn routes() -> UnifiedRouter {\n\
+				     UnifiedRouter::new()\n\
+				 }\n\n\
+				 If your project uses a library/binary split (src/lib.rs + src/bin/manage.rs),\n\
+				 the linker may silently discard route registrations from the library crate.\n\
+				 Fix: add `use your_crate_name as _;` to src/bin/manage.rs to force-link\n\
+				 the library and preserve its side-effectful route registrations."
+				.to_string()
+				.into());
+		}
+		1 => {
+			// Expected case: exactly one registration. Continue below.
+		}
+		n => {
+			return Err(format!(
+				"Multiple #[routes] functions detected ({n} found).\n\
+				 Only one function in the entire project should be annotated with #[routes].\n\n\
+				 Please ensure that:\n\
+				 1. Only one #[routes] attribute exists in your codebase\n\
+				 2. Check src/config/urls.rs and any other files that might have #[routes]\n\
+				 3. If you have multiple router configurations, combine them into a single function"
+			)
+			.into());
+		}
+	}
+
+	let registration = registrations[0];
+	let router = registration
+		.server_router_async()
+		.await
+		.map_err(|e| format!("Failed to create router from #[routes] function: {e}"))?;
+	register_router_arc(router);
+
+	Ok(())
+}
+
+/// Boot the dashboard HTTP server on `bind_addr`.
+///
+/// This is what `src/main.rs` calls in the container ENTRYPOINT and
+/// what `tests/server_startup.rs` calls to assert that the entrypoint
+/// performs router registration before delegating to
+/// `RunServerCommand`.
+pub async fn run(bind_addr: &str) -> Result<(), Box<dyn Error>> {
+	register_router_from_inventory().await?;
+
+	let ctx = CommandContext::new(vec![bind_addr.to_string()]);
+	let cmd = RunServerCommand;
+	cmd.execute(&ctx)
+		.await
+		.map_err(|e| Box::<dyn Error>::from(e.to_string()))
+}

--- a/dashboard/tests/server_startup.rs
+++ b/dashboard/tests/server_startup.rs
@@ -1,0 +1,59 @@
+//! Integration tests for the dashboard server entrypoint.
+//!
+//! These tests verify the regression captured in
+//! kent8192/reinhardt-cloud#478: launching the dashboard via
+//! `RunServerCommand::execute()` directly previously failed with
+//! `No router registered` because the inventory walk performed by
+//! `execute_from_command_line()` was being skipped.
+//!
+//! We exercise the helper that `src/main.rs` now calls in its hot
+//! path so the regression cannot reappear silently.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use reinhardt::urls::routers::{clear_router, is_router_registered};
+use reinhardt_cloud_dashboard::server;
+use rstest::rstest;
+use serial_test::serial;
+
+/// `register_router_from_inventory` is what the binary's
+/// `server::run` calls before `RunServerCommand::execute`. Asserting
+/// it on its own (rather than spawning the full server) lets the
+/// test stay deterministic and fast while still catching the
+/// `No router registered` regression directly: if the inventory walk
+/// fails, this returns `Err` and the assertion below fails.
+#[rstest]
+#[tokio::test]
+#[serial(router_global)]
+async fn register_router_from_inventory_populates_global_router_slot()
+-> Result<(), Box<dyn std::error::Error>> {
+	// Arrange — the global router slot is process-wide. A previous
+	// test may have left a router registered (or another integration
+	// test running serially in the same group), so reset to a clean
+	// "no router" state before exercising the helper.
+	clear_router();
+	assert!(
+		!is_router_registered(),
+		"precondition: global router slot must be empty before invoking the inventory walk"
+	);
+
+	// Act — drive the same code path that `dashboard/src/main.rs` runs
+	// inside the container ENTRYPOINT. If the dashboard's `#[routes]`
+	// inventory entry is missing or duplicated this returns `Err` and
+	// the test fails with a deterministic, debuggable message.
+	server::register_router_from_inventory().await?;
+
+	// Assert — the helper must have populated the global router slot
+	// that `RunServerCommand::execute` reads on startup. Without this
+	// step the binary fails with "Execution error: No router registered."
+	assert!(
+		is_router_registered(),
+		"register_router_from_inventory must register a router; \
+		 see kent8192/reinhardt-cloud#478"
+	);
+
+	// Cleanup — leave the global slot empty for the next serial test.
+	clear_router();
+
+	Ok(())
+}


### PR DESCRIPTION
## Summary

This PR addresses:

- The `reinhardt-cloud-dashboard` server binary crashed at container startup with `Execution error: No router registered.` because `RunServerCommand::execute()` skips the inventory walk that `execute_from_command_line()` performs internally — and the upstream `auto_register_router()` helper is private.
- Move the binary's startup to `dashboard::server::run` and inline the inventory walk as `server::register_router_from_inventory` so the global router slot is populated before `RunServerCommand::execute` reads it.
- Add a regression-guard integration test that asserts `is_router_registered()` becomes `true` after the helper runs.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Other: introduces a documented short-term workaround for an upstream `reinhardt-web` API gap; tracked for removal.

## Motivation and Context

`#473` shipped a thin server entrypoint binary so the auto-generated `Dockerfile` does not invoke the `manage` CLI parser at runtime. That binary calls `RunServerCommand::execute()` directly, which is the documented way to launch the HTTP server outside of `manage`. However, `execute()` itself does not walk the `inventory` of `#[routes]` registrations — that walk lives in the private helper `reinhardt-commands::auto_register_router` and is only triggered from `execute_from_command_line()`.

The result is that any non-CLI server entrypoint (including the dashboard container) fails immediately. This PR replicates the inventory walk in `dashboard/src/server.rs` so direct `RunServerCommand::execute` callers also boot a usable router. The replication is wrapped in a `WP-3`-style workaround comment that names both the upstream issue (kent8192/reinhardt-web#4055) and the Reinhardt Cloud tracking issue (#479) so the workaround can be deleted as soon as upstream exposes the helper publicly.

Fixes #478

Related to: #479, kent8192/reinhardt-web#4055

## How Was This Tested?

- Added `dashboard/tests/server_startup.rs` integration test (`#[serial(router_global)]`) that drives `server::register_router_from_inventory` and asserts `is_router_registered()` returns `true`. Result: `1 passed, 0 skipped` via `cargo nextest run -p reinhardt-cloud-dashboard --test server_startup`.
- `cargo fmt -p reinhardt-cloud-dashboard --check`: clean.
- `cargo clippy -p reinhardt-cloud-dashboard --all-targets -- -D clippy::todo -D clippy::unimplemented -D clippy::dbg_macro`: no errors (only pre-existing `unused import: test_app` warnings unrelated to this PR).
- Local E2E (release binary): `./target/release/reinhardt-cloud-dashboard` boots past the router stage and now fails at `secret_key` resolution (a configuration concern, not a router one) — the regression `Execution error: No router registered.` is gone.

## Performance Impact

- None. The inventory walk runs exactly once at process startup.

## Breaking Changes

- None.

## Checklist

- [x] My code follows the project's coding style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas (workaround block carries the WP-3 ideal-implementation comment)
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been documented (upstream issue created, tracking issue created, bidirectional cross-link posted)

## Labels to Apply

- `bug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)