### PR TITLE
fix(dockerfile-generator): scope cargo build to project package (#485)

### DIFF
--- a/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/api_full.dockerfile
+++ b/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/api_full.dockerfile
@@ -17,7 +17,7 @@ WORKDIR /app
 COPY --from=chef /app/recipe.json recipe.json
 RUN cargo chef cook --release --features graphql --recipe-path recipe.json
 COPY . .
-RUN cargo build --release --features graphql
+RUN cargo build --release -p my-app --features graphql
 
 FROM debian:bookworm-slim AS runtime
 RUN apt-get update && \

--- a/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/api_graphql.dockerfile
+++ b/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/api_graphql.dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 COPY --from=chef /app/recipe.json recipe.json
 RUN cargo chef cook --release --features graphql --recipe-path recipe.json
 COPY . .
-RUN cargo build --release --features graphql
+RUN cargo build --release -p my-app --features graphql
 
 FROM debian:bookworm-slim AS runtime
 RUN apt-get update && \

--- a/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/api_grpc.dockerfile
+++ b/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/api_grpc.dockerfile
@@ -17,7 +17,7 @@ WORKDIR /app
 COPY --from=chef /app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
-RUN cargo build --release
+RUN cargo build --release -p my-app
 
 FROM debian:bookworm-slim AS runtime
 RUN apt-get update && \

--- a/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/api_minimal.dockerfile
+++ b/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/api_minimal.dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 COPY --from=chef /app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
-RUN cargo build --release
+RUN cargo build --release -p my-app
 
 FROM debian:bookworm-slim AS runtime
 RUN apt-get update && \

--- a/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/api_mysql.dockerfile
+++ b/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/api_mysql.dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 COPY --from=chef /app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
-RUN cargo build --release
+RUN cargo build --release -p my-app
 
 FROM debian:bookworm-slim AS runtime
 RUN apt-get update && \

--- a/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/api_postgres.dockerfile
+++ b/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/api_postgres.dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 COPY --from=chef /app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
-RUN cargo build --release
+RUN cargo build --release -p my-app
 
 FROM debian:bookworm-slim AS runtime
 RUN apt-get update && \

--- a/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/api_sqlite.dockerfile
+++ b/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/api_sqlite.dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 COPY --from=chef /app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
-RUN cargo build --release
+RUN cargo build --release -p my-app
 
 FROM debian:bookworm-slim AS runtime
 RUN apt-get update && \

--- a/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/pages_full.dockerfile
+++ b/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/pages_full.dockerfile
@@ -17,7 +17,7 @@ WORKDIR /app
 COPY --from=chef /app/recipe.json recipe.json
 RUN cargo chef cook --release --features graphql --recipe-path recipe.json
 COPY . .
-RUN cargo build --release --features graphql
+RUN cargo build --release -p my-app --features graphql
 
 FROM rust:1.94.1-bookworm AS wasm
 RUN apt-get update && \
@@ -27,7 +27,7 @@ RUN rustup target add wasm32-unknown-unknown
 RUN cargo install wasm-bindgen-cli@0.2.100
 WORKDIR /app
 COPY . .
-RUN cargo build --release --target wasm32-unknown-unknown
+RUN cargo build --release --target wasm32-unknown-unknown --lib -p my-app
 RUN wasm-bindgen --out-dir /wasm-dist --target web target/wasm32-unknown-unknown/release/my_app.wasm && \
     wasm-opt -Oz -o /wasm-dist/optimized.wasm /wasm-dist/*.wasm
 

--- a/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/pages_minimal.dockerfile
+++ b/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/pages_minimal.dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 COPY --from=chef /app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
-RUN cargo build --release
+RUN cargo build --release -p my-app
 
 FROM rust:1.94.1-bookworm AS wasm
 RUN apt-get update && \
@@ -21,7 +21,7 @@ RUN rustup target add wasm32-unknown-unknown
 RUN cargo install wasm-bindgen-cli@0.2.100
 WORKDIR /app
 COPY . .
-RUN cargo build --release --target wasm32-unknown-unknown
+RUN cargo build --release --target wasm32-unknown-unknown --lib -p my-app
 RUN wasm-bindgen --out-dir /wasm-dist --target web target/wasm32-unknown-unknown/release/my_app.wasm && \
     wasm-opt -Oz -o /wasm-dist/optimized.wasm /wasm-dist/*.wasm
 

--- a/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/pages_postgres.dockerfile
+++ b/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/pages_postgres.dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 COPY --from=chef /app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
-RUN cargo build --release
+RUN cargo build --release -p my-app
 
 FROM rust:1.94.1-bookworm AS wasm
 RUN apt-get update && \
@@ -21,7 +21,7 @@ RUN rustup target add wasm32-unknown-unknown
 RUN cargo install wasm-bindgen-cli@0.2.100
 WORKDIR /app
 COPY . .
-RUN cargo build --release --target wasm32-unknown-unknown
+RUN cargo build --release --target wasm32-unknown-unknown --lib -p my-app
 RUN wasm-bindgen --out-dir /wasm-dist --target web target/wasm32-unknown-unknown/release/my_app.wasm && \
     wasm-opt -Oz -o /wasm-dist/optimized.wasm /wasm-dist/*.wasm
 

--- a/crates/reinhardt-cloud-cli/src/dockerfile_generator/stages.rs
+++ b/crates/reinhardt-cloud-cli/src/dockerfile_generator/stages.rs
@@ -121,8 +121,13 @@ pub(crate) fn build_builder_stage(signals: &DockerfileSignals) -> Stage {
 		src: ".".to_string(),
 		dst: ".".to_string(),
 	});
+	// Scope the build to the project crate so wasm-incompatible workspace
+	// members (operator/agent/CLI/grpc/etc.) are not pulled into the build
+	// graph. See kent8192/reinhardt-cloud#485 for the underlying mio failure
+	// that motivated scoping.
 	instructions.push(Instruction::Run(format!(
-		"cargo build --release{feature_args}"
+		"cargo build --release -p {}{feature_args}",
+		signals.app_name
 	)));
 
 	Stage {
@@ -161,7 +166,17 @@ pub(crate) fn build_wasm_stage(signals: &DockerfileSignals) -> Stage {
 				src: ".".to_string(),
 				dst: ".".to_string(),
 			},
-			Instruction::Run("cargo build --release --target wasm32-unknown-unknown".to_string()),
+			// `--lib -p {app_name}` ensures only the dashboard crate's cdylib is
+			// built. Without `-p` cargo builds every workspace member for the
+			// wasm32 target, which fails on members that depend on
+			// `tokio = { features = ["full"] }` because `mio`'s net feature is
+			// not wasm-compatible. Without `--lib`, cargo also tries to build
+			// the project's host binary (`main.rs`) for wasm32 and fails.
+			// See kent8192/reinhardt-cloud#485.
+			Instruction::Run(format!(
+				"cargo build --release --target wasm32-unknown-unknown --lib -p {}",
+				signals.app_name
+			)),
 			Instruction::RunMulti(vec![
 				format!(
 					"wasm-bindgen --out-dir /wasm-dist --target web \
@@ -608,9 +623,10 @@ mod tests {
 
 		// Assert: both cargo-chef caching and the final build must carry the
 		// graphql feature so the compiled binary includes GraphQL code.
+		// The cargo build line also carries `-p my-app` for #485 scoping.
 		assert!(
-			stage_contains_run(&stage, "cargo build --release --features graphql"),
-			"expected graphql feature in cargo build"
+			stage_contains_run(&stage, "cargo build --release -p my-app --features graphql"),
+			"expected graphql feature in cargo build with package scope"
 		);
 		assert!(
 			stage_contains_run(&stage, "cargo chef cook --release --features graphql"),
@@ -723,6 +739,46 @@ mod tests {
 		assert!(
 			stage_contains_run(&stage, "protobuf-compiler"),
 			"builder stage must install protobuf-compiler when protoc_needed is set"
+		);
+	}
+
+	// PS1 (Refs #485): builder stage scopes cargo build to the project
+	// package, preventing wasm-incompatible workspace members from being
+	// pulled into the build graph.
+	#[rstest]
+	fn builder_stage_scopes_cargo_build_to_package(minimal_signals: DockerfileSignals) {
+		// Act
+		let stage = build_builder_stage(&minimal_signals);
+
+		// Assert
+		assert!(
+			stage_contains_run(&stage, "cargo build --release -p my-app"),
+			"builder stage must pass `-p {{app_name}}` to cargo build; \
+			 see kent8192/reinhardt-cloud#485"
+		);
+	}
+
+	// PS2 (Refs #485): wasm stage scopes cargo build to the project package
+	// AND restricts to lib targets. Without `--lib`, cargo also tries to
+	// compile the project's bin (`main.rs`) for wasm32 and fails because
+	// server-only deps (tokio with full features) are not wasm-compatible.
+	#[rstest]
+	fn wasm_stage_scopes_cargo_build_to_lib_target(mut minimal_signals: DockerfileSignals) {
+		// Arrange
+		minimal_signals.pages = true;
+		minimal_signals.wasm_bindgen_version = Some("0.2.100".to_string());
+
+		// Act
+		let stage = build_wasm_stage(&minimal_signals);
+
+		// Assert
+		assert!(
+			stage_contains_run(
+				&stage,
+				"cargo build --release --target wasm32-unknown-unknown --lib -p my-app",
+			),
+			"wasm stage must pass `--lib -p {{app_name}}` to cargo build; \
+			 see kent8192/reinhardt-cloud#485"
 		);
 	}
 


### PR DESCRIPTION
## Summary

- Add `-p {app_name}` to the `cargo build --release` invocations in both the builder stage and the wasm stage of the auto-generated `Dockerfile`.
- Add `--lib` to the wasm stage so cargo only compiles the `cdylib` target.
- Update all 10 snapshot fixtures and add two new tests (`builder_stage_scopes_cargo_build_to_package`, `wasm_stage_scopes_cargo_build_to_lib_target`) that lock the new behavior in.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Motivation and Context

Per #485, the generated Dockerfile's wasm stage previously ran:

```dockerfile
RUN cargo build --release --target wasm32-unknown-unknown
```

without a `-p <crate>` filter. Cargo with `--target` builds every member that does not opt out of the target, so the wasm-incompatible workspace members (operator, agent, CLI, grpc, core, telemetry — 7 of them depend on `tokio = { features = ["full"] }`) were pulled into the build graph. `mio`'s `net` feature is not wasm-compatible, so the build died with 48 errors in `mio`, completely blocking the `dashboard` container build for #469.

Symmetric scoping is applied to the builder stage: it previously also built the entire workspace's `--release` set, including the operator/agent/CLI binaries, which is wasted work in a dashboard image (issue body estimates ~3-5 minutes saved).

`signals.app_name` already comes from the project crate's `Cargo.toml [package].name` (via `feature_detector::detect_project`), so no new signal source is needed.

## How Was This Tested

- [x] `cargo nextest run --package reinhardt-cloud-cli` (254 tests, all passing — 10 snapshot fixtures regenerated, 2 new behavioral tests added)
- [x] `cargo make fmt-check`
- [x] `cargo make clippy-check`
- [ ] End-to-end Docker build verification (dashboard container) — to be confirmed in #486 follow-ups

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (snapshot fixtures)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Labels to Apply

- `bug` (build failure on wasm32 target)
- `enhancement` (also reduces builder stage compile time)

## Related Issues

Fixes #485
Refs #469 (dashboard container blocked by this)
Refs #477 (PR #482 added protoc install but did not address the workspace-build scoping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)