### PR TITLE
fix(dashboard/infra): resolve settings TOML by REINHARDT_ENV instead of hardcoding local.toml

### DIFF
--- a/dashboard/scripts/infra_up.sh
+++ b/dashboard/scripts/infra_up.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 # Start disposable PostgreSQL + Redis containers via `docker run --rm`.
 # Connection parameters (user / password / database / port / redis URL)
-# are parsed from `dashboard/settings/local.toml`.
+# are parsed from the settings TOML matching the active `REINHARDT_ENV`
+# profile (defaults to `local`). Reading the same profile that
+# `dashboard/src/config/settings.rs` resolves keeps the provisioned
+# container credentials in sync with what `runserver` later connects
+# with -- see kent8192/reinhardt-cloud#487.
 set -euo pipefail
 
 PG_NAME="reinhardt-cloud-dashboard-postgres"
@@ -11,12 +15,23 @@ RD_NAME="reinhardt-cloud-dashboard-redis"
 # invoked through cargo-make or directly via `bash dashboard/scripts/infra_up.sh`.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DASHBOARD_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-CONFIG="$DASHBOARD_DIR/settings/local.toml"
+# Mirror the env-aware lookup performed by `profile_name()` in
+# `dashboard/src/config/settings.rs` so infra-up and runserver pick the
+# same `<profile>.toml` file. Without this the runserver would silently
+# load `<profile>.toml` while infra-up had provisioned the container
+# from `local.toml`, producing a cryptic auth failure at first query.
+PROFILE="${REINHARDT_ENV:-local}"
+CONFIG="$DASHBOARD_DIR/settings/${PROFILE}.toml"
 
 if [ ! -f "$CONFIG" ]; then
-	echo "Error: $CONFIG not found." >&2
-	echo "  Run: cp $DASHBOARD_DIR/settings/local.example.toml $CONFIG" >&2
-	echo "       and fill in any required secrets before retrying." >&2
+	echo "Error: settings file for profile '${PROFILE}' not found at: $CONFIG" >&2
+	if [ -f "$DASHBOARD_DIR/settings/${PROFILE}.example.toml" ]; then
+		echo "  Run: cp $DASHBOARD_DIR/settings/${PROFILE}.example.toml $CONFIG" >&2
+		echo "       and fill in any required secrets before retrying." >&2
+	else
+		echo "  No example template exists for profile '${PROFILE}'." >&2
+		echo "  Either create $CONFIG manually or unset REINHARDT_ENV to use 'local'." >&2
+	fi
 	exit 1
 fi
 
@@ -27,12 +42,14 @@ fi
 
 # Delegate TOML parsing to the shared helper so future infra scripts can
 # reuse the same shape (PG_*, RD_*) without re-implementing the parser.
+# The helper accepts any settings TOML, not just `local.toml`.
 SETTINGS=$(python3 "$SCRIPT_DIR/parse_local_toml.py" "$CONFIG") || exit $?
 eval "$SETTINGS"
 
 # Drop any stale containers from a previous aborted run so --name is free.
 docker rm -f "$PG_NAME" "$RD_NAME" >/dev/null 2>&1 || true
 
+echo "Using settings profile '${PROFILE}' (from $CONFIG)"
 echo "Starting PostgreSQL ($PG_NAME) on ${PG_HOST}:${PG_PORT} as ${PG_USER}/${PG_DB}..."
 docker run --rm -d \
 	--name "$PG_NAME" \

--- a/dashboard/scripts/parse_local_toml.py
+++ b/dashboard/scripts/parse_local_toml.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
-"""Parse dashboard/settings/local.toml and emit shell-evaluable KEY=VALUE lines.
+"""Parse a dashboard settings TOML and emit shell-evaluable KEY=VALUE lines.
 
 Used by `dashboard/scripts/infra_up.sh` (and any future infra script that
 needs the same connection info) to keep the dashboard's runtime
-configuration in a single source of truth.
+configuration in a single source of truth. Despite the historical name,
+this script accepts any settings profile (local.toml, ci.toml, ...) --
+the caller picks the file based on `REINHARDT_ENV`.
 
 Usage:
-    parse_local_toml.py <path_to_local.toml>
+    parse_local_toml.py <path_to_settings.toml>
 
 Stdout (one KEY=value per line, suitable for `eval`):
     PG_HOST=localhost
@@ -58,7 +60,7 @@ def _resolve_password(raw: object) -> str:
 
 def main(argv: list[str]) -> int:
 	if len(argv) != 2:
-		sys.stderr.write("Usage: parse_local_toml.py <local.toml>\n")
+		sys.stderr.write("Usage: parse_local_toml.py <settings.toml>\n")
 		return 2
 
 	data = _load_toml(argv[1])
@@ -66,7 +68,9 @@ def main(argv: list[str]) -> int:
 	try:
 		db = data["core"]["databases"]["default"]
 	except KeyError:
-		sys.stderr.write("Error: [core.databases.default] missing from local.toml\n")
+		sys.stderr.write(
+			f"Error: [core.databases.default] missing from {argv[1]}\n"
+		)
 		return 1
 
 	pw = _resolve_password(db.get("password", ""))

--- a/docs/development/LOCAL_E2E_TESTING.md
+++ b/docs/development/LOCAL_E2E_TESTING.md
@@ -70,10 +70,19 @@ cd dashboard && cargo make infra-up
 docker ps --filter name=reinhardt-cloud-dashboard-
 ```
 
-The defaults are `postgres://reinhardt:reinhardt@localhost:5432/reinhardt_cloud`
-and `redis://localhost:6379`. Stop the containers with
-`cargo make infra-down`, or recreate from a clean state with
-`cargo make infra-reset`.
+`infra-up` reads connection parameters from the settings TOML matching
+the active `REINHARDT_ENV` profile (defaults to `local`, so `local.toml`).
+This is the same lookup `runserver` performs, so both sides stay in
+sync. With a typical `local.toml` the defaults are
+`postgres://reinhardt:reinhardt@localhost:5432/reinhardt_cloud` and
+`redis://localhost:6379`. Stop the containers with `cargo make infra-down`,
+or recreate from a clean state with `cargo make infra-reset`.
+
+> **Note:** if you have `REINHARDT_ENV` set in your shell (e.g. left over
+> from a CI shell where you exported `REINHARDT_ENV=ci`), both `infra-up`
+> and `runserver` will resolve `<env>.toml` instead of `local.toml`. Run
+> `unset REINHARDT_ENV` before running `infra-up` to use the default
+> `local` profile.
 
 ## 3. Install the CRD
 


### PR DESCRIPTION
## Summary

- `dashboard/scripts/infra_up.sh` now derives the settings TOML path from `${REINHARDT_ENV:-local}` instead of hardcoding `local.toml`, so the provisioned PostgreSQL container credentials always match what `cargo make runserver` later connects with.
- The missing-file error message tells the user *which profile* was selected, *what file* it expected, and offers either the right `cp` command (when an example template exists) or guidance to unset `REINHARDT_ENV` (when none does).
- `infra-up` now logs `Using settings profile '<profile>' (from <path>)` on every start so the active profile is obvious.
- `parse_local_toml.py` docstring/usage/error messages updated to be profile-agnostic (the helper already worked on any settings TOML; only the docs implied otherwise).
- `docs/development/LOCAL_E2E_TESTING.md` calls out the shared `REINHARDT_ENV` lookup and the leftover-shell-export footgun.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Motivation and Context

Surfaced during E2E testing of #469. With `REINHARDT_ENV=ci` set in the shell (left over from a CI session), the infra-up + runserver flow produced a confusing failure:

```
$ cd dashboard && cargo make infra-up
Starting PostgreSQL ... as reinhardt/reinhardt_cloud...     # local.toml (hardcoded)

$ cargo make runserver
[reinhardt-conf] Warning: ... TOML file: ci.toml             # runserver picks env-aware
Error: password authentication failed for user ""postgres""    # mismatch — postgres vs reinhardt
```

Root cause: ` infra_up.sh:14` had `CONFIG=""$DASHBOARD_DIR/settings/local.toml""` while `dashboard/src/config/settings.rs::profile_name()` reads `REINHARDT_ENV`. The two sides of the local-dev workflow could silently diverge.

## How Was This Tested

Verified all three error / success paths in the worktree at `fix/issue-487-infra-up-env-aware`:

| Scenario | Behavior |
|---|---|
| `REINHARDT_ENV=local` (or unset), `local.toml` present | Provisions Postgres with `local.toml` credentials, prints active profile. |
| `REINHARDT_ENV=ci`, `ci.toml` present | Provisions Postgres with `ci.toml` credentials (`postgres/postgres/reinhardt_cloud_ci`). |
| `REINHARDT_ENV=local`, `local.toml` missing | Suggests `cp local.example.toml local.toml`. |
| `REINHARDT_ENV=staging`, no `staging.toml` and no `staging.example.toml` | Suggests creating manually or unsetting `REINHARDT_ENV`. |

```
$ bash -n dashboard/scripts/infra_up.sh                 # bash syntax OK
$ python3 -c 'import ast; ast.parse(open(...))'         # python syntax OK
$ python3 dashboard/scripts/parse_local_toml.py dashboard/settings/ci.toml
PG_HOST=localhost
PG_PORT=5432
PG_DB=reinhardt_cloud_ci
PG_USER=postgres
PG_PASS=postgres
RD_HOST=localhost
RD_PORT=6379
```

## Checklist

- [x] My code follows the project's style guidelines (English comments, tabs, Conventional Commits)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Documentation is updated (`docs/development/LOCAL_E2E_TESTING.md`)
- [x] No new TODO/FIXME comments added
- [x] PR is small and focused on a single fix pattern (1 PR = 1 fix)
- [x] Linked to the originating Issue via `Fixes #487`

## Labels to Apply

- `bug` — fixes incorrect behavior
- `enhancement` — improves error message UX
- `documentation` — updates `LOCAL_E2E_TESTING.md`

## Related Issues

Fixes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)