### PR TITLE
test(dashboard): add SPA link-click smoke test in headless Chrome (Refs #574)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1135,6 +1135,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4014,6 +4020,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4379,6 +4395,12 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opaque-debug"
@@ -6238,6 +6260,7 @@ dependencies = [
  "uuid",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-bindgen-test",
  "web-sys",
  "wiremock",
 ]
@@ -9786,6 +9809,45 @@ checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb55e2540ad1c56eec35fd63e2aea15f83b11ce487fd2de9ad11578dfc047ea"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf0ca1bd612b988616bac1ab34c4e4290ef18f7148a1d8b7f31c150080e9295"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cda5ecc67248c48d3e705d3e03e00af905769b78b9d2a1678b663b8b9d4472"
 
 [[package]]
 name = "wasm-encoder"

--- a/dashboard/Cargo.toml
+++ b/dashboard/Cargo.toml
@@ -21,6 +21,10 @@ path = "src/bin/manage.rs"
 # `ResolvedUrls::from_global()` in dashboard pages and layouts.
 default = ["client-router"]
 client-router = ["reinhardt/client-router"]
+# Opts the `tests/wasm/` browser tests into the build. Off by default so
+# `cargo nextest run` (host-target) does not try to compile WASM-only
+# tests. Driven by `cargo make wasm-spa-test`. Refs #574.
+wasm-spa-test = []
 
 [dependencies]
 reinhardt = { workspace = true }
@@ -71,10 +75,27 @@ js-sys = "0.3"
 gloo-timers = "0.3"
 console_error_panic_hook = "0.1"
 
+# WASM-target dev-deps for browser tests. Driver: `wasm-pack test
+# --headless --chrome --features wasm-spa-test`. Refs #574.
+#
+# `rstest` is required because `wasm-pack test` builds the lib (with
+# `#[cfg(test)]` modules) alongside the integration test, and several
+# lib modules (e.g. `apps/deployments/client/components/log_viewer.rs`)
+# already use `rstest` for native unit tests. Without `rstest` in the
+# wasm dev-dep set, `cargo build --tests --target wasm32-unknown-unknown`
+# fails to find the `#[case]` and `#[rstest]` attributes.
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3"
+rstest = { workspace = true }
+
 [build-dependencies]
 cfg_aliases = "0.2"
 
-[dev-dependencies]
+# Native dev-deps. Pulled into a target-gated block so the WASM browser
+# tests under `tests/wasm/` (driven by `wasm-pack test --headless
+# --chrome`) do not transitively compile `tokio`/`mio`/`reqwest`/
+# `wiremock`, which fail to link for `wasm32-unknown-unknown`. Refs #574.
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 rstest = { workspace = true }
 serial_test = "3.2"
 anyhow = { workspace = true }

--- a/dashboard/Makefile.toml
+++ b/dashboard/Makefile.toml
@@ -247,6 +247,33 @@ command = "cargo"
 args = ["run", "--bin", "manage", "runserver", "--with-pages", "${@}"]
 
 # ============================================================================
+# WASM browser tests (wasm-bindgen-test in headless Chrome)
+# ============================================================================
+#
+# Closes the structural test gap behind the SPA navigation regression
+# class — every framework-side fix in the chain
+# (#4075 → #4088 → #4122 → #4203 → #4213 → #4217 → #4221) passed
+# framework-side tests because no test exercised the consumer-facing
+# `UnifiedRouter::client(...) → ClientLauncher → Router::push` topology.
+#
+# Tests live under `dashboard/tests/wasm/` per CLAUDE.md TD-3 and are
+# gated behind the `wasm-spa-test` feature so default `cargo nextest
+# run` (host target) skips them. Refs #574.
+
+[tasks.wasm-spa-test]
+description = "Run dashboard SPA browser tests under wasm-pack + headless Chrome (#574 regression suite)"
+command = "wasm-pack"
+args = [
+	"test",
+	"--headless",
+	"--chrome",
+	"--",
+	"--features",
+	"wasm-spa-test",
+]
+dependencies = ["wasm-install-tools"]
+
+# ============================================================================
 # Ephemeral Local Infrastructure (postgres / redis via docker run --rm)
 # ============================================================================
 #

--- a/dashboard/src/bin/manage.rs
+++ b/dashboard/src/bin/manage.rs
@@ -7,11 +7,24 @@
 //! URL patterns are automatically registered by the framework.
 //! No manual registration is required - see `src/config/urls.rs` for the
 //! `#[routes]` attribute macro that enables this.
+//!
+//! ## Native vs. WASM
+//!
+//! This binary is native-only (it depends on `tokio`, `reinhardt::commands`,
+//! and other server-side crates that don't link for `wasm32-unknown-unknown`).
+//! The WASM build of this crate skips it via the `cfg(not(target_arch =
+//! "wasm32"))` gate below. The empty wasm32 stub keeps `wasm-pack test`'s
+//! `cargo build --tests` happy without dragging native deps into the wasm
+//! target. Refs `kent8192/reinhardt-cloud#574`.
 
+#[cfg(not(target_arch = "wasm32"))]
 use reinhardt::commands::execute_from_command_line;
+#[cfg(not(target_arch = "wasm32"))]
 use reinhardt_cloud_dashboard as _;
+#[cfg(not(target_arch = "wasm32"))]
 use std::process;
 
+#[cfg(not(target_arch = "wasm32"))]
 #[tokio::main]
 async fn main() {
 	// SAFETY: Called at program start before any spawned tasks.
@@ -28,3 +41,9 @@ async fn main() {
 		process::exit(1);
 	}
 }
+
+/// WASM stub. The dashboard's WASM bundle is built via `cdylib` from
+/// `src/lib.rs` (`#[wasm_bindgen(start)]` in `client::wasm_entry::main`),
+/// not from this CLI. Refs #574.
+#[cfg(target_arch = "wasm32")]
+fn main() {}

--- a/dashboard/src/client.rs
+++ b/dashboard/src/client.rs
@@ -21,7 +21,20 @@ pub mod router;
 pub mod state;
 pub mod ws;
 
-#[cfg(wasm)]
+// `#[wasm_bindgen(start)]` registers a `main` entry that runs when the
+// WASM module loads. We compile that entry out of the test build because
+// `wasm-bindgen-test` injects its own `main` for the test runner, and
+// `wasm-ld` discards both when two `main` exports collide ("main symbol
+// is missing, may be because there are multiple exports with the same
+// name but different signatures").
+//
+// `cfg(not(test))` won't help here — the lib is compiled without the
+// `cfg(test)` flag when it's a dependency of `tests/wasm.rs`. Instead,
+// we negate the `wasm-spa-test` feature: the production WASM bundle
+// (built without that feature) keeps the `wasm_bindgen(start)` entry,
+// and `wasm-pack test --features wasm-spa-test` opts it out. Refs
+// `kent8192/reinhardt-cloud#574`.
+#[cfg(all(wasm, not(feature = "wasm-spa-test")))]
 mod wasm_entry {
 	use wasm_bindgen::prelude::*;
 

--- a/dashboard/src/shared/ws_messages.rs
+++ b/dashboard/src/shared/ws_messages.rs
@@ -259,6 +259,12 @@ mod tests {
 		assert_eq!(roundtrip.message, message);
 	}
 
+	// `proptest` is only wired into native dev-deps because `dashboard`
+	// also runs `wasm-bindgen-test` browser tests (#574); pulling
+	// `proptest` into the WASM dev-dep set would bloat the wasm test
+	// build. The fuzz coverage is target-agnostic — running it on the
+	// native target is sufficient. Refs #574.
+	#[cfg(not(target_arch = "wasm32"))]
 	mod property_tests {
 		use super::super::*;
 		use proptest::prelude::*;

--- a/dashboard/tests/e2e.rs
+++ b/dashboard/tests/e2e.rs
@@ -1,3 +1,10 @@
+// Native-only — `tests/wasm.rs` covers the wasm32 target. The native
+// e2e tests pull in tokio/reqwest/uuid/etc. that don't link for
+// `wasm32-unknown-unknown`, so they would break `wasm-pack test` (which
+// passes `--tests` to cargo and rebuilds every integration test crate).
+// Refs #574.
+#![cfg(not(target_arch = "wasm32"))]
+
 #[path = "e2e/auth_clusters.rs"]
 mod auth_clusters;
 #[path = "e2e/auth_clusters_deployments.rs"]

--- a/dashboard/tests/openapi_test.rs
+++ b/dashboard/tests/openapi_test.rs
@@ -4,6 +4,9 @@
 //! `/api/redoc`) are available and return valid content when the router
 //! is wrapped with `OpenApiRouter`.
 
+// Native-only — see `tests/wasm.rs` for browser tests. Refs #574.
+#![cfg(not(target_arch = "wasm32"))]
+
 use reinhardt::test::APIClient;
 use reinhardt_cloud_dashboard::config::test_helpers::{ResolvedUrls, test_app};
 use rstest::rstest;

--- a/dashboard/tests/server_startup.rs
+++ b/dashboard/tests/server_startup.rs
@@ -9,6 +9,7 @@
 //! We exercise the helper that `src/main.rs` now calls in its hot
 //! path so the regression cannot reappear silently.
 
+// Native-only — see `tests/wasm.rs` for browser tests. Refs #574.
 #![cfg(not(target_arch = "wasm32"))]
 
 use reinhardt::urls::routers::{clear_router, is_router_registered};

--- a/dashboard/tests/smoke_test.rs
+++ b/dashboard/tests/smoke_test.rs
@@ -1,5 +1,8 @@
 //! End-to-end smoke tests for the reinhardt-cloud-dashboard application.
 
+// Native-only — see `tests/wasm.rs` for browser tests. Refs #574.
+#![cfg(not(target_arch = "wasm32"))]
+
 use rstest::rstest;
 
 #[rstest]

--- a/dashboard/tests/unit.rs
+++ b/dashboard/tests/unit.rs
@@ -1,3 +1,6 @@
+// Native-only — see `tests/wasm.rs` for browser tests. Refs #574.
+#![cfg(not(target_arch = "wasm32"))]
+
 #[path = "unit/test_routes_configuration.rs"]
 mod test_routes_configuration;
 

--- a/dashboard/tests/wasm.rs
+++ b/dashboard/tests/wasm.rs
@@ -1,0 +1,22 @@
+//! WASM-target browser tests for the dashboard SPA client.
+//!
+//! Driven by `wasm-pack test --headless --chrome --features wasm-spa-test`
+//! (see `dashboard/Makefile.toml` task `wasm-spa-test`). These tests
+//! exercise the SPA navigation chain that ships in production WASM
+//! bundles, mirroring the topology used by `dashboard/src/client.rs`.
+//!
+//! Each test file lives under `tests/wasm/` per `dashboard/CLAUDE.md`
+//! TD-3, with the file name describing the feature under test.
+//!
+//! Refs `kent8192/reinhardt-cloud#574` and upstream
+//! `kent8192/reinhardt-web#4221` (7th SPA navigation regression).
+
+#![cfg(all(target_arch = "wasm32", feature = "wasm-spa-test"))]
+
+// `tests/wasm.rs` is the integration-test crate root; its child modules
+// live under `tests/wasm/`. Cargo does not auto-discover that layout for
+// integration tests (it would expect siblings), so we point at each
+// module file explicitly. This keeps the directory structure aligned
+// with `dashboard/CLAUDE.md` TD-3 without relying on `mod.rs`.
+#[path = "wasm/test_spa_navigation_smoke.rs"]
+mod test_spa_navigation_smoke;

--- a/dashboard/tests/wasm/test_spa_navigation_smoke.rs
+++ b/dashboard/tests/wasm/test_spa_navigation_smoke.rs
@@ -1,0 +1,136 @@
+//! SPA navigation smoke test — closes the structural test gap behind
+//! the 7-iteration SPA regression chain (#4075 → #4088 → #4122 → #4203
+//! → #4213 → #4217 → #4221).
+//!
+//! Mirrors upstream `kent8192/reinhardt-web` PR #4227's
+//! `nav_diag_dom_advances_through_full_link_click_chain`, but launches
+//! the dashboard's actual `init_router()` (named routes for
+//! `dashboard:home`, `dashboard:clusters`, etc.) so a regression in the
+//! `UnifiedRouter::client(...) → ClientLauncher → reinhardt-pages
+//! Router::push → reinhardt-urls push_state → state_to_js_object` chain
+//! is caught by tests that sit on the actual click-to-render path. Every
+//! framework-side fix in the regression chain has passed framework-side
+//! tests because no test exercised the consumer-facing topology — this
+//! test removes that gap.
+//!
+//! Refs `kent8192/reinhardt-cloud#574`.
+
+use js_sys::Reflect;
+use reinhardt::pages::ClientLauncher;
+use reinhardt::{ClientUrlReverser, register_client_reverser};
+use reinhardt_cloud_dashboard::client::router::init_router;
+use reinhardt_cloud_dashboard::client::state;
+use std::collections::HashMap;
+use wasm_bindgen::JsCast;
+use wasm_bindgen::JsValue;
+use wasm_bindgen_test::*;
+use web_sys::HtmlElement;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+/// Ensure the SPA mount point exists on the test page. `wasm-pack test`
+/// produces a bare HTML wrapper without `<div id="app">`, so we provision
+/// one before launching the client.
+fn ensure_mount_point(document: &web_sys::Document, body: &web_sys::HtmlElement) {
+	if document.get_element_by_id("app").is_some() {
+		return;
+	}
+	let app_div = document.create_element("div").expect("create #app div");
+	app_div.set_id("app");
+	body.append_child(&app_div).expect("append #app to body");
+}
+
+/// Register the SPA route names that the dashboard's `dashboard_shell`
+/// layout needs to resolve via `ResolvedUrls`. In production WASM this
+/// is wired up by the `#[routes]` macro through `UnifiedRouter::client(...)`
+/// (which calls `register_client_reverser` internally). The test bypasses
+/// that path because it never instantiates a `UnifiedRouter`, so we
+/// register a hand-built reverser that mirrors the route table from
+/// `dashboard/src/client/router.rs`. Refs #574.
+///
+/// Keep these patterns in sync with `init_router()`'s `named_route`
+/// calls — drift would cause the panic the test is here to prevent.
+fn register_dashboard_url_reverser() {
+	let patterns = HashMap::from([
+		("dashboard:home".to_string(), "/".to_string()),
+		("auth:login_page".to_string(), "/login".to_string()),
+		("auth:register_page".to_string(), "/register".to_string()),
+		("dashboard:clusters".to_string(), "/clusters".to_string()),
+		(
+			"dashboard:deployments".to_string(),
+			"/deployments".to_string(),
+		),
+	]);
+	register_client_reverser(ClientUrlReverser::new(patterns));
+}
+
+/// Launch the dashboard's client just like `dashboard/src/client.rs`
+/// does in production, minus the `on_path` hooks that depend on a live
+/// notifications WebSocket. Reuses the same `init_router()` so route
+/// names and patterns match the production topology byte-for-byte.
+fn launch_dashboard_for_test() {
+	register_dashboard_url_reverser();
+	state::init_app_state();
+	ClientLauncher::new("#app")
+		.router(init_router)
+		.launch()
+		.expect("ClientLauncher::launch must succeed");
+}
+
+#[wasm_bindgen_test]
+fn link_click_advances_history_state_as_object() {
+	// Arrange — mirror the dashboard's launch path
+	let window = web_sys::window().expect("window");
+	let document = window.document().expect("document");
+	let body = document.body().expect("body");
+	ensure_mount_point(&document, &body);
+	launch_dashboard_for_test();
+
+	let anchor: HtmlElement = document
+		.create_element("a")
+		.expect("create anchor")
+		.dyn_into()
+		.expect("anchor as HtmlElement");
+	anchor.set_attribute("href", "/clusters").expect("set href");
+	body.append_child(&anchor).expect("append anchor to body");
+
+	// Act — bubbling click that the framework's link interceptor must
+	// observe and route through `Router::push → Router::navigate →
+	// push_state → state_to_js_object`
+	anchor.click();
+
+	// Assert — exact symptom predicates from #4221 round 7
+	let history = window.history().expect("history");
+	let state: JsValue = history.state().expect("history.state");
+
+	assert!(
+		!state.is_string(),
+		"history.state must be a JS object (not a JSON string); \
+		 #4221 round 7 invariant. Saw state.is_string() == true. \
+		 Raw value: {:?}",
+		state.as_string().unwrap_or_default()
+	);
+	assert!(
+		state.is_object(),
+		"history.state must be a JS object; #4218 invariant"
+	);
+
+	let route_name = Reflect::get(&state, &JsValue::from_str("route_name"))
+		.expect("Reflect::get(state, 'route_name')")
+		.as_string()
+		.unwrap_or_default();
+	assert_eq!(
+		route_name, "dashboard:clusters",
+		"named route must resolve to 'dashboard:clusters'; \
+		 empty route_name was the original #4221 symptom"
+	);
+
+	let path = Reflect::get(&state, &JsValue::from_str("path"))
+		.expect("Reflect::get(state, 'path')")
+		.as_string()
+		.unwrap_or_default();
+	assert_eq!(
+		path, "/clusters",
+		"history.state.path must reflect the navigation target"
+	);
+}


### PR DESCRIPTION
## Summary

- Adds a `wasm-bindgen-test` browser smoke test for SPA navigation in `dashboard/tests/wasm/test_spa_navigation_smoke.rs`, mirroring upstream `kent8192/reinhardt-web` PR #4227's `nav_diag_dom_advances_through_full_link_click_chain` pattern but launching the dashboard's actual `init_router()` (with named routes for `dashboard:home`, `dashboard:clusters`, etc.).
- Closes the structural test gap behind the 7-iteration SPA navigation regression chain (#4075 → #4088 → #4122 → #4203 → #4213 → #4217 → #4221). Every framework-side fix passed framework-side tests, but no test sat on the consumer-facing `UnifiedRouter::client(...) → ClientLauncher → Router::push → push_state → state_to_js_object` path the dashboard actually exercises.
- Drives `wasm-pack test --headless --chrome --features wasm-spa-test` via a new `[tasks.wasm-spa-test]` in `dashboard/Makefile.toml`.

## Type of Change

- [x] Test addition
- [x] Refactoring (code change that neither fixes a bug nor adds a feature)

## Motivation and Context

Issue #574 (umbrella) and the existing tracking issues #562 / #552 / #550 chase the same SPA navigation regression class as upstream `kent8192/reinhardt-web#4221`. Static, source-level, and ABI-level hypotheses are all falsified — most recently by upstream verifying the *exact* cloud bundle (SHA256 `263e23c41fc3db39…`) under `python3 -m http.server` and observing correct behaviour. The class keeps recurring because no test in either repo sits on the actual click-to-render path that downstream consumers exercise.

This PR adds that test on the cloud side. The test:

1. Mounts a `<div id="app">` and registers the dashboard's `ClientUrlReverser` (mirroring what the `#[routes]` macro auto-wires in production via `UnifiedRouter::client(...)`).
2. Calls `ClientLauncher::new("#app").router(init_router).launch()` — the same entry the production bundle uses.
3. Injects a real `<a href="/clusters">` and dispatches a bubbling click via `HtmlElement::click()`.
4. Asserts the exact #4221 symptom predicates:
   - `!history.state.is_string()` — not a JSON string
   - `history.state.is_object()` — #4218 invariant
   - `route_name == "dashboard:clusters"` — named route correctly resolved
   - `path == "/clusters"` — navigation target reflected

**Result at the cloud's currently-pinned `reinhardt-web b63bb3d3`: PASS.** This corroborates upstream's framework-side claim that the chain works correctly in isolation, and isolates the live `runserver --with-pages` symptom from the framework primitive — the test is now positioned to catch any future ABI/dedup/symbol-leak regression in this chain end-to-end.

## How Was This Tested?

```bash
cd dashboard && cargo make wasm-spa-test
# wasm-pack test --headless --chrome -- --features wasm-spa-test
# running 1 test
# test test_spa_navigation_smoke::link_click_advances_history_state_as_object ... ok
```

Also verified `cargo check -p reinhardt-cloud-dashboard` (native target) and `cargo clippy -p reinhardt-cloud-dashboard --all-targets --no-deps -- -D warnings` are clean.

## Implementation Notes

- **Native-only gating** (separate `chore:` commit): pre-existing integration tests (`tests/e2e.rs`, `tests/openapi_test.rs`, `tests/server_startup.rs`, `tests/smoke_test.rs`, `tests/unit.rs`), the `manage` binary (uses `#[tokio::main]`), and the `proptest`-using `property_tests` module in `shared/ws_messages.rs` are now gated behind `cfg(not(target_arch = "wasm32"))`. `wasm-pack test` builds with `--tests`, so without these gates the wasm test build pulls in `tokio`/`mio`/`reqwest`/`wiremock`/`uuid` and fails to link.
- **`main` symbol collision**: `wasm-bindgen-test` injects its own `main` for the runner; the dashboard's `#[wasm_bindgen(start)] fn main()` in `client::wasm_entry` would collide and `wasm-ld` would discard both. The wasm entry module is now gated behind `cfg(all(wasm, not(feature = "wasm-spa-test")))` so production builds keep the start function and `wasm-pack test --features wasm-spa-test` opts it out.
- **Per-target dev-deps**: `proptest`/`reqwest`/`wiremock`/`tokio`-via-`reqwest` etc. moved to `[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]`. `rstest` is added to wasm dev-deps so source-level `#[cfg(test)]` modules using `#[rstest]`/`#[case]` continue to compile.
- **Reverser registration**: production WASM gets the `ClientUrlReverser` via the `#[routes]` macro's `UnifiedRouter::client(...)` plumbing; the test bypasses that path because it never instantiates a `UnifiedRouter`, so it builds a `HashMap` mirror of `init_router()`'s `named_route` calls. Drift would re-trigger the panic the test prevents — comments in the test call this out explicitly.

## Out of Scope

- Resolving the actual #4221 symptom on `runserver --with-pages` is deferred to a follow-up after Phase 2 (bumping `reinhardt-web` to a SHA with #4222/#4223/#4227 and enabling `pages-nav-diag-dom`). The structural test landed here is a precondition for that diagnosis.
- Updating tracking issues #562/#552/#550 with the verdict will happen after this PR merges.

## Related Issues

Refs #574
Refs #562, #552, #550 (upstream-tracking issues — to be updated after merge)
Refs `kent8192/reinhardt-web#4221`, `#4218`, `#4222`, `#4223`, `#4227`

## Labels to Apply

### Type Label
- [x] `code-quality` — adds a regression test that closes a long-standing structural test gap

### Scope Label
- [x] `dashboard` — touches `dashboard/` exclusively

🤖 Generated with [Claude Code](https://claude.com/claude-code)
