### PR TITLE
fix(dashboard): complete local.example.toml with required ProjectSettings sections (Fixes #584)

### DIFF
--- a/dashboard/settings/local.example.toml
+++ b/dashboard/settings/local.example.toml
@@ -65,3 +65,38 @@ options = {}
 # Allowed origins for OriginGuardMiddleware (exact match, no wildcards).
 # OriginGuard filters out "*" — use explicit URLs.
 allow_origins = ["http://localhost:8000", "http://127.0.0.1:8000"]
+
+[i18n]
+language_code = "en-us"
+time_zone = "UTC"
+use_i18n = true
+use_tz = true
+
+[static_files]
+url = "/static/"
+root = "static"
+
+[media]
+url = "/media/"
+root = "media"
+
+# Local email defaults target Mailpit (`docker run mailpit`) on plaintext 1025.
+# Override host/port/credentials via REINHARDT_EMAIL__* env vars when pointing
+# at a real provider (Resend / SES / SendGrid / Postmark).
+[email]
+host = "localhost"
+port = 1025
+from_email = "noreply@localhost"
+use_ssl = false
+use_tls = false
+
+# Top-level [database] section required by reinhardt-web's runserver/migrate
+# CLI commands. Mirrors [core.databases.default] above with a plain-string
+# password field (the CLI does not understand the `{ secret = ... }` shape).
+[database]
+engine = "postgresql"
+host = "${RC_DB_HOST:-localhost}"
+port = 5432
+name = "reinhardt_cloud_dev"
+user = "postgres"
+password = "CHANGE-ME"

--- a/dashboard/settings/local.example.toml
+++ b/dashboard/settings/local.example.toml
@@ -80,7 +80,8 @@ root = "static"
 url = "/media/"
 root = "media"
 
-# Local email defaults target Mailpit (`docker run mailpit`) on plaintext 1025.
+# Local email defaults target a plaintext SMTP catcher on 127.0.0.1:1025
+# (e.g. Mailpit: `docker run -d -p 1025:1025 -p 8025:8025 axllent/mailpit`).
 # Override host/port/credentials via REINHARDT_EMAIL__* env vars when pointing
 # at a real provider (Resend / SES / SendGrid / Postmark).
 [email]
@@ -93,10 +94,14 @@ use_tls = false
 # Top-level [database] section required by reinhardt-web's runserver/migrate
 # CLI commands. Mirrors [core.databases.default] above with a plain-string
 # password field (the CLI does not understand the `{ secret = ... }` shape).
+# `${RC_DB_PASSWORD:-CHANGE-ME}` lets the password come from an env var
+# (mirroring the `RC_DB_HOST` pattern elsewhere) so that automated flows
+# can avoid editing this file; if RC_DB_PASSWORD is unset the placeholder
+# remains and must be replaced manually in `local.toml`.
 [database]
 engine = "postgresql"
 host = "${RC_DB_HOST:-localhost}"
 port = 5432
 name = "reinhardt_cloud_dev"
 user = "postgres"
-password = "CHANGE-ME"
+password = "${RC_DB_PASSWORD:-CHANGE-ME}"


### PR DESCRIPTION
## Summary

- Add `[i18n]`, `[static_files]`, `[media]`, `[email]`, and top-level `[database]` sections to `dashboard/settings/local.example.toml`.
- Sections mirror the canonical defaults in `dashboard/settings/base.example.toml` (lines 41–86) and the `[database]` shape already shipped in `staging.toml` / `production.toml`, with values tuned for local development (Mailpit on `localhost:1025`, `reinhardt_cloud_dev` postgres database, etc.).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation

## Motivation and Context

`.devcontainer/post-create.sh` copies `local.example.toml` → `local.toml` on first container bring-up. The template was missing five sections required by \`ProjectSettings\` deserialization and by reinhardt-web's \`runserver\` / \`migrate\` commands, so the documented "copy the example then run runserver" path panicked immediately on \`missing field 'i18n'\` (and then a cascade of further missing fields). Devcontainer / CI / agent flows all ran into this and had to hand-patch the file.

## How Was This Tested

- [x] \`grep -E '^\[(i18n|static_files|media|email|database)\]' dashboard/settings/local.example.toml\` reports all 5 sections.
- [x] Using \`local.example.toml\` as \`local.toml\`, \`cargo nextest run -p reinhardt-cloud-dashboard config::settings::tests\` passes (10/10) — the deserialization path that previously panicked now succeeds end-to-end.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] No new warnings introduced
- [x] All comments in English

## Labels to Apply

- \`bug\`
- \`documentation\`
- \`high\`

## Related Issues

Fixes #584
Refs #582 (discovered while setting up the bare-CLI devcontainer flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)