### PR TITLE
fix(operator): inject core.secret_key via per-app Secret + TOML interpolation

### DIFF
--- a/crates/reinhardt-cloud-operator/src/inference/configmap.rs
+++ b/crates/reinhardt-cloud-operator/src/inference/configmap.rs
@@ -20,9 +20,17 @@ pub(crate) fn build_settings_configmap(app_name: &str, namespace: &str) -> Confi
 	// `allowed_hosts` defaults to empty (deny all) for security. Users should
 	// override via `REINHARDT_CORE__ALLOWED_HOSTS` env var or by customizing
 	// this ConfigMap after deployment.
+	//
+	// `secret_key` is filled in by reinhardt-conf's `${VAR}` interpolation
+	// from `REINHARDT_CLOUD_SECRET_KEY`, which the operator injects into the
+	// Pod via `valueFrom.secretKeyRef` against the per-app
+	// `<app>-core-secret-key` Secret (see
+	// `inference::env_vars::build_core_secret_key_env_var`). Storing only
+	// the placeholder here keeps the actual key value out of the ConfigMap.
 	let production_toml = r#"[core]
 debug = false
 allowed_hosts = []
+secret_key = "${REINHARDT_CLOUD_SECRET_KEY}"
 
 [security]
 session_cookie_secure = true
@@ -160,6 +168,28 @@ mod tests {
 				.get("secure_ssl_redirect")
 				.and_then(|v| v.as_bool()),
 			Some(false),
+		);
+	}
+
+	#[rstest]
+	fn configmap_production_toml_references_secret_key_via_env_var_interpolation() {
+		// Arrange & Act
+		let cm = build_settings_configmap("myapp", "default");
+
+		// Assert — the placeholder must be present and must NOT carry an
+		// inline key value (which would defeat the point of moving the
+		// signing key into a Secret).
+		let data = cm.data.as_ref().unwrap();
+		let toml_content = &data["production.toml"];
+		let parsed: toml::Value = toml::from_str(toml_content).expect("valid TOML");
+		let secret_key = parsed
+			.get("core")
+			.and_then(|c| c.get("secret_key"))
+			.and_then(|v| v.as_str())
+			.expect("`core.secret_key` must be set so reinhardt-conf can interpolate it");
+		assert_eq!(
+			secret_key, "${REINHARDT_CLOUD_SECRET_KEY}",
+			"`core.secret_key` must reference the operator-injected env var, never an inline value",
 		);
 	}
 

--- a/crates/reinhardt-cloud-operator/src/inference/env_vars.rs
+++ b/crates/reinhardt-cloud-operator/src/inference/env_vars.rs
@@ -161,6 +161,28 @@ pub(crate) fn build_system_env_vars() -> Vec<EnvVar> {
 	]
 }
 
+/// Build the `REINHARDT_CLOUD_SECRET_KEY` env var referencing the per-app
+/// `<app>-core-secret-key` Secret created by
+/// `inference::secrets::build_core_secret_key_secret`.
+///
+/// The generated `production.toml` reads this back via `${VAR}` interpolation
+/// in the `[core] secret_key` field, so the actual key value is never stored
+/// in a ConfigMap.
+pub(crate) fn build_core_secret_key_env_var(app_name: &str) -> EnvVar {
+	EnvVar {
+		name: "REINHARDT_CLOUD_SECRET_KEY".to_string(),
+		value: None,
+		value_from: Some(EnvVarSource {
+			secret_key_ref: Some(SecretKeySelector {
+				name: format!("{app_name}-core-secret-key"),
+				key: "secret-key".to_string(),
+				optional: Some(false),
+			}),
+			..Default::default()
+		}),
+	}
+}
+
 /// Merge auto-generated and user-supplied environment variables.
 ///
 /// User overrides (`user_vars`) always take priority over auto-generated
@@ -506,5 +528,39 @@ mod tests {
 		// Assert
 		assert_eq!(merged.len(), 1);
 		assert_eq!(merged[0].name, "X");
+	}
+
+	#[rstest]
+	fn core_secret_key_env_var_references_per_app_secret() {
+		// Arrange & Act
+		let var = build_core_secret_key_env_var("myapp");
+
+		// Assert — the actual key bytes must come from the Secret, never
+		// be inlined into the Pod spec.
+		assert_eq!(var.name, "REINHARDT_CLOUD_SECRET_KEY");
+		assert!(var.value.is_none());
+		let key_ref = var
+			.value_from
+			.as_ref()
+			.and_then(|vf| vf.secret_key_ref.as_ref())
+			.expect("must use SecretKeyRef so the key value is never inlined");
+		assert_eq!(key_ref.name, "myapp-core-secret-key");
+		assert_eq!(key_ref.key, "secret-key");
+		assert_eq!(key_ref.optional, Some(false));
+	}
+
+	#[rstest]
+	fn core_secret_key_env_var_secret_name_tracks_app_name() {
+		// Arrange & Act — a different app must reference its own Secret;
+		// the helper must NOT share a single Secret across apps.
+		let var = build_core_secret_key_env_var("other-app");
+
+		// Assert
+		let key_ref = var
+			.value_from
+			.as_ref()
+			.and_then(|vf| vf.secret_key_ref.as_ref())
+			.unwrap();
+		assert_eq!(key_ref.name, "other-app-core-secret-key");
 	}
 }

--- a/crates/reinhardt-cloud-operator/src/inference/secrets.rs
+++ b/crates/reinhardt-cloud-operator/src/inference/secrets.rs
@@ -35,6 +35,37 @@ pub(crate) fn build_jwt_secret(app_name: &str, namespace: &str) -> Secret {
 	}
 }
 
+/// Build a Kubernetes Secret containing the per-app `core.secret_key`.
+///
+/// reinhardt-web's `CoreSettings::secret_key` is required at startup and
+/// cannot be populated through the `REINHARDT_*` env-var override path
+/// because `HighPriorityEnvSource` does not expand `__` into nested keys.
+/// Instead, the Secret holds a 256-bit random value, the operator injects
+/// it as `REINHARDT_CLOUD_SECRET_KEY`, and the generated `production.toml`
+/// references it via `${REINHARDT_CLOUD_SECRET_KEY}` interpolation.
+///
+/// Generates a 256-bit random key, base64-encodes it, and stores the
+/// result under the `secret-key` data key.
+pub(crate) fn build_core_secret_key_secret(app_name: &str, namespace: &str) -> Secret {
+	let key_bytes: [u8; 32] = rand::random();
+	let key_b64 = base64_encode(&key_bytes);
+
+	Secret {
+		metadata: ObjectMeta {
+			name: Some(format!("{app_name}-core-secret-key")),
+			namespace: Some(namespace.to_string()),
+			labels: Some(standard_secret_labels(app_name)),
+			..Default::default()
+		},
+		data: Some(BTreeMap::from([(
+			"secret-key".to_string(),
+			ByteString(key_b64.into_bytes()),
+		)])),
+		type_: Some("Opaque".to_string()),
+		..Default::default()
+	}
+}
+
 /// Build a Kubernetes Secret containing database credentials.
 pub(crate) fn build_db_credentials_secret(
 	app_name: &str,
@@ -265,5 +296,71 @@ mod tests {
 		let data1 = secret1.data.as_ref().unwrap();
 		let data2 = secret2.data.as_ref().unwrap();
 		assert_ne!(data1["jwt-secret"].0, data2["jwt-secret"].0);
+	}
+
+	#[rstest]
+	fn core_secret_key_secret_has_correct_name() {
+		// Arrange & Act
+		let secret = build_core_secret_key_secret("myapp", "default");
+
+		// Assert
+		assert_eq!(
+			secret.metadata.name.as_deref(),
+			Some("myapp-core-secret-key")
+		);
+	}
+
+	#[rstest]
+	fn core_secret_key_secret_stores_secret_key_under_documented_data_key() {
+		// Arrange & Act
+		let secret = build_core_secret_key_secret("myapp", "default");
+
+		// Assert — the data key name `secret-key` is part of the operator's
+		// public reconciler contract; env_vars::build_core_secret_key_env_var
+		// references it explicitly, so renaming requires updating both sites.
+		let data = secret.data.as_ref().unwrap();
+		assert!(data.contains_key("secret-key"));
+	}
+
+	#[rstest]
+	fn core_secret_key_secret_value_is_32_bytes_when_decoded() {
+		// Arrange & Act
+		let secret = build_core_secret_key_secret("myapp", "default");
+
+		// Assert
+		let data = secret.data.as_ref().unwrap();
+		let raw = &data["secret-key"].0;
+		let decoded = base64::engine::general_purpose::STANDARD
+			.decode(raw)
+			.expect("data key value must be valid base64");
+		assert_eq!(decoded.len(), 32);
+	}
+
+	#[rstest]
+	fn core_secret_key_secret_has_opaque_type_and_standard_labels() {
+		// Arrange & Act
+		let secret = build_core_secret_key_secret("myapp", "default");
+
+		// Assert
+		assert_eq!(secret.type_.as_deref(), Some("Opaque"));
+		let labels = secret.metadata.labels.as_ref().unwrap();
+		assert_eq!(labels.get("app.kubernetes.io/name").unwrap(), "myapp");
+		assert_eq!(
+			labels.get("app.kubernetes.io/managed-by").unwrap(),
+			"reinhardt-cloud-operator"
+		);
+	}
+
+	#[rstest]
+	fn two_core_secret_key_secrets_have_different_values() {
+		// Arrange & Act — calls must use a fresh CSPRNG draw each time so
+		// regenerating the Secret cannot accidentally restore an old value.
+		let s1 = build_core_secret_key_secret("app", "ns");
+		let s2 = build_core_secret_key_secret("app", "ns");
+
+		// Assert
+		let d1 = s1.data.as_ref().unwrap();
+		let d2 = s2.data.as_ref().unwrap();
+		assert_ne!(d1["secret-key"].0, d2["secret-key"].0);
 	}
 }

--- a/crates/reinhardt-cloud-operator/src/reconciler.rs
+++ b/crates/reinhardt-cloud-operator/src/reconciler.rs
@@ -28,7 +28,7 @@ use crate::inference::configmap::build_settings_configmap;
 use crate::inference::database::{DatabaseResource, infer_database_resources};
 use crate::inference::pages::{ResolvedPagesConfig, resolve_pages_config};
 use crate::inference::platform::{Platform, PlatformConfig, ResourceDefaults};
-use crate::inference::secrets::build_jwt_secret;
+use crate::inference::secrets::{build_core_secret_key_secret, build_jwt_secret};
 use crate::metrics::Metrics;
 use crate::resources::credentials;
 use crate::resources::preview;
@@ -248,6 +248,31 @@ async fn apply(app: Arc<ReinhardtApp>, ctx: &Context, namespace: &str) -> Result
 			.await
 			.map_err(Error::Kube)?;
 		info!("Reconciled ConfigMap {namespace}/{cm_name}");
+	}
+
+	// Create the per-app `core.secret_key` Secret unconditionally, so every
+	// reinhardt-web app reconciled by this operator can resolve
+	// `core.secret_key` from `production.toml` via the
+	// `${REINHARDT_CLOUD_SECRET_KEY}` env-var interpolation. Use idempotent
+	// get-or-create so we never rotate the key on a follow-up reconcile —
+	// rotating the signing key would invalidate every active session and
+	// CSRF token in the running Pod.
+	{
+		let core_secret_name = format!("{name}-core-secret-key");
+		let secret_api: Api<Secret> = Api::namespaced(ctx.client.clone(), namespace);
+		if secret_api
+			.get_opt(&core_secret_name)
+			.await
+			.map_err(Error::Kube)?
+			.is_none()
+		{
+			let core_secret = build_core_secret_key_secret(&name, namespace);
+			secret_api
+				.create(&PostParams::default(), &core_secret)
+				.await
+				.map_err(|e| Error::SecretGeneration(e.to_string()))?;
+			info!("Created core secret_key Secret {namespace}/{core_secret_name}");
+		}
 	}
 
 	// Create JWT Secret if auth.jwt is enabled (preserve existing tokens)

--- a/crates/reinhardt-cloud-operator/src/resources/deployment.rs
+++ b/crates/reinhardt-cloud-operator/src/resources/deployment.rs
@@ -20,7 +20,8 @@ use super::security::runtime_class::resolve_runtime_class_name;
 use super::validate_port;
 use crate::error::Error;
 use crate::inference::env_vars::{
-	build_database_env_vars_from_secret, build_otel_env_vars, build_system_env_vars, merge_env_vars,
+	build_core_secret_key_env_var, build_database_env_vars_from_secret, build_otel_env_vars,
+	build_system_env_vars, merge_env_vars,
 };
 use crate::inference::pages::ResolvedPagesConfig;
 use crate::inference::platform::Platform;
@@ -69,6 +70,11 @@ pub(crate) fn build_deployment(
 	});
 	let needs_db_env = explicit_db || introspect_db;
 	let mut auto_vars = build_system_env_vars();
+	// Inject the per-app `core.secret_key` env var unconditionally so the
+	// generated `production.toml` can resolve `${REINHARDT_CLOUD_SECRET_KEY}`
+	// at startup; the value lives in the operator-managed
+	// `<app>-core-secret-key` Secret, never in the Pod spec.
+	auto_vars.push(build_core_secret_key_env_var(&app_name));
 	if needs_db_env {
 		let db_host = if explicit_db {
 			format!("{app_name}-db")


### PR DESCRIPTION
## Summary

- Generate a per-app `<app>-core-secret-key` Secret with 32 bytes of CSPRNG entropy and the standard `app.kubernetes.io/managed-by` labeling.
- Inject `REINHARDT_CLOUD_SECRET_KEY` into the Pod via `valueFrom.secretKeyRef` (no inline value).
- Reference the env var from `production.toml` as `secret_key = "${REINHARDT_CLOUD_SECRET_KEY}"` so reinhardt-conf's `with_interpolation(true)` resolves it at load time, keeping the actual key out of the ConfigMap.
- Create the Secret idempotently (get-then-create) so a follow-up reconcile never rotates the signing key — rotation would invalidate every active session and CSRF token in the running Pod.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

`core.secret_key` is required by reinhardt-web at startup but had no operator-side supply path. The dashboard was crashing with `MissingRequiredField { section: "core", field: "secret_key" }` even after #561 made the operator image deployable. Setting `REINHARDT_CORE__SECRET_KEY` does not work because `HighPriorityEnvSource` does not expand `__` into nested keys, and inlining the value into the generated ConfigMap would leak it.

This is the third of three reconciler-side fixes required to unblock the documented self-hosting flow on a fresh cluster; the companions are #569 (`production.toml` schema, #567) and #570 (`secretRef:` resolution, #566).

## Stacking

This PR is **stacked on #569** (the `production.toml` schema fix). The `secret_key = "${REINHARDT_CLOUD_SECRET_KEY}"` line lives under the `[core]` section that #569 establishes. Merging #569 first keeps this PR's diff minimal; if reviewer prefers, both can be squashed together into the same merge commit.

## How Was This Tested

- `cargo nextest run -p reinhardt-cloud-operator` (439 tests, all green; 8 are new across `inference::secrets` (5) and `inference::env_vars` (2) and `inference::configmap` (1)).
- New tests verify: Secret naming, the documented `secret-key` data key, 32-byte decoded entropy, Opaque type, standard labels, fresh CSPRNG per call (no value reuse), env var uses `valueFrom.secretKeyRef` (never inline), per-app Secret naming, and the TOML placeholder is the literal `${REINHARDT_CLOUD_SECRET_KEY}` (never an inlined value).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy -D warnings` clean)
- [x] Self-review completed
- [x] Tests added that prove the fix is effective and prevent regression
- [x] All new and existing tests pass

## Related Issues

Fixes #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)