### PR TITLE
fix(dashboard): disable autoreload by default in server entrypoint (#486 issue 1)

### DIFF
--- a/dashboard/src/server.rs
+++ b/dashboard/src/server.rs
@@ -8,6 +8,7 @@
 //! router instead of duplicating reconnaissance into a parallel
 //! implementation that drifts from production.
 
+use std::collections::HashMap;
 use std::error::Error;
 
 use reinhardt::commands::{BaseCommand, CommandContext, RunServerCommand};
@@ -79,6 +80,28 @@ pub async fn register_router_from_inventory() -> Result<(), Box<dyn Error>> {
 	Ok(())
 }
 
+/// Build the `CommandContext` that drives `RunServerCommand::execute`.
+///
+/// Always sets the `noreload` option because the production container
+/// image does not ship the `src/` tree that the upstream file watcher
+/// expects. Without `noreload`, `RunServerCommand` defaults to autoreload
+/// and tries to `notify::Watcher::watch("src/")`, which returns
+/// `inotify_init1: No such file or directory` and aborts startup with
+/// `File watcher error: No path was found`.
+///
+/// Developers who want hot-reload during local iteration should run
+/// `cargo run --bin manage runserver` instead of the production binary —
+/// the dashboard server entrypoint is for containerized deployment.
+///
+/// See kent8192/reinhardt-cloud#486 (issue 1).
+pub(crate) fn build_context(bind_addr: &str) -> CommandContext {
+	let mut options: HashMap<String, Vec<String>> = HashMap::new();
+	// Empty value list — `RunServerCommand::execute` only checks key presence
+	// via `ctx.has_option("noreload")`.
+	options.insert("noreload".to_string(), Vec::new());
+	CommandContext::new(vec![bind_addr.to_string()]).with_options(options)
+}
+
 /// Boot the dashboard HTTP server on `bind_addr`.
 ///
 /// This is what `src/main.rs` calls in the container ENTRYPOINT and
@@ -88,9 +111,46 @@ pub async fn register_router_from_inventory() -> Result<(), Box<dyn Error>> {
 pub async fn run(bind_addr: &str) -> Result<(), Box<dyn Error>> {
 	register_router_from_inventory().await?;
 
-	let ctx = CommandContext::new(vec![bind_addr.to_string()]);
+	let ctx = build_context(bind_addr);
 	let cmd = RunServerCommand;
 	cmd.execute(&ctx)
 		.await
 		.map_err(|e| Box::<dyn Error>::from(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use rstest::rstest;
+
+	// Refs #486 (issue 1): the production server entrypoint must disable
+	// autoreload; otherwise the file watcher tries to inotify-watch
+	// `src/`, which does not exist in container images.
+	#[rstest]
+	fn build_context_disables_autoreload() {
+		// Arrange & Act
+		let ctx = build_context("0.0.0.0:8000");
+
+		// Assert
+		assert!(
+			ctx.has_option("noreload"),
+			"production server entrypoint must disable autoreload; \
+			 see kent8192/reinhardt-cloud#486"
+		);
+	}
+
+	// Sanity: bind address must still be forwarded as the first positional
+	// argument so `RunServerCommand::execute` picks it up unchanged.
+	#[rstest]
+	fn build_context_forwards_bind_address_as_first_arg() {
+		// Arrange & Act
+		let ctx = build_context("127.0.0.1:9000");
+
+		// Assert
+		assert_eq!(
+			ctx.arg(0).map(String::as_str),
+			Some("127.0.0.1:9000"),
+			"bind address must be passed through unchanged so RunServerCommand binds correctly"
+		);
+	}
 }


### PR DESCRIPTION
## Summary

- `dashboard::server::run` now injects `--noreload` into the `CommandContext` it hands to `RunServerCommand::execute`.
- Refactor extracts `build_context(bind_addr)` so the option-setting logic is unit-testable.
- Add two unit tests: one asserting `noreload` is set, one asserting the bind address is forwarded as the first positional argument.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Motivation and Context

Per #486 (issue 1), `RunServerCommand::execute` reads `let noreload = ctx.has_option("noreload")` and treats absence as autoreload-on. The autoreload parent then tries to `notify::Watcher::watch("src/")`, which does not exist in the container, returning `inotify_init1: No such file or directory`:

```
[INFO] Starting autoreload mode...
[VERBOSE] Watching for file changes in src/ and Cargo.toml
[VERBOSE] Starting server subprocess...
dashboard server failed: Execution error: File watcher error: No path was found.
```

Production deployments never want autoreload; the dashboard server entrypoint is the binary that the container's `ENTRYPOINT` runs. Developers who want hot-reload during local iteration should run `cargo run --bin manage runserver` instead.

This is the upstream-side counterpart to the Dockerfile fix in #485 — together with the settings-bundling fix (separate PR, follow-up to #485), they address the three blockers identified in #486.

## How Was This Tested

- [x] `cargo nextest run --package reinhardt-cloud-dashboard --lib -E 'test(/server::tests::/)'` — 2/2 passing
- [x] `cargo nextest run --package reinhardt-cloud-dashboard --test server_startup` — existing 1/1 passing (no regression)
- [x] `cargo make fmt-check`
- [x] `cargo make clippy-check`
- [ ] End-to-end Docker run verification — pending #485 + the settings-bundling PR landing

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (doc comments on `build_context`)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Labels to Apply

- `bug`
- `high`

## Related Issues

Refs #486 (issue 1; issue 2 is fixed in a follow-up PR that depends on #485)
Refs #469 (dashboard container deployment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)