### PR TITLE
docs(policy): add Reinhardt-family Autonomous Operation Policy and CLAUDE↔AGENTS sync rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,7 +154,7 @@ See instructions/DOCUMENTATION_STANDARDS.md for comprehensive documentation stan
 
 **Autonomous Operation Policy (Reinhardt Family):**
 
-This is an explicit, named exception to "NEVER commit/push without explicit user instruction" (Commit Policy above) and to the "Authorization = explicit user instruction OR Plan Mode approval" requirement in the GitHub Comments policy.
+This is an explicit, named exception to "NEVER commit/push without explicit user instruction" in the Commit Policy above. Comment-posting authorization (`instructions/GITHUB_INTERACTION.md` PP-1) is unchanged — see "Still Requires Explicit User Authorization" below.
 
 Scope (applies only when the working directory is inside one of these four repositories):
 
@@ -184,7 +184,9 @@ Still Requires Explicit User Authorization (no autonomy):
 - `git push --force`, `--force-with-lease`, or any other history-rewriting push
 - `git rebase`, `git reset --hard`, `git branch -D`, deleting tags, or any other history-destructive operation
 - Closing, merging, or deleting PRs
-- Closing or deleting Issues, comments, or review threads
+- Closing or deleting Issues
+- Deleting or hiding comments (on PRs, Issues, or commits)
+- Resolving or unresolving review threads
 - Creating release tags or any PR carrying the `release` label
 - Posting comments / replies / reviews on PRs/Issues — the comment-posting authorization model in `instructions/GITHUB_INTERACTION.md` PP-1 is unchanged; the autonomous policy covers only the **creation** of commits, pushes, Draft PRs, and Issues, not commenting
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,16 @@ See instructions/TESTING_STANDARDS.md for comprehensive testing standards includ
 
 See instructions/DOCUMENTATION_STANDARDS.md for comprehensive documentation standards.
 
+**AGENTS.md ↔ CLAUDE.md Sync Policy:**
+- `AGENTS.md` (Codex) and `CLAUDE.md` (Claude Code) are deliberate mirror copies kept in sync
+- The two files MUST differ only on a small set of mechanical substitutions:
+  - `AGENTS.md` ↔ `CLAUDE.md` (title, references)
+  - `AGENTS.local.md` ↔ `CLAUDE.local.md`
+  - `Codex attribution` ↔ `Claude Code attribution`
+- **MUST**: Any edit to one file MUST be mirrored into the other in the same commit
+- **MUST**: After editing, run `diff CLAUDE.md AGENTS.md` and confirm only the documented substitutions remain
+- **NEVER**: Commit a change that touches only one of the two files
+
 ### Git Workflow
 
 **Commit Policy:**
@@ -136,10 +146,53 @@ See instructions/DOCUMENTATION_STANDARDS.md for comprehensive documentation stan
   - When user approves a plan via Exit Plan Mode, implementation and commits are both authorized
   - Upon successful implementation, all planned commits are created automatically without additional confirmation
   - If implementation fails or tests fail, NO commits are created (report to user instead)
+- **EXCEPTION (Reinhardt family)**: When operating inside `reinhardt-web` / `reinhardt-cloud` / `awesome-delions` / `reinhardt-cc`, the **Autonomous Operation Policy** below authorizes commit and push on any non-protected branch (plus Draft PR / Issue creation) without further confirmation — see the next subsection
 - Split commits by specific intent (NOT feature-level goals)
 - Each commit MUST be small enough to explain in one line
 - Use `git apply <patchfile name>.patch` for partial file commits
 - **NEVER** execute batch commits without user confirmation
+
+**Autonomous Operation Policy (Reinhardt Family):**
+
+This is an explicit, named exception to "NEVER commit/push without explicit user instruction" (Commit Policy above) and to the "Authorization = explicit user instruction OR Plan Mode approval" requirement in the GitHub Comments policy.
+
+Scope (applies only when the working directory is inside one of these four repositories):
+
+- `kent8192/reinhardt-web`
+- `kent8192/reinhardt-cloud`
+- `kent8192/awesome-delions`
+- `kent8192/reinhardt-cc`
+
+Autonomously Allowed (no per-action confirmation required):
+
+| Operation | Constraint |
+|-----------|------------|
+| `git commit` | On any non-protected branch |
+| `git push` | On any non-protected branch (`feature/...`, `fix/...`, `refactor/...`, `docs/...`, `chore/...`, `test/...`, `perf/...`, `debug/...`, etc.); **never** on `main`, `master`, `develop/*`, or `release/*` |
+| Create a **Draft** Pull Request | `gh pr create --draft` / MCP `create_pull_request` with `draft=true`; body MUST follow `.github/PULL_REQUEST_TEMPLATE.md` |
+| Convert Draft PR to **Ready for Review** | **Implementation-complete is the only readiness criterion** — CI completion is **not** required (overrides any "CI green" criterion elsewhere in this document or in `instructions/`) |
+| Create an Issue | `gh issue create` / MCP `issue_write`; MUST follow the appropriate issue template and apply at least one type label |
+
+**Protected Branches** (commit/push always require explicit user authorization):
+- `main`, `master`
+- `develop/*` (any branch starting with `develop/`)
+- `release/*` (any branch starting with `release/`)
+
+Still Requires Explicit User Authorization (no autonomy):
+
+- Direct push to any protected branch listed above
+- `git push --force`, `--force-with-lease`, or any other history-rewriting push
+- `git rebase`, `git reset --hard`, `git branch -D`, deleting tags, or any other history-destructive operation
+- Closing, merging, or deleting PRs
+- Closing or deleting Issues, comments, or review threads
+- Creating release tags or any PR carrying the `release` label
+- Posting comments / replies / reviews on PRs/Issues — the comment-posting authorization model in `instructions/GITHUB_INTERACTION.md` PP-1 is unchanged; the autonomous policy covers only the **creation** of commits, pushes, Draft PRs, and Issues, not commenting
+
+Unchanged Quality Guardrails (apply equally to autonomous operations):
+
+- PR title and body MUST follow Conventional Commits and `.github/PULL_REQUEST_TEMPLATE.md`
+- Issue body MUST follow `.github/ISSUE_TEMPLATE/*.yml`
+- Branch naming, commit message format, Codex attribution footer, English-only policy, and all other rules in this document remain in force
 
 **Branch Operations:**
 - When merging branches and resolving conflicts, execute immediately without entering Plan Mode
@@ -177,6 +230,7 @@ See instructions/DOCUMENTATION_STANDARDS.md for comprehensive documentation stan
 - ALL comments MUST be in English and include Codex attribution footer
 - Comments MUST reference specific code locations with repository-relative paths
 - Comments MUST NOT contain user requests, AI interactions, or absolute local paths
+- **Reinhardt family scope note**: The Autonomous Operation Policy authorizes *creation* of Draft PRs and Issues without further confirmation in the four Reinhardt-family repos, but *commenting* on PRs/Issues remains fully subject to the rules above
 
 See instructions/GITHUB_INTERACTION.md for comprehensive GitHub interaction guidelines including:
 - Posting authorization policy (PP-1 ~ PP-3)
@@ -466,8 +520,10 @@ Before submitting code:
 - Update docs with code changes (same workflow)
 - Clean up ALL test artifacts
 - Delete temp files from `/tmp` immediately
-- Wait for explicit user instruction before commits
+- Wait for explicit user instruction before commits (except where the Autonomous Operation Policy applies)
 - Understand that Plan Mode approval authorizes both implementation and commits
+- Treat the Autonomous Operation Policy (Reinhardt family) as a standing exception that allows commit and push on any non-protected branch (anything other than `main`/`master`/`develop/*`/`release/*`), Draft PR creation, Draft→Ready conversion (implementation-complete only — no CI requirement), and Issue creation without further confirmation
+- When editing `AGENTS.md` or `CLAUDE.md`, mirror the change into the other file in the same commit (AGENTS.md ↔ CLAUDE.md sync policy)
 - Mark placeholders with `todo!()` or `// TODO:`
 - Use `#[serial(group_name)]` for global state tests
 - Split commits by specific intent, not features
@@ -525,7 +581,12 @@ Before submitting code:
 
 ### ❌ NEVER DO
 - Use `mod.rs` files (deprecated pattern)
-- Commit without user instruction (except Plan Mode approval)
+- Commit without user instruction (except Plan Mode approval or the Autonomous Operation Policy for Reinhardt-family repos)
+- Push directly to any protected branch (`main`, `master`, `develop/*`, `release/*`) — even under the Autonomous Operation Policy these require explicit user authorization
+- Force-push, rebase-and-push, or otherwise rewrite history without explicit user authorization (the Autonomous Operation Policy does NOT cover history-rewriting pushes)
+- Close, merge, or delete PRs / Issues / comments without explicit user authorization (autonomy covers creation only, not destruction)
+- Create release tags or any PR with the `release` label without explicit user authorization
+- Commit a change that touches only `AGENTS.md` without mirroring it into `CLAUDE.md` (and vice versa)
 - Leave docs outdated after code changes
 - Document user requests or AI interactions in project documentation
 - Save files to project directory (use `/tmp`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,7 @@ See instructions/DOCUMENTATION_STANDARDS.md for comprehensive documentation stan
 
 **Autonomous Operation Policy (Reinhardt Family):**
 
-This is an explicit, named exception to "NEVER commit/push without explicit user instruction" (Commit Policy above) and to the "Authorization = explicit user instruction OR Plan Mode approval" requirement in the GitHub Comments policy.
+This is an explicit, named exception to "NEVER commit/push without explicit user instruction" in the Commit Policy above. Comment-posting authorization (`instructions/GITHUB_INTERACTION.md` PP-1) is unchanged — see "Still Requires Explicit User Authorization" below.
 
 Scope (applies only when the working directory is inside one of these four repositories):
 
@@ -184,7 +184,9 @@ Still Requires Explicit User Authorization (no autonomy):
 - `git push --force`, `--force-with-lease`, or any other history-rewriting push
 - `git rebase`, `git reset --hard`, `git branch -D`, deleting tags, or any other history-destructive operation
 - Closing, merging, or deleting PRs
-- Closing or deleting Issues, comments, or review threads
+- Closing or deleting Issues
+- Deleting or hiding comments (on PRs, Issues, or commits)
+- Resolving or unresolving review threads
 - Creating release tags or any PR carrying the `release` label
 - Posting comments / replies / reviews on PRs/Issues — the comment-posting authorization model in `instructions/GITHUB_INTERACTION.md` PP-1 is unchanged; the autonomous policy covers only the **creation** of commits, pushes, Draft PRs, and Issues, not commenting
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,16 @@ See instructions/TESTING_STANDARDS.md for comprehensive testing standards includ
 
 See instructions/DOCUMENTATION_STANDARDS.md for comprehensive documentation standards.
 
+**CLAUDE.md ↔ AGENTS.md Sync Policy:**
+- `CLAUDE.md` (Claude Code) and `AGENTS.md` (Codex) are deliberate mirror copies kept in sync
+- The two files MUST differ only on a small set of mechanical substitutions:
+  - `CLAUDE.md` ↔ `AGENTS.md` (title, references)
+  - `CLAUDE.local.md` ↔ `AGENTS.local.md`
+  - `Claude Code attribution` ↔ `Codex attribution`
+- **MUST**: Any edit to one file MUST be mirrored into the other in the same commit
+- **MUST**: After editing, run `diff CLAUDE.md AGENTS.md` and confirm only the documented substitutions remain
+- **NEVER**: Commit a change that touches only one of the two files
+
 ### Git Workflow
 
 **Commit Policy:**
@@ -136,10 +146,53 @@ See instructions/DOCUMENTATION_STANDARDS.md for comprehensive documentation stan
   - When user approves a plan via Exit Plan Mode, implementation and commits are both authorized
   - Upon successful implementation, all planned commits are created automatically without additional confirmation
   - If implementation fails or tests fail, NO commits are created (report to user instead)
+- **EXCEPTION (Reinhardt family)**: When operating inside `reinhardt-web` / `reinhardt-cloud` / `awesome-delions` / `reinhardt-cc`, the **Autonomous Operation Policy** below authorizes commit and push on any non-protected branch (plus Draft PR / Issue creation) without further confirmation — see the next subsection
 - Split commits by specific intent (NOT feature-level goals)
 - Each commit MUST be small enough to explain in one line
 - Use `git apply <patchfile name>.patch` for partial file commits
 - **NEVER** execute batch commits without user confirmation
+
+**Autonomous Operation Policy (Reinhardt Family):**
+
+This is an explicit, named exception to "NEVER commit/push without explicit user instruction" (Commit Policy above) and to the "Authorization = explicit user instruction OR Plan Mode approval" requirement in the GitHub Comments policy.
+
+Scope (applies only when the working directory is inside one of these four repositories):
+
+- `kent8192/reinhardt-web`
+- `kent8192/reinhardt-cloud`
+- `kent8192/awesome-delions`
+- `kent8192/reinhardt-cc`
+
+Autonomously Allowed (no per-action confirmation required):
+
+| Operation | Constraint |
+|-----------|------------|
+| `git commit` | On any non-protected branch |
+| `git push` | On any non-protected branch (`feature/...`, `fix/...`, `refactor/...`, `docs/...`, `chore/...`, `test/...`, `perf/...`, `debug/...`, etc.); **never** on `main`, `master`, `develop/*`, or `release/*` |
+| Create a **Draft** Pull Request | `gh pr create --draft` / MCP `create_pull_request` with `draft=true`; body MUST follow `.github/PULL_REQUEST_TEMPLATE.md` |
+| Convert Draft PR to **Ready for Review** | **Implementation-complete is the only readiness criterion** — CI completion is **not** required (overrides any "CI green" criterion elsewhere in this document or in `instructions/`) |
+| Create an Issue | `gh issue create` / MCP `issue_write`; MUST follow the appropriate issue template and apply at least one type label |
+
+**Protected Branches** (commit/push always require explicit user authorization):
+- `main`, `master`
+- `develop/*` (any branch starting with `develop/`)
+- `release/*` (any branch starting with `release/`)
+
+Still Requires Explicit User Authorization (no autonomy):
+
+- Direct push to any protected branch listed above
+- `git push --force`, `--force-with-lease`, or any other history-rewriting push
+- `git rebase`, `git reset --hard`, `git branch -D`, deleting tags, or any other history-destructive operation
+- Closing, merging, or deleting PRs
+- Closing or deleting Issues, comments, or review threads
+- Creating release tags or any PR carrying the `release` label
+- Posting comments / replies / reviews on PRs/Issues — the comment-posting authorization model in `instructions/GITHUB_INTERACTION.md` PP-1 is unchanged; the autonomous policy covers only the **creation** of commits, pushes, Draft PRs, and Issues, not commenting
+
+Unchanged Quality Guardrails (apply equally to autonomous operations):
+
+- PR title and body MUST follow Conventional Commits and `.github/PULL_REQUEST_TEMPLATE.md`
+- Issue body MUST follow `.github/ISSUE_TEMPLATE/*.yml`
+- Branch naming, commit message format, Claude Code attribution footer, English-only policy, and all other rules in this document remain in force
 
 **Branch Operations:**
 - When merging branches and resolving conflicts, execute immediately without entering Plan Mode
@@ -177,6 +230,7 @@ See instructions/DOCUMENTATION_STANDARDS.md for comprehensive documentation stan
 - ALL comments MUST be in English and include Claude Code attribution footer
 - Comments MUST reference specific code locations with repository-relative paths
 - Comments MUST NOT contain user requests, AI interactions, or absolute local paths
+- **Reinhardt family scope note**: The Autonomous Operation Policy authorizes *creation* of Draft PRs and Issues without further confirmation in the four Reinhardt-family repos, but *commenting* on PRs/Issues remains fully subject to the rules above
 
 See instructions/GITHUB_INTERACTION.md for comprehensive GitHub interaction guidelines including:
 - Posting authorization policy (PP-1 ~ PP-3)
@@ -466,8 +520,10 @@ Before submitting code:
 - Update docs with code changes (same workflow)
 - Clean up ALL test artifacts
 - Delete temp files from `/tmp` immediately
-- Wait for explicit user instruction before commits
+- Wait for explicit user instruction before commits (except where the Autonomous Operation Policy applies)
 - Understand that Plan Mode approval authorizes both implementation and commits
+- Treat the Autonomous Operation Policy (Reinhardt family) as a standing exception that allows commit and push on any non-protected branch (anything other than `main`/`master`/`develop/*`/`release/*`), Draft PR creation, Draft→Ready conversion (implementation-complete only — no CI requirement), and Issue creation without further confirmation
+- When editing `CLAUDE.md` or `AGENTS.md`, mirror the change into the other file in the same commit (CLAUDE.md ↔ AGENTS.md sync policy)
 - Mark placeholders with `todo!()` or `// TODO:`
 - Use `#[serial(group_name)]` for global state tests
 - Split commits by specific intent, not features
@@ -525,7 +581,12 @@ Before submitting code:
 
 ### ❌ NEVER DO
 - Use `mod.rs` files (deprecated pattern)
-- Commit without user instruction (except Plan Mode approval)
+- Commit without user instruction (except Plan Mode approval or the Autonomous Operation Policy for Reinhardt-family repos)
+- Push directly to any protected branch (`main`, `master`, `develop/*`, `release/*`) — even under the Autonomous Operation Policy these require explicit user authorization
+- Force-push, rebase-and-push, or otherwise rewrite history without explicit user authorization (the Autonomous Operation Policy does NOT cover history-rewriting pushes)
+- Close, merge, or delete PRs / Issues / comments without explicit user authorization (autonomy covers creation only, not destruction)
+- Create release tags or any PR with the `release` label without explicit user authorization
+- Commit a change that touches only `CLAUDE.md` without mirroring it into `AGENTS.md` (and vice versa)
 - Leave docs outdated after code changes
 - Document user requests or AI interactions in project documentation
 - Save files to project directory (use `/tmp`)

--- a/instructions/COMMIT_GUIDELINE.md
+++ b/instructions/COMMIT_GUIDELINE.md
@@ -25,6 +25,7 @@ Key principles from the specification:
 - **NEVER** push commits without explicit user instruction
 - Always wait for user confirmation before committing changes
 - Prepare changes and inform the user, but let them decide when to commit
+- **EXCEPTION (Reinhardt family)**: When operating inside `reinhardt-web` / `reinhardt-cloud` / `awesome-delions` / `reinhardt-cc`, the **Autonomous Operation Policy** in `CLAUDE.md` / `AGENTS.md` (see the "Autonomous Operation Policy (Reinhardt Family)" subsection of `### Git Workflow`) authorizes commit and push on any non-protected branch without further confirmation. Protected branches (`main`, `master`, `develop/*`, `release/*`) and history-rewriting pushes (force-push, rebase-push) still require explicit user instruction.
 
 The following diagram summarizes the commit authorization decision flow:
 

--- a/instructions/GITHUB_INTERACTION.md
+++ b/instructions/GITHUB_INTERACTION.md
@@ -33,6 +33,8 @@ Claude Code MUST follow this authorization model before posting any comment:
 | Plan Mode approval | Post directly |
 | Self-initiated (no instruction) | MUST preview and get user confirmation |
 
+**Scope clarification (Reinhardt family Autonomous Operation Policy):** The Autonomous Operation Policy defined in `CLAUDE.md` / `AGENTS.md` authorizes *creation* of Draft PRs and Issues without further confirmation in the four Reinhardt-family repos, but the comment authorization model above is **unchanged**. Posting comments, replies, or reviews on PRs/Issues still requires explicit user instruction or Plan Mode approval, even in the four repos covered by the autonomous policy.
+
 **Self-Initiated Comment Flow:**
 
 1. Draft the comment content

--- a/instructions/ISSUE_GUIDELINES.md
+++ b/instructions/ISSUE_GUIDELINES.md
@@ -35,6 +35,8 @@ Issues MUST be created using:
 gh issue create --title "Bug: Reconciler panics on missing Deployment" --body "Description..."
 ```
 
+**Autonomy (Reinhardt family):** Creating an Issue is authorized without further user confirmation in `reinhardt-web` / `reinhardt-cloud` / `awesome-delions` / `reinhardt-cc` (see Autonomous Operation Policy in `CLAUDE.md` / `AGENTS.md`); the Issue body MUST still follow the appropriate template under `.github/ISSUE_TEMPLATE/` and carry at least one type label. Closing or deleting Issues remains subject to explicit user authorization.
+
 ### IC-2 (MUST): Search Before Creating
 
 **ALWAYS** search existing issues before creating a new one:

--- a/instructions/PR_GUIDELINE.md
+++ b/instructions/PR_GUIDELINE.md
@@ -24,6 +24,7 @@ This file defines the pull request (PR) policy for the Reinhardt Cloud project. 
 - **MUST** prefer GitHub MCP tools (`create_pull_request`) for creating pull requests when available
 - **Fallback**: Use GitHub CLI (`gh pr create`) when GitHub MCP is not available
 - **NEVER** use web browser UI for PR creation when MCP or CLI is available
+- **Autonomy (Reinhardt family)**: Creating a **Draft** PR is authorized without further user confirmation in `reinhardt-web` / `reinhardt-cloud` / `awesome-delions` / `reinhardt-cc` (see Autonomous Operation Policy in `CLAUDE.md` / `AGENTS.md`); the Draft PR body MUST still follow `.github/PULL_REQUEST_TEMPLATE.md` and `--draft` MUST be passed. Marking a PR as Ready for Review is also authorized autonomously once the implementation is complete (CI completion is **not** required).
 
 The following diagram summarizes the PR creation flow:
 
@@ -90,12 +91,15 @@ chore/ci-update-kubernetes-version
 ### PC-4 (SHOULD): Draft PRs for Work in Progress
 
 - Use draft PRs for incomplete work
-- Convert to ready for review when all tests pass
+- Convert to Ready for Review **once the implementation is complete** — CI completion is **not** a prerequisite (the Reinhardt-family Autonomous Operation Policy in `CLAUDE.md` / `AGENTS.md` overrides any "wait for all tests to pass" criterion for the Draft→Ready transition)
 - Draft PRs allow early feedback without formal review requests
 
 **Example:**
 ```bash
 gh pr create --draft --title "feat(crd): add ReinhardtApp CRD (WIP)"
+
+# Convert to Ready once implementation is complete (no need to wait for CI):
+gh pr ready <number>
 ```
 
 ### PC-5 (MUST): PR Labels


### PR DESCRIPTION
## Summary

- Add an explicit, named **Autonomous Operation Policy** under `### Git Workflow` in `CLAUDE.md` / `AGENTS.md`
- Add **CLAUDE.md ↔ AGENTS.md Sync Policy** under `### Documentation` requiring mirrored edits in the same commit
- Propagate exception notes to `instructions/COMMIT_GUIDELINE.md` (CE-1), `instructions/GITHUB_INTERACTION.md` (PP-1), `instructions/PR_GUIDELINE.md` (PC-1, PC-4), `instructions/ISSUE_GUIDELINES.md` (IC-1)

## Type of Change

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature

## Motivation and Context

The existing "NEVER commit/push without explicit user instruction" rule plus the comment-authorization model required per-action confirmation for low-risk, fully-recoverable operations (feature-branch commits/pushes, Draft PRs, Issue creation) on the four single-maintainer Reinhardt-family repositories. This PR carves out a narrow autonomy exception for those repos while keeping every high-risk lever (protected-branch push, history rewrite, PR/Issue close/delete, release tags, release-labeled PRs, *any* PR/Issue comment) explicit-instruction-only.

The PR also formalises an invariant the two files already followed: `CLAUDE.md` (Claude Code) and `AGENTS.md` (Codex) are mirror copies — editing one alone has caused drift in the past, so the new sync policy requires the mirror update in the same commit.

## What changed precisely

**Autonomously allowed** (in the 4 repos only):
| Operation | Constraint |
|-----------|------------|
| `git commit` | Any non-protected branch |
| `git push` | Any non-protected branch (`feature/...`, `fix/...`, `refactor/...`, `docs/...`, `chore/...`, etc.); **never** `main`, `master`, `develop/*`, `release/*` |
| Create Draft PR | `--draft` is mandatory; body follows PR template |
| Draft → Ready | Implementation complete is the only criterion; CI green is **not** required |
| Create Issue | Template + at least one type label |

**Still requires explicit authorization:**
- Push to `main`, `master`, `develop/*`, `release/*`
- `git push --force[-with-lease]`, rebase-push, history rewrite
- Close / merge / delete PRs or Issues
- Release tags or PRs carrying the `release` label
- Posting *any* comment / reply / review on PRs/Issues (PP-1 unchanged)

## How Was This Tested

- `diff CLAUDE.md AGENTS.md` reduced to the documented mechanical substitutions only (CLAUDE↔AGENTS, Claude Code↔Codex, CLAUDE.local↔AGENTS.local — 54 lines, all on the expected substitution sites)
- Manually walked through each rule cross-reference (CE-1 ↔ Autonomous Operation Policy, PP-1 scope clarification, PC-4 Draft→Ready, IC-1)

## Checklist

- [x] Documentation updated in both CLAUDE.md and AGENTS.md (mirror invariant preserved)
- [x] No code changes (pure policy/doc update)
- [x] Conventional commit format
- [x] PR description follows template

## Labels to Apply

- `documentation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
