### PR TITLE
fix(devcontainer): mount repo root instead of parent (Fixes #582)

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       # speeds up reads in the container at the cost of slightly delayed
       # propagation back to the host - acceptable since edits originate in
       # VS Code running against the in-container files.
-      - ../..:/workspaces/reinhardt-cloud:cached
+      - ..:/workspaces/reinhardt-cloud:cached
       # Persist cargo registry / git checkouts and the workspace `target/`
       # in named volumes. Bind-mounting `target/` on macOS is unusably slow
       # because of osxfs translation overhead.


### PR DESCRIPTION
## Summary

- Change `.devcontainer/docker-compose.yml` `dev.volumes` from `../..:/workspaces/reinhardt-cloud:cached` to `..:/workspaces/reinhardt-cloud:cached`.
- Resolved relative to `.devcontainer/`, `../..` walked up two levels and bound the parent of the repo. VS Code's devcontainer extension masked this via runtime overrides; bare `devcontainer up --workspace-folder .` did not, breaking `postCreateCommand` for every automated/agent flow.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

The bare-CLI flow is what every automated/agent-driven test harness uses (including the `reinhardt-wasm-e2e` skill). It has been broken since `1488b2dc5 feat(devcontainer): add Dockerfile and docker-compose for dashboard dev`.

## How Was This Tested

- [x] `docker compose -f .devcontainer/docker-compose.yml config` reports the correct mount source (repo root, not parent).
- [x] `devcontainer up --workspace-folder .` from a fresh worktree completes `postCreateCommand` without `No such file or directory`.
- [x] `docker inspect` confirms the mount source for `/workspaces/reinhardt-cloud` is the repo root.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] No new warnings introduced

## Labels to Apply

- `bug`
- `high`

## Related Issues

Fixes #582

🤖 Generated with [Claude Code](https://claude.com/claude-code)