### PR TITLE
refactor(dashboard): un-gate client modules for cross-target SPA routes

### DIFF
--- a/dashboard/src/apps/auth.rs
+++ b/dashboard/src/apps/auth.rs
@@ -8,7 +8,9 @@ use reinhardt::app_config;
 
 #[cfg(native)]
 pub mod admin;
-#[cfg(wasm)]
+// `client` is intentionally cross-target so page constructors are
+// available for `UnifiedRouter::client(...)` reverse URL registration
+// in `crate::config::urls::make_router` (kent8192/reinhardt-web#4068).
 pub mod client;
 #[cfg(native)]
 pub mod models;

--- a/dashboard/src/lib.rs
+++ b/dashboard/src/lib.rs
@@ -16,7 +16,10 @@ pub use reinhardt_cloud_types;
 
 // Application modules — available on both platforms with conditional submodules.
 pub mod apps;
-#[cfg(any(wasm, test))]
+// `client` is intentionally cross-target. WASM consumes it as the SPA;
+// native needs the page constructors for `UnifiedRouter::client(...)`
+// to register names for server-side reverse URL resolution
+// (kent8192/reinhardt-web#4068).
 pub mod client;
 #[cfg(native)]
 pub mod config;


### PR DESCRIPTION
## Summary

- Drop the `#[cfg(any(wasm, test))]` gate from `pub mod client` in `dashboard/src/lib.rs`.
- Drop the `#[cfg(wasm)]` gate from `pub mod client` in `dashboard/src/apps/auth.rs`.
- Makes SPA page constructors (`dashboard_shell`, `not_found_page`, `login_page`, `register_page`) available cross-target so server-side code (next PR) can register them with `UnifiedRouter::client(...)` for SSR-safe reverse URL resolution.

## Type of Change

- [x] Refactor (non-breaking change)

## Motivation and Context

Prerequisite for #498 / #501 (replace static-table workaround with `UnifiedRouter::client(|c| ...)` once upstream reinhardt-web#4068 lands). Without this PR, the next PR cannot reference the SPA page functions from `make_router` (which is a native-only function).

## How Was This Tested

- [x] `cargo check --workspace --all-features` passes (warnings only with PR #505 not yet merged — see merge order below).
- [x] `cargo check --target wasm32-unknown-unknown --lib` passes.

## Suggested merge order

Merge **after** #505 (cfg-gate `form!` macro imports) so the upstream form! macro warning does not surface in CI before being silenced.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (when merged after #505)

## Labels to Apply

- `enhancement`

## Related Issues

Refs #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)