### PR TITLE
docs(dashboard): cite reinhardt-web#4258 as new SPA workaround removal blocker

### DIFF
--- a/dashboard/src/client.rs
+++ b/dashboard/src/client.rs
@@ -65,8 +65,16 @@ mod wasm_entry {
 	// for the upstream-resolved ideal form using
 	// `UnifiedRouter::new().client(|c| ...).register_globally()`.
 	//
+	// Status (verified at reinhardt-web SHA 32a244e92d, 2026-05-10):
+	// removal is now blocked on `kent8192/reinhardt-web#4258` (a
+	// regression introduced by reinhardt-web#4242 that broke `ClientRouter`
+	// `Send + Sync` on native) rather than on the original
+	// `kent8192/reinhardt-web#4230`. Tracking on cloud:
+	// `kent8192/reinhardt-cloud#600`.
+	//
 	// Remove this helper and the `register_client_url_reverser()` call
-	// in `main` when reinhardt-web#4230 is resolved.
+	// in `main` once `kent8192/reinhardt-web#4258` ships AND the cloud
+	// bumps past the merge of that fix together with reinhardt-web#4242.
 	//
 	// Ideal implementation (without workaround):
 	//   /* removed entirely; reverser is registered automatically by */

--- a/dashboard/src/client/router.rs
+++ b/dashboard/src/client/router.rs
@@ -63,14 +63,31 @@ use super::pages::not_found_page;
 // helper in `client.rs::wasm_entry`. Both consume the same const slice
 // so drift is impossible while the workaround is in place.
 //
-// Remove this workaround when reinhardt-web#4230 is resolved (the
-// framework collapses `pages::Router` into `urls::ClientRouter`,
-// `ClientLauncher::router(...)` accepts the unified type, and the
-// `#[routes]` macro emits `register_client_reverser` on WASM).
+// Status (verified at reinhardt-web SHA 32a244e92d, 2026-05-10):
+//   - Upstream PR reinhardt-web#4242 (closed reinhardt-web#4234) added
+//     `ClientLauncher::router_client` and made
+//     `UnifiedRouter::register_globally()` install the WASM-side
+//     `ClientUrlReverser` automatically — addressing #4230.
+//   - However, the same PR moved `pages::Router`'s reactive state
+//     (`Rc<Cell<u64>>`, `Rc<RefCell<Vec<Weak<dyn Fn>>>>`) into
+//     `urls::ClientRouter` *without* `#[cfg(wasm)]` gating, so the
+//     unified router is no longer `Send + Sync` on native. This breaks
+//     `DashboardRouter(pub UnifiedRouter)`'s DI registration in
+//     `crate::config::urls::make_router` (35 compile errors of the form
+//     "Rc<Cell<u64>> cannot be sent between threads safely").
+//   - Filed upstream as `kent8192/reinhardt-web#4258`; tracked in
+//     `kent8192/reinhardt-cloud#600` (`upstream-tracking`).
+//
+// Remove this workaround once `kent8192/reinhardt-web#4258` ships AND
+// the cloud bumps to a revision that includes both the #4258 fix and
+// the #4242 `ClientLauncher::router_client` API. The patch set is
+// staged on the worktree branch
+// `refactor/issue-577-unified-router-spa-32a244e9` (see #600 comments).
 //
 // Ideal implementation (without workaround):
-//   pub fn init_router() -> reinhardt::urls::UnifiedRouter {
-//       use reinhardt::urls::UnifiedRouter;
+//   use reinhardt::urls::routers::{ClientRouter, UnifiedRouter};
+//
+//   pub fn init_router() -> ClientRouter {
 //       UnifiedRouter::new()
 //           .client(|c| {
 //               c.named_route("dashboard:home", "/", dashboard_shell)
@@ -85,7 +102,7 @@ use super::pages::not_found_page;
 //
 // Caller in `client.rs::wasm_entry::main` becomes:
 //   ClientLauncher::new("#app")
-//       .router(router::init_router)  // returns ClientRouter via register_globally()
+//       .router_client(router::init_router)
 //       .launch()?;
 //
 // `client.rs::wasm_entry::register_client_url_reverser` and the const


### PR DESCRIPTION
## Summary

- Verified at `reinhardt-web` SHA `32a244e92d` that the API the parallel-route-table workaround in `dashboard/src/client.rs` and `dashboard/src/client/router.rs` was waiting on (`ClientLauncher::router_client` + `UnifiedRouter::register_globally()`, from PR `kent8192/reinhardt-web#4242` / closing `kent8192/reinhardt-web#4234`) is now available
- **However**, the same bump introduces a `Send + Sync` regression in `urls::ClientRouter` that prevents removing the workaround. Filed upstream as `kent8192/reinhardt-web#4258`; tracked on cloud as `kent8192/reinhardt-cloud#600`
- Update the existing `WORKAROUND` blocks in `dashboard/src/client.rs` and `dashboard/src/client/router.rs` to record the verification finding, point at the new blocker (`reinhardt-web#4258` / `cloud#600`), and refresh the ideal-implementation sketch to use `ClientLauncher::router_client(...)` as the call site that becomes available once unblocked

## Type of Change

- [x] Documentation update (workaround comment refresh)

## Motivation and Context

`#577` and `#574` chased the `Global client reverser not registered` panic through 7 iterations of `kent8192/reinhardt-web#4221`. The upstream resolution path was always 'collapse `pages::Router` into `urls::ClientRouter` and have `ClientLauncher` accept the unified type'. That landed in `kent8192/reinhardt-web#4242` (closing `#4234`).

Verifying the bump in a clean worktree against `reinhardt-web` SHA `32a244e92d6bde8e44b69e5ea88c219df885ed94` produced 35 native-target compile errors of the form:

```
error[E0277]: `Rc<Cell<u64>>` cannot be sent between threads safely
   --> dashboard/src/config/urls.rs:240:73
    |
240 | async fn make_router(...) -> DashboardRouter {
    |                              ^^^^^^^^^^^^^^^ `Rc<Cell<u64>>` cannot be sent between threads safely
```

Root cause: `kent8192/reinhardt-web#4242` moved `pages::Router`'s reactive observation state (`Rc<Cell<u64>>`, `Rc<RefCell<Vec<Weak<dyn Fn>>>>`) into `urls::ClientRouter` *without* `#[cfg(wasm)]` gating. The pre-#4242 `pages::Router` was `#[cfg(wasm)]`-gated on the entire struct, so cross-target consumers never saw the `Rc` fields. The new `ClientRouter` has no such gate, so the unified router transitively containing it is no longer `Send + Sync` on native, breaking `DashboardRouter(pub UnifiedRouter)`'s DI registration.

The workaround in `client.rs`/`client/router.rs` therefore cannot be removed simply by bumping past `#4242` — it has to wait for `#4258` to land first. This PR records the finding so that the next contributor reading the WORKAROUND blocks understands the actual current blocker (it's no longer `#4230` — that part is fixed — but rather the regression filed as `#4258`).

## How Was This Tested

- [x] `cargo check -p reinhardt-cloud-dashboard --all-features` — green (1m 04s)
- [x] `cargo make fmt-check` — 404 unchanged, 0 errors
- [x] `cargo clippy -p reinhardt-cloud-dashboard --all-features -- -D warnings` — clean

The bump itself was *not* applied to `Cargo.lock` in this PR; that change is staged on the worktree branch `refactor/issue-577-unified-router-spa-32a244e9` for re-application when `kent8192/reinhardt-web#4258` ships. Browser verification via Chrome DevTools MCP was deferred for the same reason — the cloud's existing workaround already serves the SPA correctly per cloud `main`'s known-good state.

## Checklist

- [x] WORKAROUND comment updated to cite the new blocker (`reinhardt-web#4258`)
- [x] Cross-references to the upstream and tracking issues added
- [x] Ideal-implementation sketch refreshed to use `ClientLauncher::router_client(...)`
- [x] No code behaviour change (comment-only refactor)

## Related Issues

Refs #574, #577

Refs #600 (`upstream-tracking` for `reinhardt-web#4258`)

Refs #601 (`upstream-tracking` for `reinhardt-web#4259`, separate but discovered during the same verification)

Refs #599 (services `#[injectable_factory]` migration, surfaced during the same review)

## Labels to Apply

- documentation
- dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)