### PR TITLE
feat(operator): add Dockerfile and image publish workflow

### DIFF
--- a/.github/workflows/build-release-assets.yml
+++ b/.github/workflows/build-release-assets.yml
@@ -219,3 +219,74 @@ jobs:
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+  build-operator-image:
+    name: Build and publish reinhardt-cloud-operator image
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    # Only publish the Operator image for operator releases. The release-plz
+    # crate-scoped tag prefix keeps the image version aligned with the crate.
+    if: startsWith(github.ref_name, 'reinhardt-cloud-operator@v')
+    permissions:
+      contents: read
+      packages: write
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/reinhardt-cloud-operator
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Derive semver image tag
+        id: tag
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        # release-plz tags look like `reinhardt-cloud-operator@v0.1.0`. The
+        # portion after `@` is the semver we want on the image tag. Strip
+        # the leading `v` so the tag matches `Chart.appVersion`, which the
+        # Helm chart resolves via `_helpers.tpl` without a prefix (mirrors
+        # the dashboard image job).
+        run: |
+          semver="${REF_NAME##*@}"
+          echo "semver=${semver#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
+
+      - name: Cache Buildx layers
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
+        with:
+          path: /tmp/.buildx-cache
+          key: buildx-operator-${{ github.ref_name }}
+          restore-keys: |
+            buildx-operator-
+
+      - name: Log in to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6
+        with:
+          context: .
+          file: crates/reinhardt-cloud-operator/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.semver }}
+            ${{ env.IMAGE_NAME }}:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+      - name: Rotate Buildx cache
+        # Moves the fresh cache into place so the next run restores it cleanly
+        # without the cache growing unbounded across runs.
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/charts/reinhardt-cloud-operator/templates/deployment.yaml
+++ b/charts/reinhardt-cloud-operator/templates/deployment.yaml
@@ -31,11 +31,17 @@ spec:
           env:
             - name: REINHARDT_CLOUD_PLATFORM
               value: {{ .Values.platform | quote }}
+            # Always bind the always-on HTTP server (healthz + optional
+            # metrics) to `.Values.metrics.port` so the containerPort and
+            # probe targets stay consistent even when metrics scraping is
+            # disabled. `REINHARDT_CLOUD_METRICS_ENABLED` remains gated by
+            # `.Values.metrics.enabled` so `/metrics` is only exposed when
+            # the operator opts in.
+            - name: REINHARDT_CLOUD_METRICS_ADDR
+              value: {{ printf "0.0.0.0:%d" (int .Values.metrics.port) | quote }}
             {{- if .Values.metrics.enabled }}
             - name: REINHARDT_CLOUD_METRICS_ENABLED
               value: "true"
-            - name: REINHARDT_CLOUD_METRICS_ADDR
-              value: {{ printf "0.0.0.0:%d" (int .Values.metrics.port) | quote }}
             {{- end }}
             - name: REINHARDT_LOG_FORMAT
               value: {{ .Values.logging.format | quote }}

--- a/charts/reinhardt-cloud-operator/templates/deployment.yaml
+++ b/charts/reinhardt-cloud-operator/templates/deployment.yaml
@@ -59,12 +59,26 @@ spec:
             - name: OTEL_SERVICE_NAME
               value: {{ .Values.tracing.serviceName | default .Release.Name | quote }}
             {{- end }}
-          {{- if .Values.metrics.enabled }}
           ports:
-            - name: metrics
+            - name: http
               containerPort: {{ .Values.metrics.port }}
               protocol: TCP
-          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           resources:

--- a/charts/reinhardt-cloud-operator/templates/service.yaml
+++ b/charts/reinhardt-cloud-operator/templates/service.yaml
@@ -15,7 +15,7 @@ spec:
   ports:
     - name: metrics
       port: {{ .Values.metrics.port }}
-      targetPort: metrics
+      targetPort: http
       protocol: TCP
   selector:
     {{- include "reinhardt-cloud-operator.selectorLabels" . | nindent 4 }}

--- a/charts/reinhardt-cloud-operator/values.yaml
+++ b/charts/reinhardt-cloud-operator/values.yaml
@@ -1,8 +1,15 @@
 replicaCount: 1
 
 image:
-  repository: reinhardt-cloud-operator
+  # Default image published to GHCR by `.github/workflows/build-release-assets.yml`
+  # on every `reinhardt-cloud-operator@v*` release-plz tag. Override
+  # `repository` when pulling from a private registry; see `values-gcp.yaml`,
+  # `values-aws.yaml`, and `values-onprem.yaml` for examples.
+  repository: ghcr.io/kent8192/reinhardt-cloud-operator
   pullPolicy: IfNotPresent
+  # When empty, the chart resolves the tag to `Chart.appVersion` via
+  # `_helpers.tpl`. Pin a value here only to override the chart-tracked
+  # version (e.g. when validating a pre-release image).
   tag: ""
 
 imagePullSecrets: []
@@ -66,7 +73,11 @@ logging:
 
 podSecurityContext:
   runAsNonRoot: true
-  runAsUser: 1000
+  # Distroless `nonroot` user (uid/gid 65532). Must match the USER
+  # directive in `crates/reinhardt-cloud-operator/Dockerfile`.
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
 
 securityContext:
   allowPrivilegeEscalation: false
@@ -81,10 +92,11 @@ resources:
     memory: 128Mi
 
 metrics:
-  # Enable the Prometheus /metrics endpoint exposed by the operator.
+  # When true, the operator's HTTP server returns Prometheus output on
+  # /metrics. The HTTP server itself is *always* started to serve /healthz
+  # for kubelet probes; this flag controls only the /metrics endpoint
+  # contents (404 when disabled).
   enabled: false
-  # Port on which the operator serves /metrics. The operator container
-  # always listens on this port when metrics are enabled.
   port: 9090
   service:
     type: ClusterIP
@@ -189,3 +201,18 @@ tracing:
   samplerArg: "0.1"
   # Service name reported in spans. Defaults to "reinhardt-cloud-operator".
   serviceName: "reinhardt-cloud-operator"
+
+# Probe timing for the operator's HTTP server. Both probes hit /healthz
+# on the container `http` port (defined by `metrics.port`). Override here
+# if your cluster needs longer startup grace.
+probes:
+  liveness:
+    initialDelaySeconds: 10
+    periodSeconds: 20
+    timeoutSeconds: 3
+    failureThreshold: 3
+  readiness:
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 3

--- a/crates/reinhardt-cloud-operator/Dockerfile
+++ b/crates/reinhardt-cloud-operator/Dockerfile
@@ -1,0 +1,62 @@
+# syntax=docker/dockerfile:1.7
+#
+# Multi-stage Dockerfile for reinhardt-cloud-operator.
+#
+# - Builder stage: pinned Rust toolchain (matches rust-toolchain.toml) with
+#   cargo-chef for dependency-layer caching and protoc for tonic codegen.
+# - Runtime stage: Google distroless cc-debian12:nonroot (uid 65532). The
+#   operator listens on a metrics/healthz HTTP port (default 9090) and does
+#   not require any privileged capability or shell at runtime.
+
+###############################################################################
+# Stage 1: cargo-chef planner
+# Computes a recipe from the workspace manifest so the dependency build layer
+# can be cached independently from the application source.
+###############################################################################
+FROM rust:1.94-bookworm AS chef
+
+# protoc is required by the `reinhardt-cloud-proto` build script (tonic-build).
+# libprotobuf-dev ships the well-known protos (google/protobuf/timestamp.proto
+# etc.) that build.proto imports. libssl-dev is omitted on purpose: the
+# workspace uses rustls for TLS.
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev \
+	&& rm -rf /var/lib/apt/lists/*
+
+RUN cargo install cargo-chef --locked --version ^0.1
+
+WORKDIR /build
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+###############################################################################
+# Stage 2: builder
+# Restores cached dependency artifacts from the chef recipe, then compiles the
+# operator binary in release mode.
+###############################################################################
+FROM chef AS builder
+
+COPY --from=planner /build/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json --bin reinhardt-cloud-operator
+
+COPY . .
+RUN cargo build --release --bin reinhardt-cloud-operator \
+	&& strip target/release/reinhardt-cloud-operator
+
+###############################################################################
+# Stage 3: runtime
+# Distroless cc-debian12:nonroot provides libc, CA certificates, and runs as
+# uid 65532 by default. No shell, no package manager, minimal attack surface.
+###############################################################################
+FROM gcr.io/distroless/cc-debian12:nonroot AS runtime
+
+COPY --from=builder /build/target/release/reinhardt-cloud-operator /usr/local/bin/reinhardt-cloud-operator
+
+USER nonroot:nonroot
+
+# Operator HTTP server (always serves /healthz; /metrics gated by env).
+EXPOSE 9090
+
+ENTRYPOINT ["/usr/local/bin/reinhardt-cloud-operator"]

--- a/crates/reinhardt-cloud-operator/Dockerfile.dockerignore
+++ b/crates/reinhardt-cloud-operator/Dockerfile.dockerignore
@@ -1,0 +1,62 @@
+# Keep the build context small and deterministic.
+#
+# The Dockerfile builds from the repository root (so cargo-chef can see the
+# full workspace manifest and Cargo.lock). The entries below exclude files
+# that are not required at build time: local tooling state, editor/IDE
+# artifacts, git metadata, docs, and every `target/` directory produced by
+# cargo.
+
+# Version control
+.git
+.gitattributes
+.gitignore
+.gitmessage
+
+# Cargo build artifacts (every workspace member)
+target
+**/target
+
+# Editor / IDE state
+.idea
+.vscode
+.zed
+.cursor
+*.swp
+*~
+.DS_Store
+
+# Claude Code / agent tooling state
+.claude
+.serena
+.devin
+.aider*
+
+# Coast / local runtime
+Coastfile
+
+# Docs and top-level markdown (not needed for the binary build).
+# README.md at the operator crate root is still included via `!` below.
+docs
+**/*.md
+!crates/reinhardt-cloud-operator/README.md
+!README.md
+
+# Test/CI artefacts
+tests/fixtures/**/target
+.cargo/registry
+.cargo/git
+
+# Node / dashboard assets not needed for the Rust binary build
+dashboard/node_modules
+dashboard/**/dist
+dashboard/**/build
+
+# Helm/Terraform/infra (not required by the operator binary)
+charts
+infra
+
+# Misc
+*.log
+.env
+.env.*
+!.env.example

--- a/crates/reinhardt-cloud-operator/src/main.rs
+++ b/crates/reinhardt-cloud-operator/src/main.rs
@@ -51,44 +51,40 @@ async fn main() -> anyhow::Result<()> {
 
 	let operator_metrics = metrics::Metrics::new();
 
-	// Launch the Prometheus exporter only when explicitly enabled. This
-	// matches the Helm chart's `metrics.enabled` flag: when disabled the
-	// operator does not open a listening socket, avoiding unexpected open
-	// ports and port conflicts. Either setting `REINHARDT_CLOUD_METRICS_ENABLED=true`
-	// or providing `REINHARDT_CLOUD_METRICS_ADDR` turns the exporter on.
-	// Errors binding the exporter are logged by the spawned task; the
-	// operator keeps running so that reconciliation is not blocked by a
-	// metrics port conflict.
+	// The operator's HTTP server is always started so that kubelet probes
+	// have a `/healthz` to call. The `/metrics` endpoint is conditionally
+	// enabled by `REINHARDT_CLOUD_METRICS_ENABLED`; when disabled, the same
+	// server returns 404 for `/metrics` while still answering `/healthz`.
 	let metrics_addr = std::env::var("REINHARDT_CLOUD_METRICS_ADDR").ok();
 	let metrics_enabled = std::env::var("REINHARDT_CLOUD_METRICS_ENABLED")
 		.ok()
 		.is_some_and(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "True"));
-	if metrics_enabled || metrics_addr.is_some() {
-		// When `REINHARDT_CLOUD_METRICS_ADDR` is present but unparsable, do
-		// NOT silently fall back to `0.0.0.0:9090` — that could expose the
-		// exporter on all interfaces or collide with another listener while
-		// hiding a configuration mistake. Refuse to start the exporter and
-		// surface the error so the operator (or its operator) can fix the
-		// supplied value.
-		let bind: Option<SocketAddr> = match metrics_addr.as_deref() {
-			Some(raw) => match raw.parse::<SocketAddr>() {
-				Ok(addr) => Some(addr),
-				Err(err) => {
-					tracing::error!(
-						"Invalid REINHARDT_CLOUD_METRICS_ADDR={raw:?}: {err}; metrics exporter disabled"
-					);
-					None
-				}
-			},
-			None => Some("0.0.0.0:9090".parse().expect("static bind address")),
-		};
-		if let Some(bind) = bind {
-			metrics::spawn_exporter(operator_metrics.clone(), bind);
-		}
+	let mode = if metrics_enabled {
+		metrics::MetricsMode::Enabled
 	} else {
-		tracing::info!(
-			"Prometheus metrics exporter disabled (set REINHARDT_CLOUD_METRICS_ENABLED=true or REINHARDT_CLOUD_METRICS_ADDR to enable)"
-		);
+		metrics::MetricsMode::Disabled
+	};
+
+	// When `REINHARDT_CLOUD_METRICS_ADDR` is present but unparsable, do
+	// NOT silently fall back to `0.0.0.0:9090` — that could expose the
+	// server on all interfaces or collide with another listener while
+	// hiding a configuration mistake. Refuse to start the listener and
+	// surface the error so the operator (or its operator) can fix the
+	// supplied value.
+	let bind: Option<SocketAddr> = match metrics_addr.as_deref() {
+		Some(raw) => match raw.parse::<SocketAddr>() {
+			Ok(addr) => Some(addr),
+			Err(err) => {
+				tracing::error!(
+					"Invalid REINHARDT_CLOUD_METRICS_ADDR={raw:?}: {err}; HTTP server (healthz/metrics) disabled"
+				);
+				None
+			}
+		},
+		None => Some("0.0.0.0:9090".parse().expect("static bind address")),
+	};
+	if let Some(bind) = bind {
+		metrics::spawn_exporter(operator_metrics.clone(), bind, mode);
 	}
 
 	// Surface the default telemetry retention policy at startup so operators

--- a/crates/reinhardt-cloud-operator/src/main.rs
+++ b/crates/reinhardt-cloud-operator/src/main.rs
@@ -51,10 +51,15 @@ async fn main() -> anyhow::Result<()> {
 
 	let operator_metrics = metrics::Metrics::new();
 
-	// The operator's HTTP server is always started so that kubelet probes
-	// have a `/healthz` to call. The `/metrics` endpoint is conditionally
-	// enabled by `REINHARDT_CLOUD_METRICS_ENABLED`; when disabled, the same
-	// server returns 404 for `/metrics` while still answering `/healthz`.
+	// The operator's HTTP server is started by default (binding to
+	// `0.0.0.0:9090`) so that kubelet probes have a `/healthz` to call.
+	// `REINHARDT_CLOUD_METRICS_ADDR` overrides the bind address; if the
+	// override is present but unparsable, the listener is intentionally
+	// skipped (see comment near `bind` below) and BOTH `/healthz` and
+	// `/metrics` will be unavailable until the env-var is fixed.
+	// The `/metrics` endpoint is conditionally enabled by
+	// `REINHARDT_CLOUD_METRICS_ENABLED`; when disabled, the same server
+	// returns 404 for `/metrics` while still answering `/healthz`.
 	let metrics_addr = std::env::var("REINHARDT_CLOUD_METRICS_ADDR").ok();
 	let metrics_enabled = std::env::var("REINHARDT_CLOUD_METRICS_ENABLED")
 		.ok()

--- a/crates/reinhardt-cloud-operator/src/metrics.rs
+++ b/crates/reinhardt-cloud-operator/src/metrics.rs
@@ -38,6 +38,18 @@ const MAX_CONCURRENT_METRICS_CONNECTIONS: usize = 32;
 /// or response-write step before giving up.
 const METRICS_IO_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Whether the HTTP server should expose Prometheus output on `/metrics`.
+///
+/// `/healthz` is served unconditionally so kubelet probes always succeed
+/// while the process is running. The `/metrics` endpoint, in contrast,
+/// is gated by chart configuration (`metrics.enabled`) so an unmonitored
+/// install does not pretend to expose telemetry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MetricsMode {
+	Enabled,
+	Disabled,
+}
+
 /// Metrics container shared with the reconciler via the `Context`.
 pub(crate) struct Metrics {
 	pub(crate) registry: Registry,
@@ -129,27 +141,32 @@ impl Metrics {
 	}
 }
 
-/// Spawn a minimal HTTP `/metrics` server on the given bind address.
+/// Spawn a minimal HTTP server on the given bind address.
 ///
 /// The server is implemented with a raw `tokio::net::TcpListener` to
 /// avoid pulling hyper/axum into the operator binary just for a single
-/// endpoint. It serves `GET /metrics` with the Prometheus text format
-/// and replies `404` to any other request.
+/// endpoint. It always serves `GET /healthz` (for kubelet probes) and
+/// conditionally serves `GET /metrics` with the Prometheus text format
+/// when `mode` is [`MetricsMode::Enabled`]. Any other request receives
+/// a `404` response.
 pub(crate) fn spawn_exporter(
 	metrics: Arc<Metrics>,
 	bind: std::net::SocketAddr,
+	mode: MetricsMode,
 ) -> tokio::task::JoinHandle<()> {
 	tokio::spawn(async move {
 		let listener = match tokio::net::TcpListener::bind(bind).await {
 			Ok(l) => l,
 			Err(err) => {
-				tracing::error!("Failed to bind metrics exporter on {bind}: {err}");
+				tracing::error!("Failed to bind operator HTTP server on {bind}: {err}");
 				return;
 			}
 		};
-		tracing::info!("Metrics exporter listening on http://{bind}/metrics");
+		tracing::info!(
+			"Operator HTTP server listening on http://{bind}/healthz (and /metrics when enabled)"
+		);
 
-		// Cap concurrent scrape connections to defend against slowloris
+		// Cap concurrent connections to defend against slowloris
 		// and runaway task/FD usage. Prometheus scrapes are serialized per
 		// target, so this limit does not block legitimate traffic.
 		let sem = Arc::new(Semaphore::new(MAX_CONCURRENT_METRICS_CONNECTIONS));
@@ -158,7 +175,7 @@ pub(crate) fn spawn_exporter(
 			let (socket, _) = match listener.accept().await {
 				Ok(s) => s,
 				Err(err) => {
-					tracing::warn!("metrics listener accept error: {err}");
+					tracing::warn!("operator http listener accept error: {err}");
 					continue;
 				}
 			};
@@ -168,7 +185,7 @@ pub(crate) fn spawn_exporter(
 				Ok(p) => p,
 				Err(_) => {
 					tracing::warn!(
-						"metrics exporter at capacity ({MAX_CONCURRENT_METRICS_CONNECTIONS}), dropping connection"
+						"operator http server at capacity ({MAX_CONCURRENT_METRICS_CONNECTIONS}), dropping connection"
 					);
 					drop(socket);
 					continue;
@@ -178,8 +195,8 @@ pub(crate) fn spawn_exporter(
 			let _ = socket.set_nodelay(true);
 			let metrics = Arc::clone(&metrics);
 			tokio::spawn(async move {
-				if let Err(err) = handle_connection(socket, metrics).await {
-					tracing::debug!("metrics connection closed with error: {err}");
+				if let Err(err) = handle_connection(socket, metrics, mode).await {
+					tracing::debug!("operator http connection closed with error: {err}");
 				}
 				drop(permit);
 			});
@@ -187,9 +204,40 @@ pub(crate) fn spawn_exporter(
 	})
 }
 
+/// Classification of an HTTP request line, used by `handle_connection` and
+/// reused in tests so the path-matching rule lives in exactly one place.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RequestKind {
+	Metrics,
+	Healthz,
+	Other,
+}
+
+/// Classify an HTTP request line into one of [`RequestKind`].
+///
+/// Matches the request line exactly so siblings such as `GET /metricsfoo`
+/// or `GET /metrics_admin` are NOT served metrics. Accepts either an
+/// HTTP-version separator (`GET /metrics HTTP/1.1`) or a query string
+/// (`GET /metrics?...`). The `/metrics` path is additionally gated by
+/// [`MetricsMode::Enabled`] so an unmonitored install does not advertise
+/// telemetry it is not collecting.
+fn classify_request(head: &[u8], mode: MetricsMode) -> RequestKind {
+	let is_metrics_path = head.starts_with(b"GET /metrics ") || head.starts_with(b"GET /metrics?");
+	let is_healthz_path = head.starts_with(b"GET /healthz ") || head.starts_with(b"GET /healthz?");
+
+	if is_metrics_path && mode == MetricsMode::Enabled {
+		RequestKind::Metrics
+	} else if is_healthz_path {
+		RequestKind::Healthz
+	} else {
+		RequestKind::Other
+	}
+}
+
 async fn handle_connection(
 	mut socket: tokio::net::TcpStream,
 	metrics: Arc<Metrics>,
+	mode: MetricsMode,
 ) -> std::io::Result<()> {
 	use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -216,29 +264,37 @@ async fn handle_connection(
 	if n == buf.len() && !head.contains(&b'\n') {
 		return Ok(());
 	}
-	// Match the request line exactly so siblings such as `GET /metricsfoo`
-	// or `GET /metrics_admin` are NOT served metrics. Accept either an
-	// HTTP-version separator (`GET /metrics HTTP/1.1`) or a query string
-	// (`GET /metrics?...`).
-	let is_metrics = head.starts_with(b"GET /metrics ") || head.starts_with(b"GET /metrics?");
+	let kind = classify_request(head, mode);
 
 	let write_fut = async {
-		if is_metrics {
-			let body = metrics.encode();
-			let header = format!(
-				"HTTP/1.1 200 OK\r\nContent-Type: text/plain; version=0.0.4\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
-				body.len()
-			);
-			socket.write_all(header.as_bytes()).await?;
-			socket.write_all(&body).await?;
-		} else {
-			let msg = b"not found";
-			let header = format!(
-				"HTTP/1.1 404 Not Found\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
-				msg.len()
-			);
-			socket.write_all(header.as_bytes()).await?;
-			socket.write_all(msg).await?;
+		match kind {
+			RequestKind::Metrics => {
+				let body = metrics.encode();
+				let header = format!(
+					"HTTP/1.1 200 OK\r\nContent-Type: text/plain; version=0.0.4\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+					body.len()
+				);
+				socket.write_all(header.as_bytes()).await?;
+				socket.write_all(&body).await?;
+			}
+			RequestKind::Healthz => {
+				let body = b"ok";
+				let header = format!(
+					"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+					body.len()
+				);
+				socket.write_all(header.as_bytes()).await?;
+				socket.write_all(body).await?;
+			}
+			RequestKind::Other => {
+				let msg = b"not found";
+				let header = format!(
+					"HTTP/1.1 404 Not Found\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+					msg.len()
+				);
+				socket.write_all(header.as_bytes()).await?;
+				socket.write_all(msg).await?;
+			}
 		}
 		socket.shutdown().await?;
 		Ok::<(), std::io::Error>(())
@@ -283,25 +339,146 @@ mod tests {
 		assert!(text.contains("reinhardt_cloud_operator_managed_apps"));
 	}
 
-	/// Reproduces the path-matching behavior used in `handle_connection`
-	/// so the strictness can be regression-tested without spinning up a
-	/// real `TcpListener`.
-	fn matches_metrics_path(request_line: &[u8]) -> bool {
-		request_line.starts_with(b"GET /metrics ") || request_line.starts_with(b"GET /metrics?")
-	}
-
 	#[rstest]
-	#[case(b"GET /metrics HTTP/1.1\r\n", true)]
-	#[case(b"GET /metrics?debug=1 HTTP/1.1\r\n", true)]
-	#[case(b"GET /metricsfoo HTTP/1.1\r\n", false)]
-	#[case(b"GET /metrics_admin HTTP/1.1\r\n", false)]
-	#[case(b"GET /healthz HTTP/1.1\r\n", false)]
-	#[case(b"POST /metrics HTTP/1.1\r\n", false)]
-	fn metrics_path_matches_strictly(#[case] line: &[u8], #[case] expected: bool) {
+	#[case(
+		b"GET /metrics HTTP/1.1\r\n",
+		MetricsMode::Enabled,
+		RequestKind::Metrics
+	)]
+	#[case(
+		b"GET /metrics?debug=1 HTTP/1.1\r\n",
+		MetricsMode::Enabled,
+		RequestKind::Metrics
+	)]
+	#[case(
+		b"GET /metrics HTTP/1.1\r\n",
+		MetricsMode::Disabled,
+		RequestKind::Other
+	)]
+	#[case(
+		b"GET /metricsfoo HTTP/1.1\r\n",
+		MetricsMode::Enabled,
+		RequestKind::Other
+	)]
+	#[case(
+		b"GET /metrics_admin HTTP/1.1\r\n",
+		MetricsMode::Enabled,
+		RequestKind::Other
+	)]
+	#[case(
+		b"GET /healthz HTTP/1.1\r\n",
+		MetricsMode::Enabled,
+		RequestKind::Healthz
+	)]
+	#[case(
+		b"POST /metrics HTTP/1.1\r\n",
+		MetricsMode::Enabled,
+		RequestKind::Other
+	)]
+	fn classify_metrics_paths(
+		#[case] line: &[u8],
+		#[case] mode: MetricsMode,
+		#[case] expected: RequestKind,
+	) {
 		// Act
-		let actual = matches_metrics_path(line);
+		let actual = classify_request(line, mode);
 
 		// Assert
 		assert_eq!(actual, expected);
+	}
+
+	#[rstest]
+	#[case(b"GET /healthz HTTP/1.1\r\n", true)]
+	#[case(b"GET /healthz?ts=1 HTTP/1.1\r\n", true)]
+	#[case(b"GET /healthzfoo HTTP/1.1\r\n", false)]
+	#[case(b"GET /healthz_admin HTTP/1.1\r\n", false)]
+	#[case(b"GET /metrics HTTP/1.1\r\n", false)]
+	#[case(b"POST /healthz HTTP/1.1\r\n", false)]
+	fn classify_healthz_paths(#[case] line: &[u8], #[case] expected: bool) {
+		// Act
+		// Use `Disabled` so the `/metrics` request line in this matrix is
+		// classified as `Other` rather than `Metrics`, isolating the
+		// `/healthz` strictness check from the metrics gate.
+		let actual = classify_request(line, MetricsMode::Disabled);
+
+		// Assert: only `/healthz` GETs classify as `Healthz`.
+		assert_eq!(actual == RequestKind::Healthz, expected);
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn healthz_returns_200_ok_when_metrics_disabled() {
+		// Arrange: bind on an ephemeral port with metrics disabled.
+		let metrics = Metrics::new();
+		let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+			.await
+			.expect("bind ephemeral");
+		let bind = listener.local_addr().expect("local_addr");
+		let handle = tokio::spawn(serve_one(listener, metrics, MetricsMode::Disabled));
+
+		// Act: GET /healthz over a raw TCP client.
+		let body = http_get(bind, "/healthz").await;
+		handle.abort();
+
+		// Assert
+		assert!(
+			body.starts_with("HTTP/1.1 200 OK\r\n"),
+			"unexpected status line: {body:?}"
+		);
+		assert!(
+			body.contains("Content-Type: text/plain"),
+			"missing CT: {body:?}"
+		);
+		assert!(body.ends_with("ok"), "unexpected body suffix: {body:?}");
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn metrics_returns_404_when_disabled() {
+		// Arrange
+		let metrics = Metrics::new();
+		let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+			.await
+			.expect("bind ephemeral");
+		let bind = listener.local_addr().expect("local_addr");
+		let handle = tokio::spawn(serve_one(listener, metrics, MetricsMode::Disabled));
+
+		// Act
+		let body = http_get(bind, "/metrics").await;
+		handle.abort();
+
+		// Assert
+		assert!(
+			body.starts_with("HTTP/1.1 404 Not Found\r\n"),
+			"unexpected status line: {body:?}"
+		);
+	}
+
+	/// Helper that accepts exactly one connection from the listener and
+	/// invokes `handle_connection`. Used by the integration-style tests
+	/// above to keep them self-contained without spawning a long-lived
+	/// exporter task.
+	async fn serve_one(
+		listener: tokio::net::TcpListener,
+		metrics: Arc<Metrics>,
+		mode: MetricsMode,
+	) {
+		if let Ok((socket, _)) = listener.accept().await {
+			let _ = socket.set_nodelay(true);
+			let _ = handle_connection(socket, metrics, mode).await;
+		}
+	}
+
+	/// Minimal HTTP/1.1 client that sends `GET <path>` and reads the full
+	/// response into a `String`.
+	async fn http_get(addr: std::net::SocketAddr, path: &str) -> String {
+		use tokio::io::{AsyncReadExt, AsyncWriteExt};
+		let mut stream = tokio::net::TcpStream::connect(addr).await.expect("connect");
+		let req = format!("GET {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+		stream.write_all(req.as_bytes()).await.expect("write");
+		stream.shutdown().await.ok();
+		let mut buf = Vec::with_capacity(4096);
+		stream.read_to_end(&mut buf).await.expect("read_to_end");
+		String::from_utf8_lossy(&buf).into_owned()
 	}
 }

--- a/crates/reinhardt-cloud-operator/src/resources/tenant.rs
+++ b/crates/reinhardt-cloud-operator/src/resources/tenant.rs
@@ -301,7 +301,7 @@ mod tests {
 				.map(String::as_str),
 			Some(MANAGED_BY_VALUE),
 		);
-		assert!(labels.get(TENANT_TEAM_LABEL_KEY).is_none());
+		assert!(!labels.contains_key(TENANT_TEAM_LABEL_KEY));
 	}
 
 	#[rstest]

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -30,7 +30,9 @@ place:
 1. **Operator installed.** The `reinhardt-cloud-operator` Helm chart
    (`charts/reinhardt-cloud-operator`) is deployed into the
    `reinhardt-cloud-system` namespace, and the `reinhardtapps.paas.reinhardt-cloud.dev`
-   CRD (version `v1alpha2`) is registered in the cluster.
+   CRD (version `v1alpha2`) is registered in the cluster. See the
+   [Operator bootstrap](#operator-bootstrap) section below for three
+   install paths (GHCR, local kind cluster, cloud overlay).
 2. **Dashboard image published.** The dashboard image is built and pushed to
    `ghcr.io/kent8192/reinhardt-cloud-dashboard:<tag>` for every release. The
    image tag must match the GitHub release tag (minus any leading `v`).
@@ -47,6 +49,66 @@ place:
 
    The operator resolves the `secretRef:<secret>/<key>` values declared in
    `spec.env` against this `Secret` at reconciliation time.
+
+## Operator bootstrap
+
+The operator image is published to GHCR by the `build-operator-image`
+job in the [Build Release Assets](../.github/workflows/build-release-assets.yml)
+workflow on every `reinhardt-cloud-operator@v*` release-plz tag. The
+chart's default `image.repository` resolves to
+`ghcr.io/kent8192/reinhardt-cloud-operator:<Chart.appVersion>`, so a
+vanilla `helm install` works against the public registry.
+
+### Production install (GHCR default)
+
+```bash
+helm install reinhardt-cloud-operator \
+  charts/reinhardt-cloud-operator \
+  -n reinhardt-cloud-system --create-namespace
+```
+
+The chart's `_helpers.tpl` resolves `image.tag` to `Chart.appVersion`
+when `image.tag` is empty (the default). Pin a specific image tag with
+`--set image.tag=<semver>` (without a leading `v`, matching the
+workflow's tag-stripping convention) if you need to roll back without
+bumping the chart.
+
+### Local kind cluster (development / pre-release validation)
+
+```bash
+docker build \
+  -f crates/reinhardt-cloud-operator/Dockerfile \
+  -t reinhardt-cloud-operator:dev .
+
+kind load docker-image reinhardt-cloud-operator:dev --name <cluster>  # cluster name from `kind create cluster --name`
+
+helm install reinhardt-cloud-operator charts/reinhardt-cloud-operator \
+  -n reinhardt-cloud-system --create-namespace \
+  --set image.repository=reinhardt-cloud-operator \
+  --set image.tag=dev \
+  --set image.pullPolicy=Never
+```
+
+`pullPolicy=Never` ensures kubelet uses the locally loaded image instead
+of trying to pull `reinhardt-cloud-operator:dev` from a registry.
+
+### Cloud overlays
+
+The chart ships overlays for managed and on-prem registries:
+
+- `values-gcp.yaml` — GCP Artifact Registry
+- `values-aws.yaml` — AWS ECR
+- `values-onprem.yaml` — air-gapped or self-hosted private registry
+
+```bash
+helm install reinhardt-cloud-operator charts/reinhardt-cloud-operator \
+  -n reinhardt-cloud-system --create-namespace \
+  -f charts/reinhardt-cloud-operator/values-gcp.yaml   # or values-aws.yaml / values-onprem.yaml
+```
+
+Each overlay pins `image.repository` to the platform-specific registry
+placeholder; replace the placeholder values (`<region>`, `<project-id>`,
+`<account-id>`) before applying.
 
 ## Bootstrap
 


### PR DESCRIPTION
## Summary

Closes the operator-deployment gap described in issue #559: the operator now has a Dockerfile, a GHCR publish workflow, and a Helm chart that resolves to a working image by default. Bonus: the operator HTTP server now serves `/healthz` so kubelet probes work, and the dashboard self-hosting flow has a documented "Operator bootstrap" path.

This PR addresses:

- Operator container image build path (Dockerfile + `.dockerignore`) modeled on `crates/reinhardt-cloud-agent/Dockerfile`
- GHCR multi-arch (`linux/amd64,linux/arm64`) publish workflow job mirroring `build-dashboard-image`
- Helm chart default image, `runAsUser`, container port name, and probes wired to `/healthz`
- New `/healthz` endpoint on the operator HTTP server (always served; `/metrics` still gated by `metrics.enabled`)
- Self-hosting docs explaining production GHCR install, local kind validation, and cloud overlays

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] CI/CD changes
- [x] Documentation update

## Motivation and Context

`docs/self-hosting.md` lists "Operator installed" as Prerequisite #1, but on `main` that prerequisite is impossible to satisfy: there is no operator Dockerfile, no GHCR-published image (`gh api /users/kent8192/packages/container/reinhardt-cloud-operator/versions` → 404), and the chart's `image.repository: reinhardt-cloud-operator` (no registry, no tag) is not a pullable reference. This blocks any end-to-end deployment, including the dashboard dogfooding flow.

This PR makes Prerequisite #1 satisfiable: a vanilla `helm install` resolves to `ghcr.io/kent8192/reinhardt-cloud-operator:<Chart.appVersion>` once the next `reinhardt-cloud-operator@v*` tag is cut.

Fixes #559

## How Was This Tested?

- `cargo nextest run --package reinhardt-cloud-operator --all-features` — 430 passed, 0 failed (includes 13 new `metrics::*` cases covering `/healthz` round-trip, `/metrics` 404 when disabled, and exact-match path classification).
- `cargo make clippy-check`, `cargo make fmt-check` — clean.
- `helm lint charts/reinhardt-cloud-operator` — passes.
- `helm template charts/reinhardt-cloud-operator` — renders `image: ghcr.io/.../reinhardt-cloud-operator:0.1.0`, both probes targeting `/healthz`, `runAsUser: 65532`, `targetPort: http`, and the cloud overlays still produce their respective registry-pinned images.
- `docker build -f crates/reinhardt-cloud-operator/Dockerfile -t reinhardt-cloud-operator:dev .` — builds a 46.7 MB image. `docker run` confirms the binary launches as `nonroot:nonroot` and logs `Operator HTTP server listening on http://0.0.0.0:9090/healthz (and /metrics when enabled)` before exiting on the expected missing-kubeconfig error.
- Workflow YAML validated with `python3 -c yaml.safe_load(...)` and `actionlint`.

## Performance Impact

None. The operator HTTP server was already running when `metrics.enabled=true`; this PR only changes the gating to "always on for /healthz, conditional for /metrics content".

## Breaking Changes

None for end users. Two internal-only behaviors changed:

- The container port name renamed `metrics` → `http` (it now serves both `/healthz` and `/metrics`). The Service port name stays `metrics`, and the existing `ServiceMonitor` selector (`port: metrics`) is unchanged. Prometheus scrapers are unaffected.
- `podSecurityContext.runAsUser` changed from `1000` to `65532` to match the distroless `nonroot` user baked into the new Operator Dockerfile. The previous value was nominal — there was no image at all to compare against.

## Checklist

- [x] I have followed the Contributing Guidelines
- [x] I have followed the Commit Guidelines
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with \`cargo make fmt-fix\`
- [x] I have checked the code with \`cargo make clippy-check\`

## Related Issues

Fixes #559

## Labels to Apply

### Type Label
- \`enhancement\`

### Scope Label
- \`operator\` — Kubernetes operator logic
- \`ci-cd\` — CI/CD workflow changes

### Priority Label
- \`high\` — Blocks the dashboard self-hosting flow

---

**Additional Context:**

The branch is structured as 6 small commits, each split by intent:

1. \`chore(operator): fix clippy::unnecessary_get_then_check in tenant.rs\` — preceding clippy fix that surfaced when running \`-D warnings\` for the operator crate.
2. \`feat(operator): add /healthz endpoint and run HTTP server unconditionally\` — Rust changes (\`metrics.rs\` + \`main.rs\`), TDD-driven.
3. \`feat(charts): wire operator probes and default to GHCR-published image\` — \`values.yaml\` / \`deployment.yaml\` / \`service.yaml\` updates.
4. \`feat(operator): add multi-stage Dockerfile and dockerignore\` — distroless cc-debian12:nonroot, 46.7 MB image. Adds \`libprotobuf-dev\` (in addition to \`protobuf-compiler\`) because \`reinhardt-cloud-proto/proto/build.proto\` imports \`google/protobuf/timestamp.proto\` (a well-known proto shipped only by \`libprotobuf-dev\` on Debian Bookworm). The agent Dockerfile installs only \`protobuf-compiler\` and would hit the same failure if its proto definitions ever import a WKT — worth tracking separately as a latent agent-image bug.
5. \`ci: publish reinhardt-cloud-operator image to GHCR on release tags\` — \`build-operator-image\` job mirrors \`build-dashboard-image\` (strips the leading \`v\` so the tag matches \`Chart.appVersion\`).
6. \`docs(self-hosting): document operator bootstrap paths\` — final commit, contains \`Fixes #559\`.

Out-of-scope follow-ups (separate issues if/when needed): release-plz hook to keep \`Chart.yaml\` \`appVersion\` synced with workspace version, \`:edge\` rolling images, cosign signing & SBOM generation for all three published images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)