### PR TITLE
refactor(dashboard/auth): SPA-navigate to dashboard on login/register success

### DIFF
--- a/dashboard/src/apps/auth/client/pages/login.rs
+++ b/dashboard/src/apps/auth/client/pages/login.rs
@@ -34,13 +34,19 @@ pub fn login_page() -> Page {
 				});
 			}
 
-			// Redirect to the dashboard via the SPA URL resolver. Mirrors
-			// the hard reload that `redirect_on_success` would emit so the
-			// new session cookie is reloaded server-side.
-			if let Some(window) = web_sys::window() {
-				let _ = window
-					.location()
-					.set_href(&ResolvedUrls::from_global().client().dashboard().home());
+			// SPA-navigate to the dashboard via the upstream `pages::navigate`
+			// (reinhardt-web#4623). The browser stores the `Set-Cookie` from
+			// the login response before this callback fires, so subsequent
+			// server_fn calls from the dashboard pick up the new session
+			// without a full page reload. Falls back to `location.set_href`
+			// when no SPA router is installed (e.g. during SSR rehearsal).
+			let home_url = ResolvedUrls::from_global().client().dashboard().home();
+			if let Err(reinhardt::pages::NavigateError::RouterNotInstalled) =
+				reinhardt::pages::navigate(home_url.clone(), reinhardt::pages::NavigationType::Push)
+			{
+				if let Some(window) = web_sys::window() {
+					let _ = window.location().set_href(&home_url);
+				}
 			}
 		},
 		fields: {

--- a/dashboard/src/apps/auth/client/pages/register.rs
+++ b/dashboard/src/apps/auth/client/pages/register.rs
@@ -34,13 +34,19 @@ pub fn register_page() -> Page {
 				});
 			}
 
-			// Redirect to the dashboard via the SPA URL resolver. Mirrors
-			// the hard reload that `redirect_on_success` would emit so the
-			// new session cookie is reloaded server-side.
-			if let Some(window) = web_sys::window() {
-				let _ = window
-					.location()
-					.set_href(&ResolvedUrls::from_global().client().dashboard().home());
+			// SPA-navigate to the dashboard via the upstream `pages::navigate`
+			// (reinhardt-web#4623). The browser stores the `Set-Cookie` from
+			// the register response before this callback fires, so subsequent
+			// server_fn calls from the dashboard pick up the new session
+			// without a full page reload. Falls back to `location.set_href`
+			// when no SPA router is installed (e.g. during SSR rehearsal).
+			let home_url = ResolvedUrls::from_global().client().dashboard().home();
+			if let Err(reinhardt::pages::NavigateError::RouterNotInstalled) =
+				reinhardt::pages::navigate(home_url.clone(), reinhardt::pages::NavigationType::Push)
+			{
+				if let Some(window) = web_sys::window() {
+					let _ = window.location().set_href(&home_url);
+				}
 			}
 		},
 		fields: {


### PR DESCRIPTION
## Summary

Replaces the \`window.location.set_href(...)\` hard reload in the login and register \`on_success:\` handlers with \`reinhardt::pages::navigate(url, NavigationType::Push)\` per the public imperative SPA navigation API introduced in reinhardt-web#4623.

Stacked on top of #610 (which bumps to the SHA that exposes \`pages::navigate\`). #610 → main must merge first.

## Type of Change

- [x] Refactoring (code change that neither fixes a bug nor adds a feature)

## Motivation and Context

The comment claiming \`set_href\` *"mirrors the hard reload that \`redirect_on_success\` would emit"* was written when \`redirect_on_success:\` did in fact emit a hard reload. Post-#4623 that is no longer true — the form! macro's \`redirect_on_success:\` codegen now emits:

\`\`\`rust
if #pages_crate::navigate(__url, NavigationType::Push).is_err() {
    if let Some(__window) = ::web_sys::window() {
        let _ = __window.location().set_href(__url);
    }
}
\`\`\`

i.e. SPA-navigate-first with \`set_href\` as the no-router fallback. This PR adopts the same pattern in the cloud dashboard's manual \`on_success:\` handlers, dropping:

- the unconditional document reload (faster perceived UX, no flash, no idle network),
- the wasted \`auth_state().update(...)\` write the reload would otherwise discard.

**Cookie semantics are unchanged** — the browser stores the \`Set-Cookie\` from the login/register server_fn response before the callback fires, so subsequent server_fn calls from the dashboard pick up the new session without needing a full page reload. This is the same response → callback ordering that \`redirect_on_success:\` relies on upstream.

## How Was This Tested?

Same matrix as #610, plus the navigate call site itself in \`login.rs\` / \`register.rs\`:

- \`cargo check -p reinhardt-cloud-dashboard --all-features\` → clean.
- \`cargo check -p reinhardt-cloud-dashboard --target wasm32-unknown-unknown --no-default-features --features client-router\` → clean.
- \`cargo nextest run -p reinhardt-cloud-dashboard --all-features --filterset 'test(apps::auth::tests::e2e)'\` → 21/21 pass (server-side login/register flow regression-free).
- \`cargo make wasm-spa-test\` → \`test_spa_navigation_smoke::link_click_advances_history_state_as_object\` ok (verifies the shared \`RouterHandle::navigate\` backend the new \`pages::navigate\` calls dispatch through).

## Breaking Changes

None. \`reinhardt::pages::navigate\` returns \`Result<(), NavigateError>\`; the call sites destructure for \`Err(NavigateError::RouterNotInstalled)\` and fall back to \`set_href\` for that branch only — preserving the pre-#4623 behavior on environments without an SPA router (e.g. SSR rehearsal).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly (in-source comment refreshed to reflect post-#4623 reality)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (covered by existing e2e + WASM SPA smoke test)
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with \`cargo make fmt-fix\`
- [x] I have checked the code with \`cargo make clippy-check\`

## Related PRs / Issues

- Base: #610 (must merge first — adds the \`pages::navigate\` API this PR consumes)
- Enabled by: reinhardt-web#4623 (public \`pages::navigate\` / \`use_router\` API)

## Labels to Apply

- \`refactoring\`
- \`dashboard\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation reliability on the login page with enhanced fallback mechanisms to ensure users are consistently redirected to the dashboard.
  * Enhanced post-registration redirect flow with better fallback support for various routing scenarios.
  * Strengthened overall authentication redirect handling to provide a more reliable and consistent user experience across login and registration pages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-cloud/pull/611?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->