### PR TITLE
fix(grpc): pass di_context from RunserverContext to start_grpc_server

### DIFF
--- a/dashboard/src/config/grpc.rs
+++ b/dashboard/src/config/grpc.rs
@@ -6,7 +6,7 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use reinhardt::di::{ContextLevel, get_di_context};
+use reinhardt::di::InjectionContext;
 use reinhardt_cloud_core::mocks::MockBuildService;
 use reinhardt_cloud_grpc::config::GrpcServerConfig;
 use reinhardt_cloud_grpc::health;
@@ -33,8 +33,15 @@ async fn mark_service_healthy(health_reporter: &mut health::HealthReporter, serv
 ///
 /// Registers health check and reflection services. The server
 /// runs until the provided shutdown signal completes.
+///
+/// `di_context` must be the root `InjectionContext` resolved at runserver
+/// startup (typically `RunserverContext::di_context`). Using the caller-
+/// supplied context avoids relying on the task-local resolve scope, which
+/// is only set inside `#[injectable_factory]` / `#[injectable]` execution
+/// and is therefore absent in spawned runserver-hook tasks.
 pub async fn start_grpc_server(
 	config: GrpcServerConfig,
+	di_context: Arc<InjectionContext>,
 	shutdown: impl std::future::Future<Output = ()>,
 ) -> Result<(), tonic::transport::Error> {
 	let addr: SocketAddr = config
@@ -45,8 +52,7 @@ pub async fn start_grpc_server(
 	// Resolve the JWT secret once at startup so a missing
 	// `REINHARDT_CLOUD_JWT_SECRET` fails fast instead of letting
 	// agents connect to an unauthenticated server.
-	let di_ctx = get_di_context(ContextLevel::Root);
-	let jwt_secret = di_ctx
+	let jwt_secret = di_context
 		.resolve::<JwtSecret>()
 		.await
 		.expect("Cannot start gRPC server without REINHARDT_CLOUD_JWT_SECRET");

--- a/dashboard/src/config/hooks.rs
+++ b/dashboard/src/config/hooks.rs
@@ -61,9 +61,14 @@ impl RunserverHook for GrpcRunserverHook {
 	) -> Result<(), Box<dyn Error + Send + Sync>> {
 		let mut shutdown_rx = ctx.shutdown_coordinator.subscribe();
 		let grpc_config = GrpcServerConfig::default();
+		// `tokio::spawn` does not propagate task-local storage, so the
+		// gRPC startup task cannot rely on `get_di_context`. Capture the
+		// root DI context here and pass it explicitly into the spawned
+		// task instead.
+		let di_context = ctx.di_context.clone();
 
 		tokio::spawn(async move {
-			if let Err(e) = start_grpc_server(grpc_config, async move {
+			if let Err(e) = start_grpc_server(grpc_config, di_context, async move {
 				let _ = shutdown_rx.recv().await;
 			})
 			.await


### PR DESCRIPTION
## Summary

This PR addresses:

- Fixes a `cargo make runserver` panic where the gRPC startup task crashed with `cannot access a task-local storage value without setting it first`.
- Plumbs `RunserverContext::di_context` (`Arc<InjectionContext>`) explicitly from `GrpcRunserverHook` into `start_grpc_server` instead of relying on the DI resolve-time task-local.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

`dashboard/src/config/grpc.rs` was using `get_di_context(ContextLevel::Root).resolve::<JwtSecret>()` from inside a `tokio::spawn`-ed task launched by `GrpcRunserverHook::on_server_start`. `get_di_context` reads a `tokio::task_local!` (`RESOLVE_CTX`) that is only set inside `#[injectable_factory]` / `#[injectable]` execution by `InjectableFactory::create` (reinhardt-di `registry.rs:99-114`). Runserver hooks run outside any such scope, and `tokio::spawn` does not propagate task-locals, so every `cargo make runserver` on `main` panicked the gRPC worker as soon as it tried to resolve `JwtSecret`.

The bug was introduced by `04156cba6 refactor(dashboard/clusters): migrate callers to Depends-resolved AgentTokenService` (Refs #599). That commit message stated *"The gRPC server is started outside of a request handler, so it goes through `get_di_context` rather than `#[inject]`,"* but `get_di_context` itself requires the DI resolution scope, so the migration replaced the working free-fn path with an unreachable one.

`reinhardt-commands` already exposes the right entry point: `RunserverContext::di_context` (`reinhardt-commands/src/runserver_hooks.rs:64`) hands hooks an `Arc<InjectionContext>` precisely for this case. Using it both avoids the task-local trap and keeps the failure mode of a missing `REINHARDT_CLOUD_JWT_SECRET` (a deploy-time configuration error) at the same fail-fast point.

Fixes #614

## How Was This Tested?

- `cargo check --package reinhardt-cloud-dashboard` ✅
- `cargo clippy --package reinhardt-cloud-dashboard --all-targets --all-features -- -D warnings` ✅ (no warnings)
- `cargo nextest run --package reinhardt-cloud-dashboard --no-fail-fast` ✅ **545 passed / 545 total** (incl. e2e + integration)
- `cargo make runserver` (workspace root) inside the worktree:
  - panic gone — runserver reaches `🚀 Server: http://127.0.0.1:8002`
  - HTTP probe: `curl -sS -o /dev/null -w "%{http_code}" http://127.0.0.1:8002/api/docs` → `200`
  - gRPC probe: `nc -z 127.0.0.1 50051` → `succeeded` (gRPC server bound on the default port alongside HTTP)

## Performance Impact

None. The change is a one-line argument plumb plus one less task-local lookup.

## Breaking Changes

`pub async fn start_grpc_server` gains a `di_context: Arc<InjectionContext>` parameter (positional, between `config` and `shutdown`). Inside this crate it has exactly one caller (`GrpcRunserverHook`), which is updated in this PR. The function is not re-exported from `reinhardt_cloud_dashboard`, so there is no external API surface to migrate.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable) — `start_grpc_server` doc comment now explains why the caller-supplied context is required
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works — the existing dashboard test suite still passes; runtime verification is captured in "How Was This Tested?" above (a unit-level regression test for this path would require spinning up a runserver hook fixture, which is outside the scope of this bug fix)
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #614
- Refs #599 (the migration commit that introduced the regression)

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured gRPC server startup sequence to ensure JWT authentication credentials are validated during initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kent8192/reinhardt-cloud/pull/615?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->