### PR TITLE
test(dashboard): assert ResolvedUrls produces expected SPA paths

### DIFF
--- a/dashboard/tests/unit.rs
+++ b/dashboard/tests/unit.rs
@@ -1,2 +1,5 @@
 #[path = "unit/test_routes_configuration.rs"]
 mod test_routes_configuration;
+
+#[path = "unit/test_resolved_urls_spa_paths.rs"]
+mod test_resolved_urls_spa_paths;

--- a/dashboard/tests/unit/test_resolved_urls_spa_paths.rs
+++ b/dashboard/tests/unit/test_resolved_urls_spa_paths.rs
@@ -1,0 +1,80 @@
+//! Regression coverage for the typed `ResolvedUrls` SPA route accessors.
+//!
+//! The `#[routes]` macro emits `urls.client().<app>().<route>()` accessors
+//! whose path strings come from each app's `#[url_patterns(... mode = client)]`
+//! / `#[url_patterns(... mode = unified)]` declarations. These tests assert
+//! the rendered paths so that:
+//!
+//! - regressions in `#[routes]` macro emission or per-app route mounting are
+//!   caught at the unit-test layer (no DB / TestContainers required), and
+//! - the original coverage from the now-deleted `dashboard/src/client/url.rs`
+//!   shim is restored against the typed accessor.
+
+use reinhardt::test::APIClient;
+use reinhardt_cloud_dashboard::config::test_helpers::{ResolvedUrls, test_app};
+use rstest::rstest;
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+async fn auth_login_page_resolves_to_expected_path(test_app: (APIClient, ResolvedUrls)) {
+	// Arrange
+	let (_client, urls) = test_app;
+
+	// Act
+	let path = urls.client().auth().login_page();
+
+	// Assert
+	assert_eq!(path, "/login");
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+async fn auth_register_page_resolves_to_expected_path(test_app: (APIClient, ResolvedUrls)) {
+	// Arrange
+	let (_client, urls) = test_app;
+
+	// Act
+	let path = urls.client().auth().register_page();
+
+	// Assert
+	assert_eq!(path, "/register");
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+async fn dashboard_home_resolves_to_expected_path(test_app: (APIClient, ResolvedUrls)) {
+	// Arrange
+	let (_client, urls) = test_app;
+
+	// Act
+	let path = urls.client().dashboard().home();
+
+	// Assert
+	assert_eq!(path, "/");
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+async fn dashboard_clusters_resolves_to_expected_path(test_app: (APIClient, ResolvedUrls)) {
+	// Arrange
+	let (_client, urls) = test_app;
+
+	// Act
+	let path = urls.client().dashboard().clusters();
+
+	// Assert
+	assert_eq!(path, "/clusters");
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+async fn dashboard_deployments_resolves_to_expected_path(test_app: (APIClient, ResolvedUrls)) {
+	// Arrange
+	let (_client, urls) = test_app;
+
+	// Act
+	let path = urls.client().dashboard().deployments();
+
+	// Assert
+	assert_eq!(path, "/deployments");
+}


### PR DESCRIPTION
## Summary

Add unit tests asserting the typed `urls.client().<app>().<route>()` accessors emitted by `#[routes]` resolve to the expected SPA paths.

Routes covered:

- `urls.client().auth().login_page()` → `/login`
- `urls.client().auth().register_page()` → `/register`
- `urls.client().dashboard().home()` → `/`
- `urls.client().dashboard().clusters()` → `/clusters`
- `urls.client().dashboard().deployments()` → `/deployments`

## Type of Change

- [x] New feature (non-breaking change that adds functionality) — restoring deleted regression coverage

## Motivation and Context

PR #545 removed `dashboard/src/client/url.rs`, which contained tests asserting key SPA route reversals via the old `url_for_spa` shim. Surfaced in Copilot review on #545. With the new typed accessor, equivalent regression coverage is missing — a route rename or `#[routes]` macro emission regression would now ship to wasm SPA call sites without any test catching it.

This PR restores coverage at the unit-test layer (no DB / TestContainers required) using `#[rstest]` per project testing standards (TI-1) with strict `assert_eq!` per project rule against loose matching.

Fixes #546

## How Was This Tested?

Locally with the CI-style settings layout (`base.example.toml` → `base.toml`, `ci.example.toml` → `ci.toml`) and `REINHARDT_ENV=ci`:

```text
$ cargo nextest run -p reinhardt-cloud-dashboard --test unit test_resolved_urls_spa_paths --test-threads=8
Starting 5 tests across 1 binary (1 test skipped)
    PASS [   0.245s] auth_login_page_resolves_to_expected_path
    PASS [   0.245s] auth_register_page_resolves_to_expected_path
    PASS [   0.245s] dashboard_home_resolves_to_expected_path
    PASS [   0.245s] dashboard_clusters_resolves_to_expected_path
    PASS [   0.245s] dashboard_deployments_resolves_to_expected_path
Summary [   0.246s] 5 tests run: 5 passed, 1 skipped
```

Three back-to-back parallel runs were stable, exercising the per-instance reverser path introduced by the prerequisite PR #548 (#547).

## Checklist

- [x] All tests pass locally with `cargo nextest run`
- [x] Tests use `#[rstest]` (project testing standard TI-1)
- [x] Tests assert with strict `assert_eq!` (no loose matching)
- [x] Test file location follows dashboard/CLAUDE.md TD-2 (cross-app unit test → `dashboard/tests/unit/`)
- [x] Test filename describes the specific feature under test (TD-3)
- [x] `cargo clippy --tests --all-features -- -D warnings` passes

## Labels to Apply

- `enhancement` (matches the linked issue's label)

## Related Issues

- Depends on: #548 (fixes #547 — `build_test_app` reverser isolation; without it the typed accessors race on the global slot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)