### PR TITLE
fix(dashboard): resolve JWT secret from TOML with env-var fallback

### DIFF
--- a/dashboard/settings/base.example.toml
+++ b/dashboard/settings/base.example.toml
@@ -59,7 +59,26 @@ allow_origins = ["http://localhost:8000", "http://127.0.0.1:8000"]
 
 [email]
 # SMTP backend configuration for transactional emails.
-# For testing, override via REINHARDT_EMAIL__* env vars to point at Mailpit.
+#
+# Domain context (`reinhardt-cloud.dev`, verified via cloudflared/dig):
+#   - NS: brynne/coleman.ns.cloudflare.com (Cloudflare-managed)
+#   - MX: route{1,2,3}.mx.cloudflare.net (Cloudflare Email Routing — INBOUND only)
+#   - SPF: "v=spf1 include:_spf.mx.cloudflare.net ~all"
+#   - DKIM: cf2024-1._domainkey present (Cloudflare signing key)
+#   - DMARC: p=none (monitoring)
+#
+# Cloudflare does NOT provide a public outbound SMTP relay, so production
+# delivery requires a third-party provider (Resend / SendGrid / AWS SES /
+# Postmark). When that provider is chosen, also extend the SPF record with
+# `include:<provider-spf>` and publish the provider's DKIM selector.
+#
+# Suggested production overrides via REINHARDT_EMAIL__* env vars:
+#   port 465 → use_ssl=true, use_tls=false  (implicit TLS)
+#   port 587 → use_ssl=false, use_tls=true  (STARTTLS)
+#
+# Defaults below target Mailpit (`docker run mailpit`) for local development;
+# `use_ssl`/`use_tls` are intentionally false because Mailpit serves plaintext
+# on 1025. Production MUST override host/port/credentials via env vars.
 host = "localhost"
 port = 1025
 from_email = "noreply@reinhardt-cloud.dev"

--- a/dashboard/settings/ci.example.toml
+++ b/dashboard/settings/ci.example.toml
@@ -9,12 +9,17 @@
 # Getting started:
 #   cp ci.example.toml ci.toml
 
-# JWT secret for session token signing (required for auth endpoints)
+# JWT secret for cluster-agent and gRPC AuthService token signing.
+# Resolved by `dashboard::config::settings::get_jwt_secret()`, which reads
+# this top-level TOML key first and falls back to the
+# `REINHARDT_CLOUD_JWT_SECRET` env var for container/CI overrides.
 jwt_secret = "ci-only-jwt-secret-not-for-production"
 
-# Redis URL for session backend (required for cookie-session auth)
-# In CI, this is overridden by REINHARDT_CLOUD_REDIS_URL env var pointing
-# to a Redis service container or TestContainers-managed instance.
+# Redis URL for cookie session storage. Resolved by
+# `dashboard::config::settings::get_redis_url()`, which reads this TOML key
+# first and falls back to the `REINHARDT_CLOUD_REDIS_URL` env var.
+# In CI, the env var typically points to a Redis service container or
+# TestContainers-managed instance.
 redis_url = "redis://localhost:6379/0"
 
 [core]

--- a/dashboard/settings/local.example.toml
+++ b/dashboard/settings/local.example.toml
@@ -8,10 +8,15 @@
 #   cp local.example.toml local.toml
 #   # Edit local.toml and fill in sensitive values.
 
-# JWT secret for session token signing (required for auth endpoints)
+# JWT secret for cluster-agent and gRPC AuthService token signing.
+# Resolved by `dashboard::config::settings::get_jwt_secret()`, which reads
+# this top-level TOML key first and falls back to the
+# `REINHARDT_CLOUD_JWT_SECRET` env var for container/CI overrides.
 jwt_secret = "CHANGE-ME-to-a-random-string"
 
-# Redis URL for session storage (required for cookie session auth)
+# Redis URL for cookie session storage. Resolved by
+# `dashboard::config::settings::get_redis_url()`, which reads this TOML key
+# first and falls back to the `REINHARDT_CLOUD_REDIS_URL` env var.
 redis_url = "redis://localhost:6379/1"
 
 [core]

--- a/dashboard/src/apps/auth/services/local_auth.rs
+++ b/dashboard/src/apps/auth/services/local_auth.rs
@@ -47,13 +47,17 @@ async fn create_local_auth_service() -> LocalAuthService {
 impl LocalAuthService {
 	/// Get the JWT secret for gRPC token operations.
 	///
-	/// Reads from `REINHARDT_CLOUD_JWT_SECRET` environment variable.
+	/// Resolves via `crate::config::settings::get_jwt_secret()` (TOML key
+	/// `jwt_secret` with `REINHARDT_CLOUD_JWT_SECRET` env-var fallback).
 	/// This is only used by the gRPC `AuthService` trait implementation,
 	/// not by the dashboard's HTTP cookie-based auth.
+	///
+	/// Issue: kent8192/reinhardt-cloud#494
 	fn secret(&self) -> Result<String, ApiError> {
-		std::env::var("REINHARDT_CLOUD_JWT_SECRET").map_err(|_| {
+		crate::config::settings::get_jwt_secret().ok_or_else(|| {
 			ApiError::Internal(
-				"JWT secret not configured: set REINHARDT_CLOUD_JWT_SECRET env var".to_string(),
+				"JWT secret not configured: set jwt_secret in TOML or REINHARDT_CLOUD_JWT_SECRET env var"
+					.to_string(),
 			)
 		})
 	}

--- a/dashboard/src/apps/clusters/services/token_issuance.rs
+++ b/dashboard/src/apps/clusters/services/token_issuance.rs
@@ -28,13 +28,19 @@ pub struct IssuedAgentToken {
 	pub hash: String,
 }
 
-/// Load the JWT signing secret from the environment.
+/// Load the JWT signing secret.
 ///
-/// Matches the convention used by the auth app's `LocalAuthService`.
+/// Resolves via `crate::config::settings::get_jwt_secret()`, which reads the
+/// top-level `jwt_secret` key from the active TOML profile and falls back to
+/// the `REINHARDT_CLOUD_JWT_SECRET` environment variable. Returns an error
+/// only when neither source supplies a value.
+///
+/// Issue: kent8192/reinhardt-cloud#494
 pub fn jwt_secret() -> Result<String, AppError> {
-	std::env::var("REINHARDT_CLOUD_JWT_SECRET").map_err(|_| {
+	crate::config::settings::get_jwt_secret().ok_or_else(|| {
 		AppError::Internal(
-			"JWT secret not configured: set REINHARDT_CLOUD_JWT_SECRET env var".to_string(),
+			"JWT secret not configured: set jwt_secret in TOML or REINHARDT_CLOUD_JWT_SECRET env var"
+				.to_string(),
 		)
 	})
 }
@@ -59,13 +65,17 @@ mod tests {
 	use rstest::rstest;
 	use serial_test::serial;
 
-	const TEST_SECRET: &str = "test-secret-for-cluster-token-issuance";
+	/// Path that is guaranteed not to contain settings TOML files.
+	/// Used to neutralise TOML lookup so env-var resolution can be tested
+	/// in isolation (`get_jwt_secret` falls back when TOML is absent).
+	const NONEXISTENT_CONFIG_DIR: &str = "/nonexistent-test-config-dir-494";
 
 	#[rstest]
 	#[serial(env_jwt_secret)]
 	fn test_issue_agent_token_roundtrip_hash_verifies() {
-		// Arrange
-		unsafe { std::env::set_var("REINHARDT_CLOUD_JWT_SECRET", TEST_SECRET) };
+		// Arrange — secret is sourced from the active settings (TOML
+		// or env var); test only verifies that the Argon2 hash matches
+		// the issued plaintext, independent of the secret value.
 		let cluster_id = Uuid::now_v7();
 
 		// Act
@@ -84,15 +94,17 @@ mod tests {
 	#[rstest]
 	#[serial(env_jwt_secret)]
 	fn test_issued_token_contains_cluster_id_claim() {
-		// Arrange
-		unsafe { std::env::set_var("REINHARDT_CLOUD_JWT_SECRET", TEST_SECRET) };
+		// Arrange — verify with the same secret that the function used
+		// to mint the token, so the assertion holds regardless of whether
+		// the secret came from TOML or the env-var fallback.
 		let cluster_id = Uuid::now_v7();
 
 		// Act
 		let issued = issue_agent_token(cluster_id).unwrap();
+		let secret = jwt_secret().unwrap();
 		let claims = reinhardt_cloud_grpc::agent_claims::verify_agent_token(
 			&issued.plaintext,
-			TEST_SECRET.as_bytes(),
+			secret.as_bytes(),
 		)
 		.unwrap();
 
@@ -103,12 +115,26 @@ mod tests {
 	#[rstest]
 	#[serial(env_jwt_secret)]
 	fn test_issue_agent_token_fails_without_secret() {
-		// Arrange
+		// Arrange — neutralise both resolution sources: redirect TOML
+		// lookup to a non-existent dir (so `base.toml`/`local.toml` cannot
+		// be parsed) and remove the env-var fallback. Issue: #494.
+		let prior_dir = std::env::var("REINHARDT_CLOUD_CONFIG_DIR").ok();
+		let prior_secret = std::env::var("REINHARDT_CLOUD_JWT_SECRET").ok();
+		unsafe { std::env::set_var("REINHARDT_CLOUD_CONFIG_DIR", NONEXISTENT_CONFIG_DIR) };
 		unsafe { std::env::remove_var("REINHARDT_CLOUD_JWT_SECRET") };
 		let cluster_id = Uuid::now_v7();
 
 		// Act
 		let result = issue_agent_token(cluster_id);
+
+		// Cleanup — restore prior values so other serial tests are unaffected.
+		match prior_dir {
+			Some(v) => unsafe { std::env::set_var("REINHARDT_CLOUD_CONFIG_DIR", v) },
+			None => unsafe { std::env::remove_var("REINHARDT_CLOUD_CONFIG_DIR") },
+		}
+		if let Some(v) = prior_secret {
+			unsafe { std::env::set_var("REINHARDT_CLOUD_JWT_SECRET", v) };
+		}
 
 		// Assert
 		assert!(result.is_err());

--- a/dashboard/src/config/settings.rs
+++ b/dashboard/src/config/settings.rs
@@ -136,7 +136,28 @@ pub fn get_settings() -> ProjectSettings {
 ///
 /// Returns `None` if the Redis URL is not configured in either source.
 pub fn get_redis_url() -> Option<String> {
-	// TOML settings take highest priority
+	get_top_level_string("redis_url", "REINHARDT_CLOUD_REDIS_URL")
+}
+
+/// Get the JWT signing secret from settings or environment.
+///
+/// Priority (highest to lowest):
+/// 1. `jwt_secret` top-level key in the active TOML settings file
+/// 2. `REINHARDT_CLOUD_JWT_SECRET` environment variable (fallback for CI/container overrides)
+///
+/// Returns `None` if the secret is not configured in either source.
+///
+/// Issue: kent8192/reinhardt-cloud#494
+pub fn get_jwt_secret() -> Option<String> {
+	get_top_level_string("jwt_secret", "REINHARDT_CLOUD_JWT_SECRET")
+}
+
+/// Resolve a top-level TOML string key with an environment-variable fallback.
+///
+/// Reads `base.toml` + `<profile>.toml` and returns the merged top-level
+/// `key` value as a `String`. If absent, reads `env_var` from the process
+/// environment. Returns `None` if neither source supplies the value.
+fn get_top_level_string(key: &str, env_var: &str) -> Option<String> {
 	let profile_str = profile_name();
 	let settings_dir = resolve_settings_dir();
 	let from_toml = SettingsBuilder::new()
@@ -148,7 +169,7 @@ pub fn get_redis_url() -> Option<String> {
 		.ok()
 		.and_then(|merged| {
 			merged
-				.get_raw("redis_url")
+				.get_raw(key)
 				.and_then(|v| v.as_str())
 				.map(String::from)
 		});
@@ -157,8 +178,7 @@ pub fn get_redis_url() -> Option<String> {
 		return from_toml;
 	}
 
-	// Fall back to env var for container/CI overrides
-	env::var("REINHARDT_CLOUD_REDIS_URL").ok()
+	env::var(env_var).ok()
 }
 
 #[cfg(test)]
@@ -241,5 +261,17 @@ mod tests {
 		// Assert
 		assert_eq!(settings.media.url, "/media/");
 		assert!(!settings.media.root.as_os_str().is_empty());
+	}
+
+	#[rstest]
+	fn test_get_jwt_secret_reads_from_local_toml() {
+		// Arrange / Act — local.toml ships with `jwt_secret = "test-secret-..."`,
+		// which `get_jwt_secret` MUST surface even when no env var is set.
+		// Issue: #494
+		let secret = get_jwt_secret();
+
+		// Assert
+		assert!(secret.is_some(), "expected jwt_secret from local.toml");
+		assert!(!secret.unwrap().is_empty());
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `get_jwt_secret()` in `dashboard/src/config/settings.rs`, mirroring the existing `get_redis_url()` pattern (TOML first, env var fallback).
- Updates `token_issuance.rs::jwt_secret()` and `local_auth.rs::secret()` to call the new helper, so the top-level `jwt_secret` key already declared in `local.toml`/`ci.toml` is finally honoured.
- Adjusts the failure-path test to neutralise both the TOML and env-var sources via `REINHARDT_CLOUD_CONFIG_DIR` redirection.
- Propagates the Cloudflare email DNS context (verified via `cloudflared`/`dig`) into `base.example.toml`, and clarifies the resolver behaviour comments in `local.example.toml`/`ci.example.toml`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Motivation and Context

`cargo make runserver` panicked on fresh checkouts with `JWT secret not configured` even though `local.toml` already had `jwt_secret = "..."`. The two helpers that resolve the JWT secret were inconsistent with the surrounding code: `get_redis_url()` reads TOML first, but the JWT helpers only read the env var. This PR makes them consistent and removes the manual `export REINHARDT_CLOUD_JWT_SECRET=...` step from the local dev flow.

The `base.example.toml` propagation captures the DNS investigation that revealed Cloudflare Email Routing is **inbound only** — so future operators can configure a real outbound SMTP provider without redoing the discovery.

## How Was This Tested

- `cargo nextest run --package reinhardt-cloud-dashboard config::settings:: apps::clusters::services::token_issuance::` → 11/11 PASS
- `cargo clippy --package reinhardt-cloud-dashboard --all-targets -- -D warnings` → clean
- `rustfmt --check` on edited Rust files → clean

New test: `test_get_jwt_secret_reads_from_local_toml` — asserts the TOML key is surfaced even without an env var present.
Updated test: `test_issue_agent_token_fails_without_secret` — now overrides `REINHARDT_CLOUD_CONFIG_DIR` to a non-existent path before unsetting the env var, so both resolution paths are exercised in the failure case.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Tests use `rstest` and AAA structure with `// Arrange`, `// Act`, `// Assert` comments
- [x] No `todo!()` / `// TODO:` / `// FIXME` introduced

## Labels to Apply

- `bug` — fixes a runtime panic in `runserver` startup
- `high` — blocks fresh-checkout `cargo make runserver`
- `dashboard` — scope is dashboard crate only

## Related Issues

Fixes #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)