### PR TITLE
docs: document dashboard-as-Reinhardt-app and config-to-deploy generation model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,10 @@ See README.md for project details.
 
 **Repository URL**: https://github.com/kent8192/reinhardt-cloud
 
+### Architecture Model
+
+The `dashboard/` crate is itself a **Reinhardt application** (built with the Reinhardt web framework). Reinhardt Cloud is the system that **reads the configuration of a Reinhardt-built application** — Cargo feature flags, `settings/*.toml`, and `manage introspect` output — and **automatically generates that application's deployment configuration files**: the `Dockerfile`, `reinhardt-cloud.toml`, the `ReinhardtApp` CRD manifest, and per-app Terraform HCL. The dashboard is therefore both a first-class application and the canonical dogfooding target of this configuration-to-deployment generation pipeline.
+
 ---
 
 ## Tech Stack

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,10 @@ See README.md for project details.
 
 **Repository URL**: https://github.com/kent8192/reinhardt-cloud
 
+### Architecture Model
+
+The `dashboard/` crate is itself a **Reinhardt application** (built with the Reinhardt web framework). Reinhardt Cloud is the system that **reads the configuration of a Reinhardt-built application** — Cargo feature flags, `settings/*.toml`, and `manage introspect` output — and **automatically generates that application's deployment configuration files**: the `Dockerfile`, `reinhardt-cloud.toml`, the `ReinhardtApp` CRD manifest, and per-app Terraform HCL. The dashboard is therefore both a first-class application and the canonical dogfooding target of this configuration-to-deployment generation pipeline.
+
 ---
 
 ## Tech Stack


### PR DESCRIPTION
## Summary

- Add an **Architecture Model** note to the Project Overview of `CLAUDE.md` and `AGENTS.md` (kept in sync per the mirror policy)
- States that the `dashboard/` crate is itself a Reinhardt application, and that Reinhardt Cloud reads a Reinhardt app's configuration (Cargo features, `settings/*.toml`, `manage introspect`) to auto-generate its deployment artifacts (`Dockerfile`, `reinhardt-cloud.toml`, `ReinhardtApp` CRD, per-app Terraform HCL)

## Type of Change

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Motivation and Context

The config-to-deployment generation model is the project's central value proposition but was not recorded in the agent instruction files. Documenting it gives future contributors (and agents) the correct lens for evaluating the dashboard's deployment path. Investigating this model also surfaced the generation-E2E gaps tracked in #620.

## How Was This Tested

- [x] `diff CLAUDE.md AGENTS.md` confirms only the documented mechanical substitutions differ (the new Architecture Model section is byte-identical in both files)
- Docs-only change; no code paths affected

## Checklist

- [x] My code follows the project style guidelines
- [x] `CLAUDE.md` and `AGENTS.md` edited in the same commit (sync policy)
- [x] Documentation updated
- [x] English-only content

## Labels to Apply

- `documentation`

## Related Issues

Refs #620

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated developer documentation to clarify the dashboard component's role in the configuration-to-deployment pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->