### PR TITLE
refactor(dashboard/server): use upstream auto_register_router

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1301,7 +1301,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1897,7 +1897,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2159,7 +2159,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4160,7 +4160,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5510,7 +5510,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5949,8 +5949,8 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reinhardt-admin"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6000,8 +6000,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-apps"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6030,8 +6030,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-auth"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "argon2",
  "async-trait",
@@ -6076,8 +6076,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-auth-macros"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6362,8 +6362,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-commands"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6418,8 +6418,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-conf"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "chrono",
  "dotenv",
@@ -6444,8 +6444,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-core"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "anyhow",
  "aquamarine 0.6.0",
@@ -6492,8 +6492,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-db"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -6547,8 +6547,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-di"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -6570,8 +6570,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-di-macros"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6581,8 +6581,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-forms"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "anyhow",
  "aquamarine 0.5.0",
@@ -6598,8 +6598,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-http"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6619,8 +6619,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-macros"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "ctor 0.8.0",
  "inventory",
@@ -6633,8 +6633,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-mail"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6654,8 +6654,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-manouche"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "aquamarine 0.6.0",
  "convert_case",
@@ -6667,8 +6667,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-middleware"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6703,8 +6703,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-openapi"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "async-trait",
  "reinhardt-http",
@@ -6715,8 +6715,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-openapi-macros"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6726,8 +6726,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-pages"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "aquamarine 0.5.0",
  "async-trait",
@@ -6766,8 +6766,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-pages-ast"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "aquamarine 0.6.0",
  "convert_case",
@@ -6780,8 +6780,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-pages-macros"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "convert_case",
  "darling 0.20.11",
@@ -6794,8 +6794,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-query"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -6808,8 +6808,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-query-macros"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -6819,8 +6819,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-rest"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6868,8 +6868,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-routers-macros"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6878,8 +6878,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-server"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6897,8 +6897,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-shortcuts"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "bytes",
  "hyper",
@@ -6915,8 +6915,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-test"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "cfg_aliases",
  "reinhardt-auth",
@@ -6935,8 +6935,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-testkit"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "async-dropper",
  "async-trait",
@@ -6990,8 +6990,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-throttling"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -7001,8 +7001,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-urls"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -7034,8 +7034,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-utils"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7070,8 +7070,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-views"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7106,8 +7106,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-web"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7148,8 +7148,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-websockets"
-version = "0.1.0-rc.24"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#2f4cf901e7a8efd3852d30947785ca6cf004b651"
+version = "0.1.0-rc.25"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#66e89a1b583cb58e6c07e77185b6c98a5ad57c4a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7499,7 +7499,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7582,7 +7582,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8579,7 +8579,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9875,7 +9875,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/dashboard/src/server.rs
+++ b/dashboard/src/server.rs
@@ -11,73 +11,16 @@
 use std::collections::HashMap;
 use std::error::Error;
 
-use reinhardt::commands::{BaseCommand, CommandContext, RunServerCommand};
-use reinhardt::urls::routers::{UrlPatternsRegistration, register_router_arc};
+use reinhardt::commands::{BaseCommand, CommandContext, RunServerCommand, auto_register_router};
 
 /// Walk the `#[routes]` inventory and register the (single) discovered
 /// router into the global slot that `RunServerCommand::execute` reads.
 ///
-/// This function is the [WP-3] workaround replicating
-/// `reinhardt-commands`'s private `auto_register_router`. Keep the
-/// error messages aligned with the upstream copy so debugging guidance
-/// stays consistent across both call paths (CLI vs. direct binary).
-///
-// Workaround for kent8192/reinhardt-web#4055
-//   (tracked in reinhardt-cloud#479)
-//
-// `RunServerCommand::execute()` does not auto-register the URL router because
-// the `auto_register_router` helper is private to reinhardt-commands. Until
-// the upstream exposes a public auto-register or `start_server(addr)` helper,
-// we replicate the inventory walk here so direct `RunServerCommand::execute()`
-// callers also boot a usable router.
-//
-// Ideal implementation (without workaround):
-//   reinhardt::urls::routers::auto_register_router().await?;
-//   RunServerCommand.execute(&ctx).await?;
+/// Thin wrapper around upstream [`auto_register_router`] preserved so
+/// `tests/server_startup.rs` can assert that the binary's startup path
+/// performs the inventory walk before delegating to `RunServerCommand`.
 pub async fn register_router_from_inventory() -> Result<(), Box<dyn Error>> {
-	// Collect every `#[routes]` registration the linker preserved.
-	let registrations: Vec<&UrlPatternsRegistration> =
-		inventory::iter::<UrlPatternsRegistration>().collect();
-
-	match registrations.len() {
-		0 => {
-			return Err("No URL patterns registered.\n\
-				 Add the `#[routes]` attribute to your routes function in src/config/urls.rs:\n\n\
-				 #[routes]\n\
-				 pub fn routes() -> UnifiedRouter {\n\
-				     UnifiedRouter::new()\n\
-				 }\n\n\
-				 If your project uses a library/binary split (src/lib.rs + src/bin/manage.rs),\n\
-				 the linker may silently discard route registrations from the library crate.\n\
-				 Fix: add `use your_crate_name as _;` to src/bin/manage.rs to force-link\n\
-				 the library and preserve its side-effectful route registrations."
-				.to_string()
-				.into());
-		}
-		1 => {
-			// Expected case: exactly one registration. Continue below.
-		}
-		n => {
-			return Err(format!(
-				"Multiple #[routes] functions detected ({n} found).\n\
-				 Only one function in the entire project should be annotated with #[routes].\n\n\
-				 Please ensure that:\n\
-				 1. Only one #[routes] attribute exists in your codebase\n\
-				 2. Check src/config/urls.rs and any other files that might have #[routes]\n\
-				 3. If you have multiple router configurations, combine them into a single function"
-			)
-			.into());
-		}
-	}
-
-	let registration = registrations[0];
-	let router = registration
-		.server_router_async()
-		.await
-		.map_err(|e| format!("Failed to create router from #[routes] function: {e}"))?;
-	register_router_arc(router);
-
-	Ok(())
+	auto_register_router().await
 }
 
 /// Build the `CommandContext` that drives `RunServerCommand::execute`.

--- a/dashboard/src/server.rs
+++ b/dashboard/src/server.rs
@@ -13,12 +13,15 @@ use std::error::Error;
 
 use reinhardt::commands::{BaseCommand, CommandContext, RunServerCommand, auto_register_router};
 
-/// Walk the `#[routes]` inventory and register the (single) discovered
-/// router into the global slot that `RunServerCommand::execute` reads.
+/// Delegate to the upstream [`auto_register_router`] helper, which walks
+/// the `#[routes]` inventory and registers the discovered router into the
+/// global slot that `RunServerCommand::execute` reads.
 ///
-/// Thin wrapper around upstream [`auto_register_router`] preserved so
-/// `tests/server_startup.rs` can assert that the binary's startup path
-/// performs the inventory walk before delegating to `RunServerCommand`.
+/// Kept as a named entry point (rather than calling `auto_register_router`
+/// directly from `run`) so `tests/server_startup.rs` can assert that the
+/// binary's startup path performs router registration before delegating to
+/// `RunServerCommand`. The actual registration mechanism lives in
+/// `reinhardt-commands` upstream.
 pub async fn register_router_from_inventory() -> Result<(), Box<dyn Error>> {
 	auto_register_router().await
 }


### PR DESCRIPTION
## Summary

- Replace the local inventory-walk implementation of `register_router_from_inventory` (a WP-3 workaround for kent8192/reinhardt-web#4055) with a thin wrapper around the now-public `reinhardt::commands::auto_register_router`
- Function name is preserved so `tests/server_startup.rs` continues to drive the production startup path

## Type of Change

- [x] Refactor (non-breaking change)

## Motivation and Context

Upstream rc.25 (kent8192/reinhardt-web#4061) exposes `auto_register_router` and `start_server` as public APIs in `reinhardt-commands`. The local replication in `dashboard/src/server.rs` was always intended as an interim workaround per the WP-3 comment, with the ideal implementation already documented inline.

Tracking issue cloud#479 was closed when upstream rc.25 landed. This PR completes the migration to the upstream API.

This PR depends on #508 for the rc.25 lockfile bump.

## How Was This Tested

- [x] `cargo nextest run -p reinhardt-cloud-dashboard --test server_startup` — passes
- [x] `RUSTFLAGS=\"-D warnings\" cargo check -p reinhardt-cloud-dashboard` — passes
- [x] Behavior preserved: `register_router_from_inventory` still populates the global router slot via `register_router_arc(...)` (called inside upstream `auto_register_router`)

## Net Diff

`dashboard/src/server.rs`: −62 LOC of duplicated inventory-walk logic, +5 LOC delegating to upstream.

## Checklist

- [x] My code follows the project style guidelines
- [x] All existing tests pass
- [x] My changes generate no new warnings

## Related Issues

Refs #479
Refs #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)