### PR TITLE
chore(makefile): enable --with-pages and dev flags on runserver task

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -200,9 +200,22 @@ args = [
 # ============================================================================
 
 [tasks.runserver]
-description = "Start local development server (requires PostgreSQL)"
+description = "Start local development server with WASM frontend (requires PostgreSQL)"
 command = "cargo"
-args = ["run", "--locked", "--bin", "manage", "--", "runserver"]
+args = [
+	"run",
+	"--locked",
+	"--bin",
+	"manage",
+	"--",
+	"runserver",
+	"--with-pages",
+	"--insecure",
+	"--static-dir",
+	"dashboard/dist",
+	"--index",
+	"dashboard/index.html",
+]
 
 [tasks.runserver.env]
 REINHARDT_ENV = "local"


### PR DESCRIPTION
## Summary

- Add `--with-pages`, `--insecure`, `--static-dir dashboard/dist`, `--index dashboard/index.html` to the workspace-root `[tasks.runserver]` so `cargo make runserver` serves the prebuilt WASM frontend out of `dashboard/dist/` with SPA fallback.
- The previous task ran `manage runserver` with no flags, so the dashboard frontend never came up locally even though `dashboard/dist/` was already built.

## Type of Change

- [x] Chore (build / dev-tooling configuration)

## Motivation and Context

`dashboard/dist/` already contains the wasm-bindgen output (`reinhardt_cloud_dashboard_bg.wasm`, ~5.1 MB) and `dashboard/index.html` exists at the project root, but `cargo make runserver` was invoked with no flags, so the local dev server returned the API only. Adding the four flags makes the task drop developers straight into a fully working dashboard.

Because `cargo make runserver` is invoked from the workspace root, the default `--static-dir dist` (relative to the cwd) and the `--index` auto-detection do not match the `dashboard/`-scoped layout, hence the explicit paths.

`--insecure` is included because `RunServerCommand` only serves arbitrary static files in development mode when this flag is present (see upstream `reinhardt-commands::builtin`).

## How Was This Tested

- [ ] `cargo make runserver` from the workspace root and confirmed:
  - `http://127.0.0.1:8000/` loads the WASM dashboard
  - SPA routes fall back to `index.html`
  - API endpoints continue to respond
  - Auto-reload still works (no `--noreload` added)

## Checklist

- [x] Workspace-root `Makefile.toml` change only — no Rust source changes
- [x] No new dependencies
- [x] English-only PR content
- [x] Follows project commit guidelines

## Related Issues

Refs #511 — production-side gap (Dockerfile / `dashboard/src/server.rs::build_context` does not propagate `with-pages` / `static-dir`, and `index.html` is not copied into the runtime image). That issue is intentionally out of scope for this PR — see "1 PR = 1 crate × 1 fix pattern".

## Labels to Apply

- `chore` / no `enhancement` (dev-tooling configuration only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)