### PR TITLE
refactor(makefile): set cwd=dashboard and consolidate manage tasks

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -201,6 +201,7 @@ args = [
 
 [tasks.runserver]
 description = "Start local development server with WASM frontend (requires PostgreSQL)"
+cwd = "dashboard"
 command = "cargo"
 args = [
 	"run",
@@ -212,9 +213,9 @@ args = [
 	"--with-pages",
 	"--insecure",
 	"--static-dir",
-	"dashboard/dist",
+	"dist",
 	"--index",
-	"dashboard/index.html",
+	"index.html",
 ]
 
 [tasks.runserver.env]
@@ -222,6 +223,7 @@ REINHARDT_ENV = "local"
 
 [tasks.showurls]
 description = "Display all registered URL patterns"
+cwd = "dashboard"
 command = "cargo"
 args = ["run", "--locked", "--bin", "manage", "--", "showurls"]
 
@@ -230,6 +232,7 @@ REINHARDT_ENV = "local"
 
 [tasks.migrate]
 description = "Apply database migrations"
+cwd = "dashboard"
 command = "cargo"
 args = ["run", "--locked", "--bin", "manage", "--", "migrate"]
 

--- a/dashboard/Makefile.toml
+++ b/dashboard/Makefile.toml
@@ -36,11 +36,6 @@ description = "Create new migrations for a specific app (usage: cargo make makem
 command = "cargo"
 args = ["run", "--bin", "manage", "makemigrations", "${@}"]
 
-[tasks.migrate]
-description = "Apply database migrations"
-command = "cargo"
-args = ["run", "--bin", "manage", "migrate"]
-
 # ============================================================================
 # Static Files
 # ============================================================================
@@ -58,11 +53,6 @@ args = ["run", "--bin", "manage", "collectstatic"]
 description = "Check the project for common issues"
 command = "cargo"
 args = ["run", "--bin", "manage", "check"]
-
-[tasks.showurls]
-description = "Display all registered URL patterns"
-command = "cargo"
-args = ["run", "--bin", "manage", "showurls"]
 
 [tasks.shell]
 description = "Run an interactive Rust shell (REPL)"
@@ -301,14 +291,12 @@ echo ""
 echo "  Database:"
 echo "    makemigrations     - Create new migrations"
 echo "    makemigrations-app - Create migrations for specific app"
-echo "    migrate            - Apply migrations"
 echo ""
 echo "  Static Files:"
 echo "    collectstatic      - Collect static files"
 echo ""
 echo "  Project Management:"
 echo "    check              - Check project for issues"
-echo "    showurls           - Show URL patterns"
 echo "    shell              - Interactive REPL"
 echo ""
 echo "  Testing:"


### PR DESCRIPTION
## Summary

- Add `cwd = \"dashboard\"` to the workspace-root `runserver`, `showurls`, and `migrate` tasks so the `manage` binary (defined in `dashboard/Cargo.toml`) and its `dashboard/settings/local.toml`-based config resolve from the correct working directory.
- Update `runserver`'s `--static-dir`/`--index` arguments to relative paths now that cwd is `dashboard/`.
- Remove the duplicated `migrate` and `showurls` tasks (and matching help-text lines) from `dashboard/Makefile.toml`; the workspace-root versions now subsume them.

## Type of Change

- [x] Refactor (no functional change to user-facing behavior)

## Motivation and Context

Several workspace-root tasks shell out to the `dashboard` crate's `manage` binary and rely on settings files resolved relative to cwd. The previous setup worked from the workspace root only because `--static-dir` / `--index` arguments were hand-written with `dashboard/` prefixes, while `dashboard/CLAUDE.md` MG-1 explicitly mandates running migration commands from the dashboard directory. Declaring `cwd` makes the dependency explicit and lets the workspace-root tasks fully replace the dashboard-local duplicates.

## How Was This Tested

- [x] \`cargo make --list-all-steps\` resolves \`migrate\`, \`showurls\`, and \`runserver\` with the expected descriptions in the worktree.
- [ ] Live \`migrate\` / \`runserver\` execution requires PostgreSQL and was not run in this PR.

## Checklist

- [x] Conventional Commits format
- [x] Aligns with \`dashboard/CLAUDE.md\` MG-1 (manage commands run from \`dashboard/\`)
- [x] No functional behavior change

## Labels to Apply

- \`enhancement\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)