### PR TITLE
chore(dashboard): apply pending clippy auto-fixes to client and config

### DIFF
--- a/dashboard/src/client.rs
+++ b/dashboard/src/client.rs
@@ -31,7 +31,7 @@ mod wasm_entry {
 
 	/// WASM entry point — invoked automatically when the module loads.
 	#[wasm_bindgen(start)]
-	pub fn main() -> Result<(), JsValue> {
+	pub(super) fn main() -> Result<(), JsValue> {
 		// Hedge: ClientLauncher installs the panic hook when its feature
 		// is enabled; calling set_once twice is harmless.
 		console_error_panic_hook::set_once();

--- a/dashboard/src/client/router.rs
+++ b/dashboard/src/client/router.rs
@@ -40,14 +40,12 @@ use super::pages::not_found_page;
 /// Passed to `ClientLauncher::router(init_router)` from `client.rs`.
 pub fn init_router() -> Router {
 	Router::new()
-		.named_route("dashboard:home", "/", || dashboard_shell())
-		.named_route("auth:login_page", "/login", || login_page())
-		.named_route("auth:register_page", "/register", || register_page())
+		.named_route("dashboard:home", "/", dashboard_shell)
+		.named_route("auth:login_page", "/login", login_page)
+		.named_route("auth:register_page", "/register", register_page)
 		// Placeholder names so navigation hrefs resolve via UrlResolver
 		// even before these pages are implemented.
-		.named_route("dashboard:clusters", "/clusters", || not_found_page())
-		.named_route("dashboard:deployments", "/deployments", || {
-			not_found_page()
-		})
-		.not_found(|| not_found_page())
+		.named_route("dashboard:clusters", "/clusters", not_found_page)
+		.named_route("dashboard:deployments", "/deployments", not_found_page)
+		.not_found(not_found_page)
 }

--- a/dashboard/src/client/ws.rs
+++ b/dashboard/src/client/ws.rs
@@ -32,10 +32,10 @@ use crate::apps::deployments::client::components::{cluster_health, log_viewer};
 #[cfg(wasm)]
 thread_local! {
 	static SUBSCRIBED_IDS: RefCell<HashSet<String>> = RefCell::new(HashSet::new());
-	static RECONNECT_ATTEMPTS: RefCell<u32> = RefCell::new(0);
+	static RECONNECT_ATTEMPTS: RefCell<u32> = const { RefCell::new(0) };
 	/// Holds the current WebSocket so it can be explicitly closed on reconnect,
 	/// preventing leaked Closures from accumulating across connection cycles.
-	static CURRENT_WS: RefCell<Option<WebSocket>> = RefCell::new(None);
+	static CURRENT_WS: RefCell<Option<WebSocket>> = const { RefCell::new(None) };
 }
 
 #[cfg(wasm)]

--- a/dashboard/src/config/urls.rs
+++ b/dashboard/src/config/urls.rs
@@ -45,6 +45,7 @@ use reinhardt::pages::server_fn::ServerFnRouterExt;
 #[cfg(native)]
 use reinhardt::register_client_reverser;
 use reinhardt::routes;
+#[cfg(native)]
 use reinhardt::urls::prelude::UnifiedRouter;
 
 #[cfg(native)]


### PR DESCRIPTION
## Summary

- Apply four mechanical clippy auto-fixes to `dashboard/src/client.rs`, `dashboard/src/client/router.rs`, `dashboard/src/client/ws.rs`, and `dashboard/src/config/urls.rs`
- Addresses `unreachable_pub`, `redundant_closure`, `thread_local_initializer_can_be_made_const`, and a `cfg(native)`-gated unused import

## Type of Change

- [x] Code quality / chore
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Motivation and Context

These improvements were prepared in the worktree backing PR #545 (the typed-URL migration that closed #519) but were out of scope and never landed. They apply cleanly against current `main` and align with project-wide policy:

- `-Wunreachable_pub` is enabled globally in `.cargo/config.toml`, so tightening `wasm_entry::main` to `pub(super)` is consistent with that lint posture.
- The `redundant_closure` cleanups remove six `|| f()` wrappers in `init_router`, leaving function pointers passed directly.
- `const { RefCell::new(...) }` thread-local initializers are stable and cheaper at startup than the runtime-evaluated form.
- The `UnifiedRouter` import was unused on non-native targets; gating it with `#[cfg(native)]` mirrors the surrounding `register_client_reverser` import pattern.

## How Was This Tested

- [x] `cargo make fmt-check` clean
- [x] `cargo make clippy-check` clean (exit 0, no warnings)
- [x] All four changes are mechanical refactors with no behavior change

## Checklist

- [x] Code follows project style guidelines
- [x] No documentation updates needed (no public API change)
- [x] No breaking changes
- [x] Commit message follows Conventional Commits
- [x] PR title follows Conventional Commits
- [x] Linked to closing issue (`Fixes #554`)

## Labels to Apply

- `enhancement`

## Related Issues

Fixes #554
Refs #519 / PR #545 (precursor; the original worktree where these fixes were authored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
