### PR TITLE
fix(dashboard): repair Makefile.toml WASM build pipeline

### DIFF
--- a/dashboard/Makefile.toml
+++ b/dashboard/Makefile.toml
@@ -219,7 +219,7 @@ if [ ! -f "$WASM_FILE" ]; then
 	exit 1
 fi
 wasm-bindgen --target web "$WASM_FILE" --out-dir dist
-if command -v wasm-opt &> /dev/null; then
+if command -v wasm-opt >/dev/null 2>&1; then
 	echo "Optimizing WASM with wasm-opt..."
 	wasm-opt -O3 dist/reinhardt_cloud_dashboard_bg.wasm -o dist/reinhardt_cloud_dashboard_bg.wasm
 fi

--- a/dashboard/Makefile.toml
+++ b/dashboard/Makefile.toml
@@ -181,7 +181,7 @@ args = ["run", "--bin", "manage", "runserver", "-vvv"]
 description = "Install WASM build tools (wasm-bindgen-cli pinned to match Cargo.lock)"
 script = '''
 # Keep this version in sync with the wasm-bindgen crate in Cargo.lock
-cargo install wasm-bindgen-cli --version "0.2.114" --locked 2>/dev/null || true
+cargo install wasm-bindgen-cli --version "0.2.118" --locked 2>/dev/null || true
 '''
 
 [tasks.wasm-compile-dev]
@@ -198,8 +198,8 @@ args = ["build", "--lib", "--target", "wasm32-unknown-unknown", "--release"]
 description = "Generate JS bindings for WASM (debug)"
 script = '''
 mkdir -p dist
-WORKSPACE_ROOT="$(cargo metadata --no-deps --format-version=1 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin)['workspace_root'])" 2>/dev/null || echo "..")"
-WASM_FILE="${WORKSPACE_ROOT}/target/wasm32-unknown-unknown/debug/reinhardt_cloud.wasm"
+TARGET_DIR="$(cargo metadata --no-deps --format-version=1 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin)['target_directory'])" 2>/dev/null || echo "../target")"
+WASM_FILE="${TARGET_DIR}/wasm32-unknown-unknown/debug/reinhardt_cloud_dashboard.wasm"
 if [ ! -f "$WASM_FILE" ]; then
 	echo "Error: WASM file not found at $WASM_FILE"
 	exit 1
@@ -212,8 +212,8 @@ dependencies = ["wasm-compile-dev"]
 description = "Generate JS bindings for WASM (release)"
 script = '''
 mkdir -p dist
-WORKSPACE_ROOT="$(cargo metadata --no-deps --format-version=1 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin)['workspace_root'])" 2>/dev/null || echo "..")"
-WASM_FILE="${WORKSPACE_ROOT}/target/wasm32-unknown-unknown/release/reinhardt_cloud.wasm"
+TARGET_DIR="$(cargo metadata --no-deps --format-version=1 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin)['target_directory'])" 2>/dev/null || echo "../target")"
+WASM_FILE="${TARGET_DIR}/wasm32-unknown-unknown/release/reinhardt_cloud_dashboard.wasm"
 if [ ! -f "$WASM_FILE" ]; then
 	echo "Error: WASM file not found at $WASM_FILE"
 	exit 1
@@ -221,7 +221,7 @@ fi
 wasm-bindgen --target web "$WASM_FILE" --out-dir dist
 if command -v wasm-opt &> /dev/null; then
 	echo "Optimizing WASM with wasm-opt..."
-	wasm-opt -O3 dist/reinhardt_cloud_bg.wasm -o dist/reinhardt_cloud_bg.wasm
+	wasm-opt -O3 dist/reinhardt_cloud_dashboard_bg.wasm -o dist/reinhardt_cloud_dashboard_bg.wasm
 fi
 '''
 dependencies = ["wasm-compile-release"]


### PR DESCRIPTION
## Summary

- Bump pinned `wasm-bindgen-cli` from `0.2.114` to `0.2.118` to match `Cargo.lock` (resolves schema-version mismatch).
- Fix WASM artifact filename from `reinhardt_cloud.wasm` to `reinhardt_cloud_dashboard.wasm` (the crate's `[lib] name`).
- Fix the release `wasm-opt` invocation to reference `reinhardt_cloud_dashboard_bg.wasm` instead of the stale `reinhardt_cloud_bg.wasm`.
- Use `target_directory` from `cargo metadata` (instead of `${WORKSPACE_ROOT}/target`) so `CARGO_TARGET_DIR` / `.cargo/config.toml` overrides are honored.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

`cargo make wasm-build-dev` and `cargo make wasm-build-release` failed out of the box on a fresh checkout because three constants in `dashboard/Makefile.toml` had drifted from the rest of the project (crate rename, dependency bump, wasm-bindgen output naming). See #537 for the full failure mode and reproduction.

While verifying the fix, an additional drift was found that the issue did not call out: the release pipeline's `wasm-opt` command still referenced the old `reinhardt_cloud_bg.wasm` stem, so release builds with `wasm-opt` installed would fail at the optimization step. Included here because it is the same class of drift breaking the same pipeline.

The `TARGET_DIR` switch (vs `WORKSPACE_ROOT/target`) is a robustness improvement discovered during local verification: my environment uses `CARGO_TARGET_DIR=/Volumes/cache/...`, and the previous script failed even with the filename fix because it assumed `target/` lives under the workspace root. Reading `target_directory` from `cargo metadata` is the canonical way to locate Cargo output.

## How Was This Tested

- [x] `cargo make wasm-clean && cargo make wasm-build-dev` — succeeds, emits `dashboard/dist/reinhardt_cloud_dashboard.js` + `reinhardt_cloud_dashboard_bg.wasm` (~5 MB)
- [x] `cargo make wasm-build-release` — succeeds, emits optimized `.wasm`
- [x] Verified `cargo metadata` reports `target_directory` correctly under both default-target-dir and `CARGO_TARGET_DIR`-override environments

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (n/a — Makefile-only)
- [x] My changes generate no new warnings
- [x] All new and existing tests pass

## Labels to Apply

- `bug`
- `dashboard`

## Related Issues

Fixes #537

## Out of Scope (Deferred)

The issue's stretch goals — deriving the WASM filename and `wasm-bindgen-cli` version dynamically from `cargo metadata` / `Cargo.lock` — are intentionally not addressed here to keep the PR focused on restoring a working build (per WU-1: 1 PR = 1 fix pattern). The filename half is now partially mooted because `TARGET_DIR` is dynamic, but the crate stem and `wasm-bindgen-cli` version still need manual sync. Can be done in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)