### PR TITLE
chore(deps): bump reinhardt-web to 1f429768

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,6 +1102,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1301,7 +1334,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1897,7 +1930,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2159,7 +2192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4160,7 +4193,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5510,7 +5543,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5949,8 +5982,8 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reinhardt-admin"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6000,8 +6033,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-apps"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6030,8 +6063,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-auth"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "argon2",
  "async-trait",
@@ -6076,8 +6109,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-auth-macros"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6362,10 +6395,11 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-commands"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "async-trait",
+ "cargo_metadata",
  "chrono",
  "clap",
  "colored",
@@ -6418,8 +6452,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-conf"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "chrono",
  "dotenv",
@@ -6445,8 +6479,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-core"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "anyhow",
  "aquamarine 0.6.0",
@@ -6493,8 +6527,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-db"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -6548,8 +6582,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-di"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -6571,8 +6605,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-di-macros"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6582,8 +6616,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-forms"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "anyhow",
  "aquamarine 0.5.0",
@@ -6599,8 +6633,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-http"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6620,8 +6654,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-macros"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "ctor 0.8.0",
  "inventory",
@@ -6634,8 +6668,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-mail"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6655,8 +6689,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-manouche"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "aquamarine 0.6.0",
  "convert_case",
@@ -6668,8 +6702,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-middleware"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6704,8 +6738,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-openapi"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "async-trait",
  "reinhardt-http",
@@ -6716,8 +6750,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-openapi-macros"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6727,8 +6761,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-pages"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "aquamarine 0.5.0",
  "async-trait",
@@ -6767,8 +6801,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-pages-ast"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "aquamarine 0.6.0",
  "convert_case",
@@ -6781,8 +6815,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-pages-macros"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "convert_case",
  "darling 0.20.11",
@@ -6795,8 +6829,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-query"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -6809,8 +6843,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-query-macros"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -6820,8 +6854,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-rest"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6869,8 +6903,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-routers-macros"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6879,8 +6913,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-server"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6898,8 +6932,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-shortcuts"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "bytes",
  "hyper",
@@ -6916,8 +6950,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-test"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "cfg_aliases",
  "reinhardt-auth",
@@ -6936,8 +6970,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-testkit"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "async-dropper",
  "async-trait",
@@ -6991,8 +7025,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-throttling"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -7002,8 +7036,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-urls"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -7035,8 +7069,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-utils"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7071,8 +7105,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-views"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7107,8 +7141,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-web"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7149,8 +7183,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-websockets"
-version = "0.1.0-rc.25"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#3e776a4a739a04374d056e27858e75f084e845c4"
+version = "0.1.0-rc.26"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#1f429768cf3d6c8536b646cd2fb6cc3d12c4b07f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7500,7 +7534,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7583,7 +7617,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7781,6 +7815,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -8580,7 +8618,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9876,7 +9914,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bump `reinhardt-web` git pin from `3e776a4a` (rc.25) to `1f429768` (rc.26).
- Pulls in the cross-target macro re-export ungate cascade: #4156, #4166 (closes #4161), #4167.
- After this lands, per-app `#[url_patterns]` / `#[app_config]` sites can compile on `wasm32-unknown-unknown` — completing the unblock that #519 / #528 were waiting on.

## Type of Change

- [x] Dependency update (no functional code change in this repo)

## Motivation and Context

This is a clean dep bump split off from #528 to unblock the broader cross-target dashboard work. It is independently mergeable — no Reinhardt Cloud source needs to change for this PR.

After merge:

- `crate::config::apps`-level lifts on the dashboard (#528) become unblocked.
- The remaining `#[routes]`-body cross-target gap is tracked at upstream kent8192/reinhardt-web#4175 / reinhardt-cloud #541.

## How Was This Tested

- Local: `cargo check -p reinhardt-cloud-dashboard --all-features` passes on native against the new pin.
- Local: previous PR #528 worktree confirmed `cargo check -p reinhardt-cloud-dashboard --target wasm32-unknown-unknown --lib` also passes against the new pin once dashboard's per-app gates are lifted (covered separately on PR #528).

## Related Issues

Refs #519
Refs #528
Refs #540 (predecessor tracking issue — unblocked by this bump)
Refs #541 (new tracking issue — remaining upstream gap)
Refs kent8192/reinhardt-web#4161 (closed)
Refs kent8192/reinhardt-web#4175 (still open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)