### PR TITLE
docs(dashboard): show explicit escape-hatch command in MG-2

### DIFF
--- a/dashboard/CLAUDE.md
+++ b/dashboard/CLAUDE.md
@@ -21,7 +21,7 @@ This file defines development conventions specific to the `dashboard/` crate, wh
   ```bash
   cd dashboard && cargo make runserver
   ```
-  The dashboard-local `cargo make runserver` (defined in `dashboard/Makefile.toml`) intentionally has no `dependencies` so it launches the server directly. The individual preflight tasks (`cargo make migrate`, `cargo make collectstatic`) remain available from either directory if you want to run only one of them.
+  The dashboard-local `cargo make runserver` (defined in `dashboard/Makefile.toml`) intentionally has no `dependencies` so it launches the server directly. To run only one preflight step, use `cargo make migrate` or `cargo make collectstatic` from the workspace root.
 
 ---
 

--- a/dashboard/CLAUDE.md
+++ b/dashboard/CLAUDE.md
@@ -17,7 +17,11 @@ This file defines development conventions specific to the `dashboard/` crate, wh
 ### MG-2 (NOTE): Auto-Applied by Workspace-Root `runserver`
 
 - Workspace-root `cargo make runserver` (defined in `/Makefile.toml`) automatically chains `migrate` and `collectstatic` before launching the dev server, so a fresh database does not produce 5xx responses on first boot.
-- The dashboard-local `cargo make runserver` (defined in `dashboard/Makefile.toml`) intentionally skips this chain for users who need to drive `manage` directly without DB or static-file mutation.
+- To skip the preflight steps (e.g., for faster restarts during iterative development, or when debugging without touching the DB), run the dashboard-local task instead:
+  ```bash
+  cd dashboard && cargo make runserver
+  ```
+  The dashboard-local `cargo make runserver` (defined in `dashboard/Makefile.toml`) intentionally has no `dependencies` so it launches the server directly. The individual preflight tasks (`cargo make migrate`, `cargo make collectstatic`) remain available from either directory if you want to run only one of them.
 
 ---
 


### PR DESCRIPTION
## Summary

This PR addresses:

- Spell out the escape-hatch command (`cd dashboard && cargo make runserver`) directly inside MG-2 in `dashboard/CLAUDE.md`, so the alternative to the workspace-root preflight chain is discoverable without chasing the cross-reference into `dashboard/Makefile.toml`
- Note that `cargo make migrate` and `cargo make collectstatic` remain available as standalone tasks from either directory

This is a small follow-up to the merged #530 (which closed #529) and addresses a Copilot review suggestion that landed too late to be folded into the original PR.

## Type of Change

- [x] Documentation update

## Motivation and Context

PR #530 introduced workspace-root `cargo make runserver` auto-chaining of `migrate` + `collectstatic` and added MG-2 in `dashboard/CLAUDE.md` describing the new behavior. Copilot's review on #530 pointed out that MG-2 referenced the dashboard-local escape hatch but did not give a literal command, leaving readers to infer the invocation from the cross-reference. This PR makes the command explicit.

Refs #529 (already closed by #530)
Refs #530 (Copilot review feedback addressed post-merge)

## How Was This Tested?

- Documentation-only change. Verified the new MG-2 paragraph reads cleanly and the `bash` code fence renders as expected
- Cherry-picked from the original feature branch (commit `34f3a4fb` -> `483d8f03` after rebase onto current main)

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (this PR is the doc update)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix` (no Rust touched)
- [x] I have checked the code with `cargo make clippy-check` (no Rust touched)
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Refs kent8192/reinhardt-cloud#529 (closed)
- Refs kent8192/reinhardt-cloud#530 (merged)

## Labels to Apply

### Type Label
- [x] `documentation` - Documentation update

### Scope Label
- [x] `dashboard`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)