### PR TITLE
chore(deps): bump reinhardt-web to main tip 80a8f345 (post rc.29)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1340,7 +1340,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1936,7 +1936,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2198,7 +2198,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4209,7 +4209,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5565,7 +5565,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6005,7 +6005,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "reinhardt-admin"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6056,7 +6056,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-apps"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6088,7 +6088,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-auth"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "argon2",
  "async-trait",
@@ -6134,7 +6134,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-auth-macros"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6423,7 +6423,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-commands"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "async-trait",
  "cargo_metadata",
@@ -6480,7 +6480,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-conf"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -6508,7 +6508,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-core"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "anyhow",
  "aquamarine 0.6.0",
@@ -6556,7 +6556,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-db"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -6611,7 +6611,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-di"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -6634,7 +6634,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-di-macros"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6645,7 +6645,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-forms"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "anyhow",
  "aquamarine 0.5.0",
@@ -6662,7 +6662,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-http"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6683,7 +6683,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-macros"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "ctor 0.8.0",
  "inventory",
@@ -6697,7 +6697,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-mail"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6718,7 +6718,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-manouche"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "aquamarine 0.6.0",
  "convert_case",
@@ -6731,7 +6731,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-middleware"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6767,7 +6767,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-openapi"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "async-trait",
  "reinhardt-http",
@@ -6779,7 +6779,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-openapi-macros"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6790,7 +6790,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-pages"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "aquamarine 0.5.0",
  "async-trait",
@@ -6831,7 +6831,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-pages-ast"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "aquamarine 0.6.0",
  "convert_case",
@@ -6845,7 +6845,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-pages-macros"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "convert_case",
  "darling 0.20.11",
@@ -6859,7 +6859,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-query"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -6873,7 +6873,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-query-macros"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -6884,7 +6884,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-rest"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6935,12 +6935,12 @@ dependencies = [
 [[package]]
 name = "reinhardt-router"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 
 [[package]]
 name = "reinhardt-routers-macros"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6950,7 +6950,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-server"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6969,7 +6969,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-shortcuts"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "bytes",
  "hyper",
@@ -6987,7 +6987,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-test"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "cfg_aliases",
  "reinhardt-auth",
@@ -7007,7 +7007,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-testkit"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "async-dropper",
  "async-trait",
@@ -7063,7 +7063,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-testkit-macros"
 version = "0.1.0-rc.28"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7073,7 +7073,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-throttling"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -7084,7 +7084,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-urls"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -7119,7 +7119,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-utils"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7157,7 +7157,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-views"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7193,7 +7193,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-web"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7235,7 +7235,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-websockets"
 version = "0.1.0-rc.29"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#80a8f3451031b8efe975992c9e4e5427a6f7c999"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7585,7 +7585,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7668,7 +7668,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8669,7 +8669,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10004,7 +10004,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1340,7 +1340,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1936,7 +1936,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2198,7 +2198,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4209,7 +4209,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5565,7 +5565,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6004,8 +6004,8 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reinhardt-admin"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6055,13 +6055,14 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-apps"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "anyhow",
  "async-trait",
  "brotli",
  "bytes",
+ "cfg_aliases",
  "chrono",
  "flate2",
  "futures",
@@ -6086,8 +6087,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-auth"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "argon2",
  "async-trait",
@@ -6132,8 +6133,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-auth-macros"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6421,8 +6422,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-commands"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "async-trait",
  "cargo_metadata",
@@ -6478,8 +6479,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-conf"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -6506,8 +6507,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-core"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "anyhow",
  "aquamarine 0.6.0",
@@ -6554,8 +6555,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-db"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -6609,8 +6610,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-di"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -6632,8 +6633,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-di-macros"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6643,8 +6644,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-forms"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "anyhow",
  "aquamarine 0.5.0",
@@ -6660,8 +6661,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-http"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6681,8 +6682,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-macros"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "ctor 0.8.0",
  "inventory",
@@ -6695,8 +6696,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-mail"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6716,8 +6717,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-manouche"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "aquamarine 0.6.0",
  "convert_case",
@@ -6729,8 +6730,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-middleware"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6765,8 +6766,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-openapi"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "async-trait",
  "reinhardt-http",
@@ -6777,8 +6778,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-openapi-macros"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6788,8 +6789,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-pages"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "aquamarine 0.5.0",
  "async-trait",
@@ -6829,8 +6830,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-pages-ast"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "aquamarine 0.6.0",
  "convert_case",
@@ -6843,8 +6844,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-pages-macros"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "convert_case",
  "darling 0.20.11",
@@ -6857,8 +6858,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-query"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -6871,8 +6872,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-query-macros"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -6882,8 +6883,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-rest"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6906,11 +6907,13 @@ dependencies = [
  "quick-xml",
  "regex",
  "reinhardt-auth",
+ "reinhardt-conf",
  "reinhardt-core",
  "reinhardt-db",
  "reinhardt-http",
  "reinhardt-openapi-macros",
  "reinhardt-query",
+ "reinhardt-router",
  "reinhardt-throttling",
  "serde",
  "serde_json",
@@ -6930,9 +6933,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "reinhardt-router"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+
+[[package]]
 name = "reinhardt-routers-macros"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6941,8 +6949,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-server"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6960,8 +6968,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-shortcuts"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "bytes",
  "hyper",
@@ -6978,8 +6986,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-test"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "cfg_aliases",
  "reinhardt-auth",
@@ -6998,8 +7006,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-testkit"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "async-dropper",
  "async-trait",
@@ -7028,6 +7036,7 @@ dependencies = [
  "reinhardt-middleware",
  "reinhardt-query",
  "reinhardt-server",
+ "reinhardt-testkit-macros",
  "reinhardt-urls",
  "reinhardt-utils",
  "reinhardt-views",
@@ -7052,9 +7061,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "reinhardt-testkit-macros"
+version = "0.1.0-rc.28"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "reinhardt-throttling"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -7064,8 +7083,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-urls"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -7084,6 +7103,7 @@ dependencies = [
  "reinhardt-di",
  "reinhardt-http",
  "reinhardt-middleware",
+ "reinhardt-router",
  "reinhardt-routers-macros",
  "reinhardt-views",
  "serde",
@@ -7098,8 +7118,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-utils"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7136,8 +7156,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-views"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7172,8 +7192,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-web"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7214,8 +7234,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-websockets"
-version = "0.1.0-rc.26"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=main#864e3b2532b8b803d31759d9c4c6e44e43de681b"
+version = "0.1.0-rc.29"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=main#73548faffb04cd4ad14c260ecbbbb6fc00394fcd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7565,7 +7585,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7648,7 +7668,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8649,7 +8669,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9984,7 +10004,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c23f3af104b40a3430ccb90ed5f7bd877a8dc5c26fc92fde51a22b40890dcf9"
+checksum = "cb50a7aae84a03bf55b067832bc376f4961b790c97e64d3eacee97d389b90277"
 dependencies = [
  "filetime",
  "futures-core",
@@ -1340,7 +1340,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2198,7 +2198,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3055,7 +3055,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -3780,9 +3780,9 @@ checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "lettre"
-version = "0.11.21"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabda5859ee7c06b995b9d1165aa52c39110e079ef609db97178d86aeb051fa7"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5525,7 +5525,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5563,9 +5563,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7585,7 +7585,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7668,7 +7668,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8669,7 +8669,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10004,7 +10004,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/dashboard/src/client.rs
+++ b/dashboard/src/client.rs
@@ -31,55 +31,12 @@ pub mod router;
 // `kent8192/reinhardt-cloud#574`.
 #[cfg(all(wasm, not(feature = "wasm-spa-test")))]
 mod wasm_entry {
-	use std::collections::HashMap;
-
 	use wasm_bindgen::prelude::*;
 
 	use reinhardt::pages::{ClientLauncher, PathCtx};
-	use reinhardt::{ClientUrlReverser, register_client_reverser};
 
 	use super::router;
 	use crate::shared::client::{components, state, ws};
-
-	// WORKAROUND for kent8192/reinhardt-web#4230 (tracked in
-	// kent8192/reinhardt-cloud#577).
-	//
-	// The native side wires the SPA URL reverser through
-	// `crate::config::urls::make_router`'s
-	// `register_client_reverser(unified.client_ref().to_reverser())`.
-	// On the WASM target the `#[routes]` macro at upstream `f0dd166c`
-	// emits only the consumer (`__url_resolver_support::ResolvedUrls`),
-	// not the registrar — so without this manual call the first WASM
-	// render of `dashboard_shell` (and `not_found_page`) panics at
-	// `ResolvedUrls::from_global()` with "Global client reverser not
-	// registered. Ensure the #[routes] function has been called."
-	// Refs `kent8192/reinhardt-cloud#574`, upstream
-	// `kent8192/reinhardt-web#4221` (7th SPA navigation regression).
-	//
-	// The workaround is this helper plus the `SPA_ROUTE_PATTERNS` const
-	// in `client/router.rs`; both consume the same slice so drift is
-	// impossible. See the full WORKAROUND block in `client/router.rs`
-	// for the upstream-resolved ideal form using
-	// `UnifiedRouter::new().client(|c| ...).register_globally()`.
-	//
-	// Status (verified at reinhardt-web SHA 32a244e92d, 2026-05-10):
-	// removal is now blocked on `kent8192/reinhardt-web#4258` (a
-	// regression introduced by reinhardt-web#4242 that broke `ClientRouter`
-	// `Send + Sync` on native) rather than on the original
-	// `kent8192/reinhardt-web#4230`. Tracking on cloud:
-	// `kent8192/reinhardt-cloud#600`.
-	//
-	// Remove this helper and the `register_client_url_reverser()` call
-	// in `main` once `kent8192/reinhardt-web#4258` ships AND the cloud
-	// bumps past the merge of that fix together with reinhardt-web#4242.
-	//
-	// Ideal implementation (without workaround):
-	//   /* removed entirely; reverser is registered automatically by */
-	//   /* `UnifiedRouter::register_globally()` in `init_router`. */
-	fn register_client_url_reverser() {
-		let patterns: HashMap<String, String> = router::spa_route_pattern_pairs().collect();
-		register_client_reverser(ClientUrlReverser::new(patterns));
-	}
 
 	/// WASM entry point — invoked automatically when the module loads.
 	#[wasm_bindgen(start)]
@@ -88,18 +45,17 @@ mod wasm_entry {
 		// is enabled; calling set_once twice is harmless.
 		console_error_panic_hook::set_once();
 
-		// Must run before `dashboard_shell` (the layout for `/`) renders,
-		// because the layout calls `ResolvedUrls::from_global()` which
-		// panics if the reverser is unset. Refs #574.
-		register_client_url_reverser();
-
 		// Delegate router init, history listener, DOM mount, SPA link
 		// interception, and re-mount on navigate to ClientLauncher.
+		// `router_client` consumes `init_router`'s `ClientRouter` (built
+		// via `UnifiedRouter::register_globally()`), which also installs
+		// the `ClientUrlReverser` consumed by `ResolvedUrls::from_global()`
+		// — no separate reverser registration is needed.
 		// Path-driven side effects (toast container + notifications WS)
 		// run through `on_path` so they re-fire on every entry to "/".
 		ClientLauncher::new("#app")
 			.before_launch(state::init_app_state)
-			.router(router::init_router)
+			.router_client(router::init_router)
 			.on_path("/", |ctx: &PathCtx<'_>| {
 				ctx.ensure_portal("toast-container", components::toast::toast_container);
 				ws::connect_notifications();

--- a/dashboard/src/client/router.rs
+++ b/dashboard/src/client/router.rs
@@ -1,8 +1,8 @@
 //! SPA router configuration for the Reinhardt Cloud WASM client.
 //!
 //! Routes are declared as a pure function returning a
-//! [`reinhardt::urls::routers::ClientRouter`] built through
-//! [`reinhardt::urls::routers::UnifiedRouter`]. Calling
+//! [`reinhardt::urls::prelude::ClientRouter`] built through
+//! [`reinhardt::urls::prelude::UnifiedRouter`]. Calling
 //! [`UnifiedRouter::register_globally`] installs the server router
 //! (empty here — server-side routes live in `crate::config::urls`) and
 //! the `ClientUrlReverser` in one step, so callers of `url_for(name)`
@@ -28,7 +28,7 @@
 //! `apps/<app>/client/pages/list.rs` so the SPA pages can be filled in
 //! per app without further refactoring of this file.
 
-use reinhardt::urls::routers::{ClientRouter, UnifiedRouter};
+use reinhardt::urls::prelude::{ClientRouter, UnifiedRouter};
 
 use crate::apps::auth::client::pages::{login_page, register_page};
 use crate::apps::clusters::client::pages::clusters_list_page;

--- a/dashboard/src/client/router.rs
+++ b/dashboard/src/client/router.rs
@@ -1,13 +1,20 @@
 //! SPA router configuration for the Reinhardt Cloud WASM client.
 //!
-//! Routes are declared as a pure function returning a `Router`. Global
-//! access at runtime is provided by `reinhardt::pages::with_router`,
+//! Routes are declared as a pure function returning a
+//! [`reinhardt::urls::routers::ClientRouter`] built through
+//! [`reinhardt::urls::routers::UnifiedRouter`]. Calling
+//! [`UnifiedRouter::register_globally`] installs the server router
+//! (empty here — server-side routes live in `crate::config::urls`) and
+//! the `ClientUrlReverser` in one step, so callers of `url_for(name)`
+//! on either side can resolve every `named_route` declared below.
+//!
+//! Global access at runtime is provided by `reinhardt::pages::with_router`,
 //! which is installed by `ClientLauncher::launch()`. This module no
 //! longer owns a thread-local instance.
 //!
 //! # Route names
 //!
-//! Every SPA route is registered via [`Router::named_route`] so that
+//! Every SPA route is registered via [`ClientRouter::named_route`] so that
 //! the typed `crate::config::urls::ResolvedUrls` accessor can resolve
 //! `href` and `redirect_on_success` values. Names follow the
 //! `<app>:<name>` namespace convention used by server-side view macros.
@@ -20,16 +27,8 @@
 //! handlers live with each app under
 //! `apps/<app>/client/pages/list.rs` so the SPA pages can be filled in
 //! per app without further refactoring of this file.
-//!
-//! # Native parallel registration
-//!
-//! Server-side reverse URL resolution is registered via
-//! `UnifiedRouter::client(...)` in `crate::config::urls::make_router`,
-//! which calls `register_client_reverser` so server-side callers of
-//! `url_for` can reverse names. Every `named_route` call below MUST
-//! appear there with the same `(name, pattern)` pair.
 
-use reinhardt::pages::router::Router;
+use reinhardt::urls::routers::{ClientRouter, UnifiedRouter};
 
 use crate::apps::auth::client::pages::{login_page, register_page};
 use crate::apps::clusters::client::pages::clusters_list_page;
@@ -37,124 +36,21 @@ use crate::apps::dashboard::client::layout::dashboard_shell;
 use crate::apps::deployments::client::pages::deployments_list_page;
 use crate::shared::client::pages::not_found::not_found_page;
 
-// ──────────────────────────────────────────────────────────────────────
-// WORKAROUND for kent8192/reinhardt-web#4230 (tracked in
-// kent8192/reinhardt-cloud#577).
-//
-// The framework currently splits SPA routing into two parallel concrete
-// types — `reinhardt::pages::router::Router` (consumed by
-// `ClientLauncher::router(...)`, with reactive observation fields) and
-// `reinhardt::urls::ClientRouter` (returned by `UnifiedRouter::client(...)`,
-// without observation). There is no `From<ClientRouter>` impl, so
-// `UnifiedRouter::register_globally()` cannot feed `ClientLauncher`. The
-// `#[routes]` macro at `f0dd166c` further only emits
-// `register_client_reverser` on the native target, leaving the WASM client
-// to register the reverser by hand. This forces this crate to maintain a
-// **parallel route table**: once for the SPA's `pages::Router`
-// (`init_router` below) and once for the URL reverser
-// (`client::wasm_entry::register_client_url_reverser` in `client.rs`).
-// Drift between the two re-introduces the `Global client reverser not
-// registered` panic that #574 chased through 7 iterations of
-// `kent8192/reinhardt-web#4221`.
-//
-// The workaround is the `SPA_ROUTE_PATTERNS` const + handler-dispatch
-// `init_router` in this file plus the `register_client_url_reverser`
-// helper in `client.rs::wasm_entry`. Both consume the same const slice
-// so drift is impossible while the workaround is in place.
-//
-// Status (verified at reinhardt-web SHA 32a244e92d, 2026-05-10):
-//   - Upstream PR reinhardt-web#4242 (closed reinhardt-web#4234) added
-//     `ClientLauncher::router_client` and made
-//     `UnifiedRouter::register_globally()` install the WASM-side
-//     `ClientUrlReverser` automatically — addressing #4230.
-//   - However, the same PR moved `pages::Router`'s reactive state
-//     (`Rc<Cell<u64>>`, `Rc<RefCell<Vec<Weak<dyn Fn>>>>`) into
-//     `urls::ClientRouter` *without* `#[cfg(wasm)]` gating, so the
-//     unified router is no longer `Send + Sync` on native. This breaks
-//     `DashboardRouter(pub UnifiedRouter)`'s DI registration in
-//     `crate::config::urls::make_router` (35 compile errors of the form
-//     "Rc<Cell<u64>> cannot be sent between threads safely").
-//   - Filed upstream as `kent8192/reinhardt-web#4258`; tracked in
-//     `kent8192/reinhardt-cloud#600` (`upstream-tracking`).
-//
-// Remove this workaround once `kent8192/reinhardt-web#4258` ships AND
-// the cloud bumps to a revision that includes both the #4258 fix and
-// the #4242 `ClientLauncher::router_client` API. The patch set is
-// staged on the worktree branch
-// `refactor/issue-577-unified-router-spa-32a244e9` (see #600 comments).
-//
-// Ideal implementation (without workaround):
-//   use reinhardt::urls::routers::{ClientRouter, UnifiedRouter};
-//
-//   pub fn init_router() -> ClientRouter {
-//       UnifiedRouter::new()
-//           .client(|c| {
-//               c.named_route("dashboard:home", "/", dashboard_shell)
-//                   .named_route("auth:login_page", "/login", login_page)
-//                   .named_route("auth:register_page", "/register", register_page)
-//                   .named_route("clusters:list", "/clusters", clusters_list_page)
-//                   .named_route("deployments:list", "/deployments", deployments_list_page)
-//                   .not_found(not_found_page)
-//           })
-//           .register_globally()
-//   }
-//
-// Caller in `client.rs::wasm_entry::main` becomes:
-//   ClientLauncher::new("#app")
-//       .router_client(router::init_router)
-//       .launch()?;
-//
-// `client.rs::wasm_entry::register_client_url_reverser` and the const
-// slice / `spa_route_pattern_pairs` helper below all disappear.
-// ──────────────────────────────────────────────────────────────────────
-
-/// Single source of truth for the SPA's `(name, pattern)` table.
+/// Build the SPA router and register the client URL reverser globally.
 ///
-/// Consumed by [`init_router`] (to build `pages::Router` via
-/// `named_route`) and [`spa_route_pattern_pairs`] (to feed
-/// `ClientUrlReverser` registration from `client::wasm_entry::main`).
-/// See the WORKAROUND block above for why this duplication is necessary
-/// today and the ideal `UnifiedRouter::register_globally()` form that
-/// replaces it after `kent8192/reinhardt-web#4230` lands.
-pub(crate) const SPA_ROUTE_PATTERNS: &[(&str, &str)] = &[
-	("dashboard:home", "/"),
-	("auth:login_page", "/login"),
-	("auth:register_page", "/register"),
-	("clusters:list", "/clusters"),
-	("deployments:list", "/deployments"),
-];
-
-/// Iterator-friendly view onto [`SPA_ROUTE_PATTERNS`] used by callers that
-/// need owned `String` pairs (e.g. `ClientUrlReverser::new(HashMap<...>)`).
-pub(crate) fn spa_route_pattern_pairs() -> impl Iterator<Item = (String, String)> + 'static {
-	SPA_ROUTE_PATTERNS
-		.iter()
-		.map(|(name, pattern)| ((*name).to_string(), (*pattern).to_string()))
-}
-
-/// Build the router with all application routes.
-///
-/// Passed to `ClientLauncher::router(init_router)` from `client.rs`.
-/// Routes are wired from [`SPA_ROUTE_PATTERNS`] so the table cannot
-/// drift from `client::wasm_entry`'s reverser registration (#574).
-pub fn init_router() -> Router {
-	// Each `(name, pattern)` in `SPA_ROUTE_PATTERNS` maps to a handler
-	// here. Keep the match arms in lock-step with the const slice —
-	// adding an entry to the slice without an arm here will produce a
-	// compile error from the exhaustive `match`.
-	let mut router = Router::new();
-	for (name, pattern) in SPA_ROUTE_PATTERNS {
-		router = match *name {
-			"dashboard:home" => router.named_route(name, pattern, dashboard_shell),
-			"auth:login_page" => router.named_route(name, pattern, login_page),
-			"auth:register_page" => router.named_route(name, pattern, register_page),
-			"clusters:list" => router.named_route(name, pattern, clusters_list_page),
-			"deployments:list" => router.named_route(name, pattern, deployments_list_page),
-			other => panic!(
-				"client/router.rs: SPA_ROUTE_PATTERNS entry '{other}' has no \
-				 matching handler in init_router(); add an arm or remove the entry"
-			),
-		};
-	}
-	router.not_found(not_found_page)
+/// Passed to `ClientLauncher::router_client(init_router)` from
+/// `client.rs`. The returned [`ClientRouter`] carries the named-route
+/// table that drives both SPA navigation and `ResolvedUrls`-backed
+/// reverse URL lookup on the WASM client.
+pub fn init_router() -> ClientRouter {
+	UnifiedRouter::new()
+		.client(|c| {
+			c.named_route("dashboard:home", "/", dashboard_shell)
+				.named_route("auth:login_page", "/login", login_page)
+				.named_route("auth:register_page", "/register", register_page)
+				.named_route("clusters:list", "/clusters", clusters_list_page)
+				.named_route("deployments:list", "/deployments", deployments_list_page)
+				.not_found(not_found_page)
+		})
+		.register_globally()
 }

--- a/dashboard/src/client/router.rs
+++ b/dashboard/src/client/router.rs
@@ -1,9 +1,10 @@
 //! SPA router configuration for the Reinhardt Cloud WASM client.
 //!
-//! Routes are declared as a pure function returning a
-//! [`reinhardt::urls::prelude::ClientRouter`] built through
-//! [`reinhardt::urls::prelude::UnifiedRouter`]. Calling
-//! [`UnifiedRouter::register_globally`] installs the server router
+//! Routes are declared in [`init_router`], which builds a
+//! [`reinhardt::urls::prelude::ClientRouter`] through
+//! [`reinhardt::urls::prelude::UnifiedRouter`] and installs it globally
+//! as a side effect. The terminating
+//! [`UnifiedRouter::register_globally`] call installs the server router
 //! (empty here — server-side routes live in `crate::config::urls`) and
 //! the `ClientUrlReverser` in one step, so callers of `url_for(name)`
 //! on either side can resolve every `named_route` declared below.

--- a/dashboard/tests/wasm/test_spa_navigation_smoke.rs
+++ b/dashboard/tests/wasm/test_spa_navigation_smoke.rs
@@ -17,10 +17,8 @@
 
 use js_sys::Reflect;
 use reinhardt::pages::ClientLauncher;
-use reinhardt::{ClientUrlReverser, register_client_reverser};
 use reinhardt_cloud_dashboard::client::router::init_router;
 use reinhardt_cloud_dashboard::shared::client::state;
-use std::collections::HashMap;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::JsValue;
 use wasm_bindgen_test::*;
@@ -40,36 +38,16 @@ fn ensure_mount_point(document: &web_sys::Document, body: &web_sys::HtmlElement)
 	body.append_child(&app_div).expect("append #app to body");
 }
 
-/// Register the SPA route names that the dashboard's `dashboard_shell`
-/// layout needs to resolve via `ResolvedUrls`. In production WASM this
-/// is wired up by the `#[routes]` macro through `UnifiedRouter::client(...)`
-/// (which calls `register_client_reverser` internally). The test bypasses
-/// that path because it never instantiates a `UnifiedRouter`, so we
-/// register a hand-built reverser that mirrors the route table from
-/// `dashboard/src/client/router.rs`. Refs #574.
-///
-/// Keep these patterns in sync with `init_router()`'s `named_route`
-/// calls — drift would cause the panic the test is here to prevent.
-fn register_dashboard_url_reverser() {
-	let patterns = HashMap::from([
-		("dashboard:home".to_string(), "/".to_string()),
-		("auth:login_page".to_string(), "/login".to_string()),
-		("auth:register_page".to_string(), "/register".to_string()),
-		("clusters:list".to_string(), "/clusters".to_string()),
-		("deployments:list".to_string(), "/deployments".to_string()),
-	]);
-	register_client_reverser(ClientUrlReverser::new(patterns));
-}
-
 /// Launch the dashboard's client just like `dashboard/src/client.rs`
 /// does in production, minus the `on_path` hooks that depend on a live
 /// notifications WebSocket. Reuses the same `init_router()` so route
-/// names and patterns match the production topology byte-for-byte.
+/// names and patterns match the production topology byte-for-byte —
+/// `UnifiedRouter::register_globally()` inside `init_router` installs
+/// the `ClientUrlReverser` that `ResolvedUrls::from_global()` consumes.
 fn launch_dashboard_for_test() {
-	register_dashboard_url_reverser();
 	state::init_app_state();
 	ClientLauncher::new("#app")
-		.router(init_router)
+		.router_client(init_router)
 		.launch()
 		.expect("ClientLauncher::launch must succeed");
 }

--- a/dashboard/tests/wasm/test_spa_navigation_smoke.rs
+++ b/dashboard/tests/wasm/test_spa_navigation_smoke.rs
@@ -40,13 +40,14 @@ fn ensure_mount_point(document: &web_sys::Document, body: &web_sys::HtmlElement)
 
 /// Launch the dashboard's client just like `dashboard/src/client.rs`
 /// does in production, minus the `on_path` hooks that depend on a live
-/// notifications WebSocket. Reuses the same `init_router()` so route
-/// names and patterns match the production topology byte-for-byte —
+/// notifications WebSocket. Reuses the same `init_router()` and the same
+/// `before_launch(state::init_app_state)` hook so route names, patterns,
+/// and launcher topology match production byte-for-byte —
 /// `UnifiedRouter::register_globally()` inside `init_router` installs
 /// the `ClientUrlReverser` that `ResolvedUrls::from_global()` consumes.
 fn launch_dashboard_for_test() {
-	state::init_app_state();
 	ClientLauncher::new("#app")
+		.before_launch(state::init_app_state)
 		.router_client(init_router)
 		.launch()
 		.expect("ClientLauncher::launch must succeed");


### PR DESCRIPTION
## Summary

Stacks on top of #609 (rc.28 → rc.29 bump + SPA workaround removal) and incrementally bumps the `reinhardt-web` git dep to the current `main` tip ([\`80a8f345\`](https://github.com/kent8192/reinhardt-web/commit/80a8f3451031b8efe975992c9e4e5427a6f7c999)), picking up nine additional PRs merged between rc.29 (\`73548faf\`) and today.

**Incremental contribution: Cargo.lock only — no _new_ functional code changes in this PR.** The follow-up PR ([#612](https://github.com/kent8192/reinhardt-cloud/pull/612) — stacked on top of this one) actually consumes the new APIs.

> ⚠️ Diff-page note for reviewers: because the PR base is `main` and this branch sits on top of #609, GitHub's diff currently shows the functional rows inherited from #609 (`dashboard/src/client.rs`, `dashboard/src/client/router.rs`, `dashboard/tests/wasm/test_spa_navigation_smoke.rs`). Those rows will disappear once #609 merges into `main`; this PR's incremental contribution is just the two `chore(deps): bump …` commits at the tip plus the matching Cargo.lock delta.

## Type of Change

- [x] Dependency update

## Motivation and Context

reinhardt-web has been moving fast. Nine PRs merged in the five days between rc.29 and today's tip include several that directly improve the dashboard's surface:

- reinhardt-web#4623 — **public \`pages::navigate\` / \`use_router\` API** for imperative SPA navigation outside reactive contexts. Form! macro's \`redirect_on_success:\` now SPA-navigates first and falls back to \`set_href\` only on \`RouterNotInstalled\`. Consumed by #612.
- reinhardt-web#4625 / #4627 — \`on_success:\` and \`on_success_ref:\` outer-scope capture for form! macro callbacks.
- reinhardt-web#4655 — **typed \`urls::*\` helpers** generated from \`#[url_patterns]\` (compile-time-safe replacement for stringly-typed \`ResolvedUrls::resolve_client_url\`). Likely a follow-up adoption PR.
- reinhardt-web#4658 — example refactor showing the new typed helper adoption pattern.
- reinhardt-web#4669 — \`page!\` macro accepts dynamic \`img { src: ... }\` and restores \`reinhardt-urls\` facade re-export for wasm32 builds.
- reinhardt-web#4647 — DI scope attribute syntax docs (\`#[scope(...)]\` → \`(scope = \"...\")\`).
- reinhardt-web#4626 — stability policy consolidation; drops the 0.x exception (signal that rc.30+ tightens breaking-change discipline).
- reinhardt-web#4636 — perf: cache empty \`ClientUrlReverser\` fallback via OnceLock.

## How Was This Tested?

Verified against this branch's commit on the same worktree:

- \`cargo check -p reinhardt-cloud-dashboard --all-features\` → clean (1m 07s).
- \`cargo check -p reinhardt-cloud-dashboard --target wasm32-unknown-unknown --no-default-features --features client-router\` → clean (1m 17s).
- \`cargo nextest run -p reinhardt-cloud-dashboard --all-features --filterset 'test(apps::auth::tests::e2e) or test(dashboard::e2e)'\` → **21/21 pass** (the same e2e battery that regressed on rc.28 / cloud#608 and was unblocked on rc.29 stays green at 80a8f345).
- \`cargo make wasm-spa-test\` (headless Chrome via wasm-pack) → \`test_spa_navigation_smoke::link_click_advances_history_state_as_object\` ok (verifies the shared \`RouterHandle::navigate\` backend that the new \`pages::navigate\` API dispatches through).

## Breaking Changes

None. This is a pure dependency-bump; no Reinhardt Cloud public API surface changes.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly (no doc updates needed — Cargo.lock only)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with \`cargo make fmt-fix\` (no source changes)
- [x] I have checked the code with \`cargo make clippy-check\` (no source changes)

## Related PRs / Issues

- Base: #609 (closes #608, #600, #607 — must merge first; this PR will rebase cleanly once that happens since it carries a strict superset of the dependency state)
- Enabled by: reinhardt-web#4623 (new \`pages::navigate\` API used in stacked #612)

## Labels to Apply

- \`dependencies\`
- \`dashboard\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Routing initialization now registers client routes globally and handles URL reversal automatically.
  * Removed the prior manual URL-reverser workaround and parallel route table.
  * Named SPA routes are declared as part of the unified client router.

* **Tests**
  * Test harness updated to launch the client with the unified router so route resolution matches production.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-cloud/pull/610?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
