### PR TITLE
chore(settings): add production.example.toml and staging.example.toml templates

### DIFF
--- a/dashboard/settings/production.example.toml
+++ b/dashboard/settings/production.example.toml
@@ -1,0 +1,87 @@
+# Production Environment Settings — TEMPLATE
+#
+# This file is a documented reference for the production environment. It
+# mirrors the schema of `production.toml` (which is loaded when
+# REINHARDT_ENV=production) so deployers can compare the active config
+# against a known-good shape.
+#
+# In normal deployments, `production.toml` is what the server actually loads;
+# this `.example.toml` is *not* read at runtime. Use it as:
+#   1. A reference for required keys when authoring overrides.
+#   2. A starting point if `production.toml` ever needs to be regenerated.
+#
+# Note: env-specific TOML replaces the entire [core] section from base.toml,
+# so all required core fields must be specified here.
+#
+# Secrets MUST be supplied at deploy time via REINHARDT_* environment
+# variables (Kubernetes Secret, SealedSecret, External Secrets, etc.). The
+# placeholders below exist only to keep the schema valid; deploying with them
+# unmodified is unsafe.
+#   REINHARDT_CLOUD_JWT_SECRET                       — top-level jwt_secret
+#   REINHARDT_CLOUD_REDIS_URL                        — top-level redis_url
+#   REINHARDT_CORE__SECRET_KEY                       — [core].secret_key
+#   REINHARDT_CORE__DATABASES__DEFAULT__PASSWORD     — [core.databases.default].password
+#   REINHARDT_DATABASE__PASSWORD                     — [database].password
+#   REINHARDT_EMAIL__HOST / __PORT / __USERNAME / __PASSWORD — [email] SMTP
+
+# JWT secret — MUST be overridden via REINHARDT_CLOUD_JWT_SECRET (>= 32 bytes
+# of cryptographically random data).
+jwt_secret = "CHANGE-ME-via-REINHARDT_CLOUD_JWT_SECRET"
+
+# Redis URL — MUST be overridden via REINHARDT_CLOUD_REDIS_URL.
+redis_url = "redis://redis.production.internal:6379/0"
+
+[core]
+debug = false
+secret_key = "CHANGE-ME-via-REINHARDT_CORE__SECRET_KEY"
+allowed_hosts = ["reinhardt-cloud.dev", "www.reinhardt-cloud.dev"]
+root_urlconf = ""
+
+middleware = []
+
+# Security settings (full production hardening)
+[core.security]
+append_slash = true
+session_cookie_secure = true
+csrf_cookie_secure = true
+secure_ssl_redirect = true
+secure_hsts_include_subdomains = true
+secure_hsts_preload = true
+
+# Database configuration — credentials MUST be overridden via
+# REINHARDT_CORE__DATABASES__DEFAULT__* env vars (or equivalent secret store).
+[core.databases.default]
+engine = "postgresql"
+host = "db.production.internal"
+port = 5432
+name = "reinhardt_cloud"
+user = "reinhardt"
+password = { secret = "CHANGE-ME-via-REINHARDT_CORE__DATABASES__DEFAULT__PASSWORD" }
+options = {}
+
+# Top-level [database] section required by reinhardt-web's runserver/migrate commands.
+[database]
+engine = "postgresql"
+host = "db.production.internal"
+port = 5432
+name = "reinhardt_cloud"
+user = "reinhardt"
+password = "CHANGE-ME-via-REINHARDT_DATABASE__PASSWORD"
+
+[cors]
+allow_origins = ["https://reinhardt-cloud.dev", "https://www.reinhardt-cloud.dev"]
+
+# Production email delivery — Cloudflare Email Routing is INBOUND only
+# (see base.toml [email] comment). Outbound delivery REQUIRES a third-party
+# provider (Resend / SendGrid / AWS SES / Postmark). Override host/port/
+# credentials via REINHARDT_EMAIL__* env vars and publish the provider's SPF
+# include + DKIM selector on the reinhardt-cloud.dev DNS zone.
+#
+# Defaults below assume STARTTLS on 587; switch to use_ssl=true / use_tls=false
+# for implicit-TLS providers on 465.
+[email]
+host = "smtp.production-provider.invalid"
+port = 587
+from_email = "noreply@reinhardt-cloud.dev"
+use_ssl = false
+use_tls = true

--- a/dashboard/settings/production.example.toml
+++ b/dashboard/settings/production.example.toml
@@ -22,7 +22,15 @@
 #   REINHARDT_CORE__SECRET_KEY                       — [core].secret_key
 #   REINHARDT_CORE__DATABASES__DEFAULT__PASSWORD     — [core.databases.default].password
 #   REINHARDT_DATABASE__PASSWORD                     — [database].password
-#   REINHARDT_EMAIL__HOST / __PORT / __USERNAME / __PASSWORD — [email] SMTP
+#   REINHARDT_EMAIL__BACKEND="smtp"                  — Trigger env-based SMTP override
+#   REINHARDT_EMAIL__HOST / __PORT                   — SMTP target (read only when BACKEND=smtp)
+#
+# Note: SMTP credentials, TLS settings, from_email, and timeout are NOT yet
+# read from env vars by `dashboard::apps::auth::services::email::get_email_backend()`
+# (only BACKEND/HOST/PORT are honored, and the env-driven path forces
+# `SmtpSecurity::None` with no credentials). Configure those fields in this
+# TOML or via TOML overrides at deploy time. Broader env-var coverage is
+# tracked in #558.
 
 # JWT secret — MUST be overridden via REINHARDT_CLOUD_JWT_SECRET (>= 32 bytes
 # of cryptographically random data).
@@ -73,9 +81,16 @@ allow_origins = ["https://reinhardt-cloud.dev", "https://www.reinhardt-cloud.dev
 
 # Production email delivery — Cloudflare Email Routing is INBOUND only
 # (see base.toml [email] comment). Outbound delivery REQUIRES a third-party
-# provider (Resend / SendGrid / AWS SES / Postmark). Override host/port/
-# credentials via REINHARDT_EMAIL__* env vars and publish the provider's SPF
-# include + DKIM selector on the reinhardt-cloud.dev DNS zone.
+# provider (Resend / SendGrid / AWS SES / Postmark) and the provider's SPF
+# include + DKIM selector must be published on the reinhardt-cloud.dev DNS zone.
+#
+# Env-var overrides supported by the runtime today (see header for the full
+# list and #558 for upcoming expansion):
+#   REINHARDT_EMAIL__BACKEND="smtp"  — must be set to enable env override
+#   REINHARDT_EMAIL__HOST            — SMTP destination
+#   REINHARDT_EMAIL__PORT            — SMTP port
+# All other fields below (credentials, TLS toggles, from_email, timeout) are
+# read from this TOML; setting them via env has no effect at present.
 #
 # Defaults below assume STARTTLS on 587; switch to use_ssl=true / use_tls=false
 # for implicit-TLS providers on 465.

--- a/dashboard/settings/staging.example.toml
+++ b/dashboard/settings/staging.example.toml
@@ -1,0 +1,86 @@
+# Staging Environment Settings — TEMPLATE
+#
+# This file is a documented reference for the staging environment. It mirrors
+# the schema of `staging.toml` (which is loaded when REINHARDT_ENV=staging) so
+# deployers can compare the active config against a known-good shape.
+#
+# In normal deployments, `staging.toml` is what the server actually loads;
+# this `.example.toml` is *not* read at runtime. Use it as:
+#   1. A reference for required keys when authoring overrides.
+#   2. A starting point if `staging.toml` ever needs to be regenerated.
+#
+# Staging mirrors the production posture (security on, debug off) but uses
+# staging-specific hosts and lower-stakes credentials so release candidates
+# can be exercised end-to-end before promotion.
+#
+# Note: env-specific TOML replaces the entire [core] section from base.toml,
+# so all required core fields must be specified here.
+#
+# Secrets MUST be supplied at deploy time via REINHARDT_* environment
+# variables; the placeholders below exist only to keep the schema valid for
+# `cargo check` and local previews.
+#   REINHARDT_CLOUD_JWT_SECRET                       — top-level jwt_secret
+#   REINHARDT_CLOUD_REDIS_URL                        — top-level redis_url
+#   REINHARDT_CORE__SECRET_KEY                       — [core].secret_key
+#   REINHARDT_CORE__DATABASES__DEFAULT__PASSWORD     — [core.databases.default].password
+#   REINHARDT_DATABASE__PASSWORD                     — [database].password
+#   REINHARDT_EMAIL__HOST / __PORT / __USERNAME / __PASSWORD — [email] SMTP
+
+# JWT secret — MUST be overridden via REINHARDT_CLOUD_JWT_SECRET in the
+# deployed environment.
+jwt_secret = "CHANGE-ME-via-REINHARDT_CLOUD_JWT_SECRET"
+
+# Redis URL — MUST be overridden via REINHARDT_CLOUD_REDIS_URL.
+redis_url = "redis://redis.staging.internal:6379/0"
+
+[core]
+debug = false
+secret_key = "CHANGE-ME-via-REINHARDT_CORE__SECRET_KEY"
+allowed_hosts = ["staging.reinhardt-cloud.dev"]
+root_urlconf = ""
+
+middleware = []
+
+# Security settings (production-aligned; staging serves over HTTPS).
+# HSTS preload stays disabled until the staging hostname is ready for the
+# preload list; flip secure_hsts_preload to true after rollout sign-off.
+[core.security]
+append_slash = true
+session_cookie_secure = true
+csrf_cookie_secure = true
+secure_ssl_redirect = true
+secure_hsts_include_subdomains = true
+secure_hsts_preload = false
+
+# Database configuration — credentials MUST be overridden via
+# REINHARDT_CORE__DATABASES__DEFAULT__* env vars (or equivalent secret store).
+[core.databases.default]
+engine = "postgresql"
+host = "db.staging.internal"
+port = 5432
+name = "reinhardt_cloud_staging"
+user = "reinhardt"
+password = { secret = "CHANGE-ME-via-REINHARDT_CORE__DATABASES__DEFAULT__PASSWORD" }
+options = {}
+
+# Top-level [database] section required by reinhardt-web's runserver/migrate commands.
+[database]
+engine = "postgresql"
+host = "db.staging.internal"
+port = 5432
+name = "reinhardt_cloud_staging"
+user = "reinhardt"
+password = "CHANGE-ME-via-REINHARDT_DATABASE__PASSWORD"
+
+[cors]
+allow_origins = ["https://staging.reinhardt-cloud.dev"]
+
+# Staging email delivery — point at a real provider (Resend/SES/etc.) via env
+# overrides (REINHARDT_EMAIL__HOST, REINHARDT_EMAIL__PORT, REINHARDT_EMAIL__USERNAME,
+# REINHARDT_EMAIL__PASSWORD). Defaults below assume STARTTLS on 587.
+[email]
+host = "smtp.staging-provider.invalid"
+port = 587
+from_email = "noreply@staging.reinhardt-cloud.dev"
+use_ssl = false
+use_tls = true

--- a/dashboard/settings/staging.example.toml
+++ b/dashboard/settings/staging.example.toml
@@ -24,7 +24,15 @@
 #   REINHARDT_CORE__SECRET_KEY                       — [core].secret_key
 #   REINHARDT_CORE__DATABASES__DEFAULT__PASSWORD     — [core.databases.default].password
 #   REINHARDT_DATABASE__PASSWORD                     — [database].password
-#   REINHARDT_EMAIL__HOST / __PORT / __USERNAME / __PASSWORD — [email] SMTP
+#   REINHARDT_EMAIL__BACKEND="smtp"                  — Trigger env-based SMTP override
+#   REINHARDT_EMAIL__HOST / __PORT                   — SMTP target (read only when BACKEND=smtp)
+#
+# Note: SMTP credentials, TLS settings, from_email, and timeout are NOT yet
+# read from env vars by `dashboard::apps::auth::services::email::get_email_backend()`
+# (only BACKEND/HOST/PORT are honored, and the env-driven path forces
+# `SmtpSecurity::None` with no credentials). Configure those fields in this
+# TOML or via TOML overrides at deploy time. Broader env-var coverage is
+# tracked in #558.
 
 # JWT secret — MUST be overridden via REINHARDT_CLOUD_JWT_SECRET in the
 # deployed environment.
@@ -75,9 +83,17 @@ password = "CHANGE-ME-via-REINHARDT_DATABASE__PASSWORD"
 [cors]
 allow_origins = ["https://staging.reinhardt-cloud.dev"]
 
-# Staging email delivery — point at a real provider (Resend/SES/etc.) via env
-# overrides (REINHARDT_EMAIL__HOST, REINHARDT_EMAIL__PORT, REINHARDT_EMAIL__USERNAME,
-# REINHARDT_EMAIL__PASSWORD). Defaults below assume STARTTLS on 587.
+# Staging email delivery — point at a real provider (Resend/SES/etc.).
+#
+# Env-var overrides supported by the runtime today (see header for the full
+# list and #558 for upcoming expansion):
+#   REINHARDT_EMAIL__BACKEND="smtp"  — must be set to enable env override
+#   REINHARDT_EMAIL__HOST            — SMTP destination
+#   REINHARDT_EMAIL__PORT            — SMTP port
+# All other fields below (credentials, TLS toggles, from_email, timeout) are
+# read from this TOML; setting them via env has no effect at present.
+#
+# Defaults below assume STARTTLS on 587.
 [email]
 host = "smtp.staging-provider.invalid"
 port = 587


### PR DESCRIPTION
## Summary

- Add `dashboard/settings/production.example.toml` and `dashboard/settings/staging.example.toml`
- Mirror the existing `base.example.toml` / `ci.example.toml` / `local.example.toml` convention
- Document the complete `REINHARDT_*` env-var override flow inline (jwt_secret, redis_url, secret_key, database password, SMTP provider)

## Type of Change

- [x] Documentation update / chore
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Motivation and Context

The settings directory previously shipped active `production.toml` / `staging.toml` (added in PR #507) but no companion `*.example.toml` files. Other environments (`base`, `ci`, `local`) all ship example templates; this PR closes that gap so the layout is symmetric and deployers no longer need to cross-reference unrelated env templates when authoring overrides.

Each template now documents the full env-var override path inline so the resolution flow in `dashboard::config::settings` is discoverable from the file itself.

## How Was This Tested

- [x] `python3 -m tomllib` parses both new files cleanly
- [x] `cargo make fmt-check` clean (no Rust changes; verifies repo-wide formatting state is unchanged)
- [x] `dashboard/settings/.gitignore` already exempts `*.example.toml` (`!*.example.toml`), so the new files are tracked correctly
- [x] No active runtime path loads `*.example.toml`; production.toml/staging.toml are unchanged

## Checklist

- [x] Code follows project style guidelines (no Rust changes)
- [x] Documentation updated (the templates themselves are the documentation)
- [x] No breaking changes
- [x] Commit message follows Conventional Commits
- [x] PR title follows Conventional Commits
- [x] Linked to closing issue (`Fixes #553`)

## Labels to Apply

- `enhancement`

## Related Issues

Fixes #553
Refs #499 (precursor PR #507 added the active `production.toml` / `staging.toml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
