### PR TITLE
fix(dashboard): isolate build_test_app reverser from global slot

### DIFF
--- a/dashboard/src/config/test_helpers.rs
+++ b/dashboard/src/config/test_helpers.rs
@@ -65,6 +65,11 @@ pub fn test_app() -> (APIClient, ResolvedUrls) {
 /// start. Without this ordering, view handlers that use DI-based DB injection
 /// (e.g. `#[inject] Depends<DatabaseConnection>`) would not see the
 /// TestContainers database.
+///
+/// The returned [`ResolvedUrls`] is constructed from the just-built router's
+/// own `ClientUrlReverser` rather than the process-global slot, so concurrent
+/// callers receive independent resolvers and do not race on the global
+/// reverser registered by `make_router`.
 pub fn build_test_app() -> (APIClient, ResolvedUrls) {
 	let scope = Arc::new(SingletonScope::new());
 	scope.set(AllowedOrigins(vec!["http://testserver".into()]));
@@ -86,6 +91,15 @@ pub fn build_test_app() -> (APIClient, ResolvedUrls) {
 		tokio::runtime::Handle::current().block_on(di_ctx.resolve::<DashboardRouter>())
 	})
 	.expect("Failed to resolve DashboardRouter");
+
+	// Snapshot the per-instance client reverser before unwrapping the Arc so
+	// the resulting `ResolvedUrls` does not depend on the process-global
+	// `ClientUrlReverser` slot. `make_router` still registers the reverser in
+	// that slot for production SSR `url_for` callers, but concurrent
+	// `build_test_app` invocations no longer race on global overwrites for
+	// the typed `urls.client().<app>()` accessors used by tests.
+	let client_reverser = Arc::new(router.0.client_ref().to_reverser());
+
 	let server_router = Arc::new(
 		Arc::try_unwrap(router)
 			.expect("DashboardRouter has multiple owners after resolve")
@@ -93,13 +107,6 @@ pub fn build_test_app() -> (APIClient, ResolvedUrls) {
 			.into_server(),
 	);
 
-	// `make_router` calls `register_client_reverser` as a side effect of
-	// the DI resolve above, so the client reverser is registered globally
-	// by the time we land here. Pull it out so `ResolvedUrls` can serve
-	// both `urls.server().<app>()` and `urls.client().<app>()` typed
-	// accessors in tests.
-	let client_reverser = reinhardt::get_client_reverser()
-		.expect("global ClientUrlReverser must be registered by make_router");
 	let urls = ResolvedUrls::from_router(server_router.clone(), client_reverser);
 
 	// Wrap with OpenApiRouter to serve /api/openapi.json, /api/docs, /api/redoc.

--- a/dashboard/tests/unit.rs
+++ b/dashboard/tests/unit.rs
@@ -1,2 +1,5 @@
 #[path = "unit/test_routes_configuration.rs"]
 mod test_routes_configuration;
+
+#[path = "unit/test_resolved_urls_spa_paths.rs"]
+mod test_resolved_urls_spa_paths;

--- a/dashboard/tests/unit/test_resolved_urls_spa_paths.rs
+++ b/dashboard/tests/unit/test_resolved_urls_spa_paths.rs
@@ -1,0 +1,80 @@
+//! Regression coverage for the typed `ResolvedUrls` SPA route accessors.
+//!
+//! The `#[routes]` macro emits `urls.client().<app>().<route>()` accessors
+//! whose path strings come from each app's `#[url_patterns(... mode = client)]`
+//! / `#[url_patterns(... mode = unified)]` declarations. These tests assert
+//! the rendered paths so that:
+//!
+//! - regressions in `#[routes]` macro emission or per-app route mounting are
+//!   caught at the unit-test layer (no DB / TestContainers required), and
+//! - the original coverage from the now-deleted `dashboard/src/client/url.rs`
+//!   shim is restored against the typed accessor.
+
+use reinhardt::test::APIClient;
+use reinhardt_cloud_dashboard::config::test_helpers::{ResolvedUrls, test_app};
+use rstest::rstest;
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+async fn auth_login_page_resolves_to_expected_path(test_app: (APIClient, ResolvedUrls)) {
+	// Arrange
+	let (_client, urls) = test_app;
+
+	// Act
+	let path = urls.client().auth().login_page();
+
+	// Assert
+	assert_eq!(path, "/login");
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+async fn auth_register_page_resolves_to_expected_path(test_app: (APIClient, ResolvedUrls)) {
+	// Arrange
+	let (_client, urls) = test_app;
+
+	// Act
+	let path = urls.client().auth().register_page();
+
+	// Assert
+	assert_eq!(path, "/register");
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+async fn dashboard_home_resolves_to_expected_path(test_app: (APIClient, ResolvedUrls)) {
+	// Arrange
+	let (_client, urls) = test_app;
+
+	// Act
+	let path = urls.client().dashboard().home();
+
+	// Assert
+	assert_eq!(path, "/");
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+async fn dashboard_clusters_resolves_to_expected_path(test_app: (APIClient, ResolvedUrls)) {
+	// Arrange
+	let (_client, urls) = test_app;
+
+	// Act
+	let path = urls.client().dashboard().clusters();
+
+	// Assert
+	assert_eq!(path, "/clusters");
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+async fn dashboard_deployments_resolves_to_expected_path(test_app: (APIClient, ResolvedUrls)) {
+	// Arrange
+	let (_client, urls) = test_app;
+
+	// Act
+	let path = urls.client().dashboard().deployments();
+
+	// Assert
+	assert_eq!(path, "/deployments");
+}


### PR DESCRIPTION
## Summary

Snapshot the per-instance `ClientUrlReverser` from the resolved `DashboardRouter` before unwrapping its `Arc`, so the `ResolvedUrls` returned by `build_test_app()` no longer depends on the process-global slot populated by `make_router`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

Before this change, `build_test_app()` pulled the client URL reverser out of the global `OnceCell<RwLock<Option<Arc<ClientUrlReverser>>>>` populated as a side effect of `make_router()`. Concurrent `build_test_app()` callers therefore raced on global overwrites: a router built by test A could resolve URLs against test B's reverser when both ran in parallel.

This implements option (1) from the issue — construct the resolver from the just-built router's own reverser via `router.0.client_ref().to_reverser()`, captured before `Arc::try_unwrap` consumes the `DashboardRouter`. `make_router` still writes the reverser to the global slot, since production SSR `url_for(name)` callers (post-login redirect, layout `href`s) continue to depend on it.

Fixes #547

## How Was This Tested?

- `cargo check -p reinhardt-cloud-dashboard --all-features` passes.
- `cargo clippy -p reinhardt-cloud-dashboard --all-features --lib -- -D warnings` passes.
- Existing `dashboard/tests/e2e/**` tests that consume the `test_app` fixture continue to compile against the unchanged two-arg `ResolvedUrls::from_router(server_router, client_reverser)` signature.

## Checklist

- [x] Code compiles without warnings
- [x] Lints pass (`cargo make clippy-check` equivalent)
- [x] Documentation comment on `build_test_app()` updated to describe the new isolation guarantee
- [x] No new TODOs or `dbg!` calls
- [x] No new global state introduced

## Labels to Apply

- `enhancement` (matches the linked issue's label)

🤖 Generated with [Claude Code](https://claude.com/claude-code)