### PR TITLE
chore(deps): enable client-router feature on reinhardt-web

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1301,7 +1301,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1897,7 +1897,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2159,7 +2159,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4160,7 +4160,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5510,7 +5510,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5949,8 +5949,8 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reinhardt-admin"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6000,8 +6000,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-apps"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6030,8 +6030,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-auth"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "argon2",
  "async-trait",
@@ -6076,8 +6076,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-auth-macros"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6362,8 +6362,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-commands"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6418,8 +6418,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-conf"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "chrono",
  "dotenv",
@@ -6444,8 +6444,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-core"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "anyhow",
  "aquamarine 0.6.0",
@@ -6492,8 +6492,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-db"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -6547,8 +6547,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-di"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -6570,8 +6570,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-di-macros"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6581,8 +6581,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-forms"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "anyhow",
  "aquamarine 0.5.0",
@@ -6598,8 +6598,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-http"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6619,8 +6619,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-macros"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "ctor 0.8.0",
  "inventory",
@@ -6633,8 +6633,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-mail"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6654,8 +6654,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-manouche"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "aquamarine 0.6.0",
  "convert_case",
@@ -6667,8 +6667,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-middleware"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6703,8 +6703,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-openapi"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "async-trait",
  "reinhardt-http",
@@ -6715,8 +6715,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-openapi-macros"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6726,8 +6726,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-pages"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "aquamarine 0.5.0",
  "async-trait",
@@ -6766,8 +6766,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-pages-ast"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "aquamarine 0.6.0",
  "convert_case",
@@ -6780,8 +6780,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-pages-macros"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "convert_case",
  "darling 0.20.11",
@@ -6794,8 +6794,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-query"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -6808,8 +6808,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-query-macros"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -6819,8 +6819,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-rest"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6868,8 +6868,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-routers-macros"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6878,8 +6878,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-server"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6897,8 +6897,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-shortcuts"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "bytes",
  "hyper",
@@ -6915,8 +6915,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-test"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "cfg_aliases",
  "reinhardt-auth",
@@ -6935,8 +6935,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-testkit"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "async-dropper",
  "async-trait",
@@ -6990,8 +6990,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-throttling"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -7001,8 +7001,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-urls"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -7034,8 +7034,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-utils"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7070,8 +7070,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-views"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7106,8 +7106,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-web"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7148,8 +7148,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-websockets"
-version = "0.1.0-rc.23"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#52abaa722904c00f1b71085f9b78f95823acf7c3"
+version = "0.1.0-rc.24"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7499,7 +7499,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7582,7 +7582,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8579,7 +8579,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9875,7 +9875,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ rustls = { version = "0.23", default-features = false, features = ["ring"] }
 # Reinhardt — umbrella crate providing: HTTP server, auth (JWT + Argon2), database (SeaQuery),
 # configuration, DI container, middleware, OpenAPI, and management commands.
 # Direct hyper/jsonwebtoken/argon2/sea-query deps are NOT needed — reinhardt provides them.
-reinhardt = { package = "reinhardt-web", git = "https://github.com/kent8192/reinhardt-web", branch = "main", features = ["database", "db-postgres", "auth", "auth-jwt", "argon2-hasher", "core", "conf", "server", "di", "middleware", "middleware-security", "middleware-auth-jwt", "rest", "openapi", "openapi-router", "commands", "test", "testcontainers", "pages", "websockets", "admin", "sessions", "session-redis", "mail"] }
+reinhardt = { package = "reinhardt-web", git = "https://github.com/kent8192/reinhardt-web", branch = "main", features = ["database", "db-postgres", "auth", "auth-jwt", "argon2-hasher", "core", "conf", "server", "di", "middleware", "middleware-security", "middleware-auth-jwt", "rest", "openapi", "openapi-router", "commands", "test", "testcontainers", "pages", "websockets", "admin", "sessions", "session-redis", "mail", "client-router"] }
 
 # PostgreSQL driver (sea-query is available via reinhardt::prelude — no direct dep needed)
 tokio-postgres = { version = "0.7", features = ["with-serde_json-1"] }


### PR DESCRIPTION
## Summary

- Add `client-router` feature to the `reinhardt` (reinhardt-web) dependency in workspace Cargo.toml.
- Pulls in upstream kent8192/reinhardt-web#4068 (Signal<T> Send + Sync on native via Arc<RwLock<T>>) which unblocks `UnifiedRouter::client(...)` usage from DI-resolved router newtypes.

## Type of Change

- [x] Maintenance (dependency update)

## Motivation and Context

This is the prerequisite dependency bump for #498 / #501 — it does not by itself change behaviour, but enables the cross-target SPA route registration that follows in the next PRs.

## How Was This Tested

- [x] `cargo check --workspace --all-features` passes
- [x] No code changes — only Cargo.toml + Cargo.lock

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Labels to Apply

- `dependencies`

## Related Issues

Refs #501
Refs kent8192/reinhardt-web#4068

🤖 Generated with [Claude Code](https://claude.com/claude-code)