### PR TITLE
fix(dashboard): cfg-gate form! server_fn imports on wasm only

### DIFF
--- a/dashboard/src/apps/auth/client/pages/login.rs
+++ b/dashboard/src/apps/auth/client/pages/login.rs
@@ -9,6 +9,14 @@ use reinhardt::pages::form;
 use reinhardt::pages::page;
 
 use crate::apps::auth::client::components::oauth_buttons;
+// Workaround for kent8192/reinhardt-web#4070 (tracked in #503).
+// `form!` macro expands the `server_fn: login` reference on WASM only,
+// so the import is unused on native. Cfg-gate the import until the
+// macro emits a native-side reference too.
+//
+// Ideal implementation (without workaround):
+//   use crate::apps::auth::server::login::login;
+#[cfg(wasm)]
 use crate::apps::auth::server::login::login;
 use crate::client::url::url_for;
 

--- a/dashboard/src/apps/auth/client/pages/register.rs
+++ b/dashboard/src/apps/auth/client/pages/register.rs
@@ -9,6 +9,14 @@ use reinhardt::pages::form;
 use reinhardt::pages::page;
 
 use crate::apps::auth::client::components::{auth_layout, oauth_buttons};
+// Workaround for kent8192/reinhardt-web#4070 (tracked in #503).
+// `form!` macro expands the `server_fn: register` reference on WASM
+// only, so the import is unused on native. Cfg-gate until the macro
+// emits a native-side reference too.
+//
+// Ideal implementation (without workaround):
+//   use crate::apps::auth::server::register::register;
+#[cfg(wasm)]
 use crate::apps::auth::server::register::register;
 use crate::client::url::url_for;
 


### PR DESCRIPTION
## Summary

- Cfg-gate `use crate::apps::auth::server::login::login` and `use crate::apps::auth::server::register::register` to `#[cfg(wasm)]` to silence `unused_imports` warnings on native that surface once the surrounding modules become cross-target.
- Workaround for upstream kent8192/reinhardt-web#4070 (form! macro does not emit a native-side reference to the function passed via `server_fn:`).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

While the surrounding `dashboard/src/apps/auth/client/pages/{login,register}.rs` modules remain `#[cfg(wasm)]`-only this change is a no-op. It becomes load-bearing when the next PR (#506 — refactor/issue-501-client-cross-target) un-gates the modules so they compile on native, exposing the upstream form! macro's missing native-side import reference as a `-D warnings` build failure.

Workaround code includes WP-3 ideal-implementation comment pointing at upstream issue + tracking issue #503.

## How Was This Tested

- [x] `cargo check --workspace --all-features` passes (no behaviour change on its own)
- [x] Combined with PR #506: `cargo check` is warning-free on native too

## Suggested merge order

Merge **before** #506 so the un-gate PR doesn't introduce a transient `-D warnings` failure on main.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Labels to Apply

- `bug`

## Related Issues

Refs #503
Refs kent8192/reinhardt-web#4070

🤖 Generated with [Claude Code](https://claude.com/claude-code)