### PR TITLE
fix(deploy): preserve generated ReinhardtApp specs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6273,6 +6273,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "serde_yaml",
  "serial_test",
  "sha2 0.10.9",
  "subtle",

--- a/crates/reinhardt-cloud-cli/src/client.rs
+++ b/crates/reinhardt-cloud-cli/src/client.rs
@@ -77,7 +77,8 @@ impl ReinhardtCloudClient {
 	/// Deploys an application by sending JSON to the dashboard API.
 	///
 	/// The dashboard create-deployment endpoint expects a JSON body with
-	/// `app_name`, `image`, and optionally `cluster_id`.
+	/// `app_name`, `image`, optionally `cluster_id`, and optionally the
+	/// generated `ReinhardtApp` manifest YAML.
 	///
 	/// Returns the response body on success.
 	pub(crate) async fn deploy(
@@ -85,6 +86,7 @@ impl ReinhardtCloudClient {
 		app_name: &str,
 		image: &str,
 		cluster_id: Option<&str>,
+		reinhardt_app_yaml: Option<&str>,
 	) -> Result<String, ClientError> {
 		let mut payload = serde_json::json!({
 			"app_name": app_name,
@@ -92,6 +94,9 @@ impl ReinhardtCloudClient {
 		});
 		if let Some(cid) = cluster_id {
 			payload["cluster_id"] = serde_json::Value::String(cid.to_string());
+		}
+		if let Some(manifest) = reinhardt_app_yaml {
+			payload["reinhardt_app_yaml"] = serde_json::Value::String(manifest.to_string());
 		}
 
 		let response = self

--- a/crates/reinhardt-cloud-cli/src/client.rs
+++ b/crates/reinhardt-cloud-cli/src/client.rs
@@ -16,6 +16,9 @@ pub(crate) enum ClientError {
 
 	#[error("invalid URL: {0}")]
 	InvalidUrl(#[from] url::ParseError),
+
+	#[error("invalid cluster id '{value}': expected a positive 64-bit integer")]
+	InvalidClusterId { value: String },
 }
 
 /// REST API client for the Reinhardt Cloud platform.
@@ -88,16 +91,7 @@ impl ReinhardtCloudClient {
 		cluster_id: Option<&str>,
 		reinhardt_app_yaml: Option<&str>,
 	) -> Result<String, ClientError> {
-		let mut payload = serde_json::json!({
-			"app_name": app_name,
-			"image": image,
-		});
-		if let Some(cid) = cluster_id {
-			payload["cluster_id"] = serde_json::Value::String(cid.to_string());
-		}
-		if let Some(manifest) = reinhardt_app_yaml {
-			payload["reinhardt_app_yaml"] = serde_json::Value::String(manifest.to_string());
-		}
+		let payload = build_deploy_payload(app_name, image, cluster_id, reinhardt_app_yaml)?;
 
 		let response = self
 			.request(reqwest::Method::POST, "/api/deployments/")?
@@ -207,6 +201,33 @@ impl ReinhardtCloudClient {
 			})
 		}
 	}
+}
+
+fn build_deploy_payload(
+	app_name: &str,
+	image: &str,
+	cluster_id: Option<&str>,
+	reinhardt_app_yaml: Option<&str>,
+) -> Result<serde_json::Value, ClientError> {
+	let mut payload = serde_json::json!({
+		"app_name": app_name,
+		"image": image,
+	});
+	if let Some(cid) = cluster_id {
+		let parsed = cid
+			.parse::<i64>()
+			.ok()
+			.filter(|value| *value > 0)
+			.ok_or_else(|| ClientError::InvalidClusterId {
+				value: cid.to_string(),
+			})?;
+		payload["cluster_id"] = serde_json::json!(parsed);
+	}
+	if let Some(manifest) = reinhardt_app_yaml {
+		payload["reinhardt_app_yaml"] = serde_json::Value::String(manifest.to_string());
+	}
+
+	Ok(payload)
 }
 
 #[cfg(test)]
@@ -335,6 +356,39 @@ mod tests {
 		// Assert
 		assert_eq!(req.url().as_str(), "http://localhost:8000/api/deployments/");
 		assert_eq!(req.method(), reqwest::Method::POST);
+	}
+
+	#[rstest]
+	fn test_build_deploy_payload_serializes_cluster_id_as_number() {
+		// Arrange
+		let manifest = "apiVersion: paas.reinhardt-cloud.dev/v1\nkind: ReinhardtApp\n";
+
+		// Act
+		let payload = build_deploy_payload("web", "web:v1", Some("42"), Some(manifest)).unwrap();
+
+		// Assert
+		assert_eq!(payload["app_name"], serde_json::json!("web"));
+		assert_eq!(payload["image"], serde_json::json!("web:v1"));
+		assert_eq!(payload["cluster_id"], serde_json::json!(42));
+		assert_eq!(payload["reinhardt_app_yaml"], serde_json::json!(manifest));
+	}
+
+	#[rstest]
+	#[case("abc")]
+	#[case("0")]
+	#[case("-1")]
+	fn test_build_deploy_payload_rejects_invalid_cluster_id(#[case] cluster_id: &str) {
+		// Arrange
+		let invalid_cluster_id = cluster_id;
+
+		// Act
+		let result = build_deploy_payload("web", "web:v1", Some(invalid_cluster_id), None);
+
+		// Assert
+		assert!(
+			matches!(result, Err(ClientError::InvalidClusterId { .. })),
+			"expected invalid cluster id error, got {result:?}"
+		);
 	}
 
 	#[rstest]

--- a/crates/reinhardt-cloud-cli/src/commands/deploy.rs
+++ b/crates/reinhardt-cloud-cli/src/commands/deploy.rs
@@ -9,6 +9,7 @@ use crate::client::ReinhardtCloudClient;
 use crate::crd_version::{COMPILE_TIME_DEFAULT, resolve_api_version};
 use crate::feature_detector::{InfraSignals as DetectedInfraSignals, detect_project};
 use crate::settings_reader::{DatabaseConfig, read_database_config};
+use reinhardt_cloud_types::crd::ReinhardtAppSpec;
 use reinhardt_cloud_types::introspect::{
 	AppMetadata, DatabaseMetadata, FeaturesMetadata, InfraSignals as IntrospectInfraSignals,
 	IntrospectOutput,
@@ -250,33 +251,56 @@ fn run_manage_introspect() -> Result<String, String> {
 	}
 }
 
-/// Builds a `ReinhardtApp` CRD YAML value with optional introspect data.
+/// Builds a `ReinhardtAppSpec` from `reinhardt-cloud.toml`, CLI overrides,
+/// and optional introspect data.
+fn build_reinhardt_app_spec(
+	toml_config: Option<&ReinhardtCloudToml>,
+	image: String,
+	replicas: i32,
+	introspect: Option<IntrospectOutput>,
+) -> ReinhardtAppSpec {
+	let mut spec = toml_config
+		.map(ReinhardtCloudToml::to_reinhardt_app_spec)
+		.unwrap_or_else(|| ReinhardtAppSpec {
+			image: image.clone(),
+			replicas: Some(replicas),
+			..Default::default()
+		});
+
+	spec.image = image;
+	spec.replicas = Some(replicas);
+	spec.introspect = introspect;
+	spec
+}
+
+/// Removes null values from serialized Kubernetes YAML so absent optional
+/// fields stay absent in dry-run output and server-side apply payloads.
+fn prune_yaml_nulls(value: &mut serde_yaml::Value) {
+	match value {
+		serde_yaml::Value::Mapping(mapping) => {
+			mapping.retain(|_, nested| !nested.is_null());
+			for nested in mapping.values_mut() {
+				prune_yaml_nulls(nested);
+			}
+		}
+		serde_yaml::Value::Sequence(items) => {
+			for item in items {
+				prune_yaml_nulls(item);
+			}
+		}
+		_ => {}
+	}
+}
+
+/// Builds a `ReinhardtApp` CRD YAML value with typed spec data.
 fn build_reinhardt_app_crd(
 	name: &str,
 	namespace: &str,
-	image: &str,
-	replicas: Option<i32>,
-	introspect: Option<IntrospectOutput>,
+	spec: &ReinhardtAppSpec,
 	api_version: &str,
 ) -> serde_yaml::Value {
-	let mut spec = serde_yaml::Mapping::new();
-	spec.insert(
-		serde_yaml::Value::String("image".to_string()),
-		serde_yaml::Value::String(image.to_string()),
-	);
-	if let Some(r) = replicas {
-		spec.insert(
-			serde_yaml::Value::String("replicas".to_string()),
-			serde_yaml::Value::Number(serde_yaml::Number::from(r)),
-		);
-	}
-	if let Some(intro) = introspect {
-		let intro_value = serde_yaml::to_value(&intro).unwrap_or(serde_yaml::Value::Null);
-		spec.insert(
-			serde_yaml::Value::String("introspect".to_string()),
-			intro_value,
-		);
-	}
+	let mut spec_value = serde_yaml::to_value(spec).unwrap_or(serde_yaml::Value::Null);
+	prune_yaml_nulls(&mut spec_value);
 
 	let mut metadata = serde_yaml::Mapping::new();
 	metadata.insert(
@@ -301,10 +325,7 @@ fn build_reinhardt_app_crd(
 		serde_yaml::Value::String("metadata".to_string()),
 		serde_yaml::Value::Mapping(metadata),
 	);
-	root.insert(
-		serde_yaml::Value::String("spec".to_string()),
-		serde_yaml::Value::Mapping(spec),
-	);
+	root.insert(serde_yaml::Value::String("spec".to_string()), spec_value);
 
 	serde_yaml::Value::Mapping(root)
 }
@@ -476,15 +497,22 @@ async fn execute_inner(
 	)
 	.await?;
 
-	// Step 5: Build CRD
-	let crd = build_reinhardt_app_crd(
-		&app_name,
-		&args.namespace,
-		&image,
-		Some(replicas_i32),
+	// Step 5: Build typed spec and CRD
+	let spec = build_reinhardt_app_spec(
+		toml_config.as_ref(),
+		image.clone(),
+		replicas_i32,
 		introspect,
-		&api_version,
 	);
+	if let Err(errors) = spec.validate() {
+		let messages = errors
+			.into_iter()
+			.map(|e| e.message)
+			.collect::<Vec<_>>()
+			.join("; ");
+		return Err(format!("invalid ReinhardtApp spec: {messages}").into());
+	}
+	let crd = build_reinhardt_app_crd(&app_name, &args.namespace, &spec, &api_version);
 
 	// Step 6: Output or apply
 	if args.dry_run {
@@ -510,8 +538,9 @@ async fn execute_inner(
 		);
 	} else {
 		// API mode: send JSON payload to the dashboard API
+		let crd_yaml = serde_yaml::to_string(&crd)?;
 		match client
-			.deploy(&app_name, &image, args.cluster.as_deref())
+			.deploy(&app_name, &image, args.cluster.as_deref(), Some(&crd_yaml))
 			.await
 		{
 			Ok(response) => {
@@ -598,6 +627,10 @@ mod tests {
 	use reinhardt_cloud_types::introspect::{
 		AppMetadata, DatabaseMetadata, FeaturesMetadata, InfraSignals, MiddlewareMetadata,
 		RouteMetadata, SecuritySettings, ServerSettings, SettingsMetadata, TableMetadata,
+	};
+	use reinhardt_cloud_types::reinhardt_cloud_toml::{
+		AppSection, DatabaseSection, HealthSection, ReinhardtCloudToml, ReplicasSection,
+		ScaleSection, ServicesSection,
 	};
 	use rstest::rstest;
 
@@ -780,12 +813,11 @@ features:
 		};
 
 		// Act
+		let spec = build_reinhardt_app_spec(None, "my-app:v1".to_string(), 3, Some(introspect));
 		let crd = build_reinhardt_app_crd(
 			"my-app",
 			"production",
-			"my-app:v1",
-			Some(3),
-			Some(introspect),
+			&spec,
 			"paas.reinhardt-cloud.dev/v1alpha2",
 		);
 
@@ -842,13 +874,14 @@ features:
 
 	#[rstest]
 	fn test_build_reinhardt_app_crd_without_introspect() {
-		// Arrange & Act
+		// Arrange
+		let spec = build_reinhardt_app_spec(None, "simple:latest".to_string(), 1, None);
+
+		// Act
 		let crd = build_reinhardt_app_crd(
 			"simple-app",
 			"default",
-			"simple:latest",
-			Some(1),
-			None,
+			&spec,
 			"paas.reinhardt-cloud.dev/v1alpha2",
 		);
 
@@ -890,15 +923,101 @@ features:
 	}
 
 	#[rstest]
+	fn test_build_reinhardt_app_crd_preserves_typed_toml_sections() {
+		// Arrange
+		let mut config = ReinhardtCloudToml {
+			app: AppSection {
+				name: "dashboard".to_string(),
+				image: "dashboard:latest".to_string(),
+			},
+			database: Some(DatabaseSection {
+				engine: "postgresql".to_string(),
+				version: Some("16".to_string()),
+				..Default::default()
+			}),
+			health: Some(HealthSection {
+				path: Some("/api/healthz/".to_string()),
+				port: Some(8000),
+				interval_seconds: Some(10),
+			}),
+			services: Some(ServicesSection {
+				port: Some(80),
+				target_port: Some(8000),
+				ingress_host: None,
+			}),
+			replicas: Some(ReplicasSection { count: 2 }),
+			scale: Some(ScaleSection {
+				min_replicas: Some(2),
+				max_replicas: Some(6),
+				metric: Some("cpu".to_string()),
+				target_value: Some(70),
+			}),
+			..Default::default()
+		};
+		config.env.insert(
+			"DATABASE_URL".to_string(),
+			"secretRef:dashboard/database-url".to_string(),
+		);
+
+		// Act
+		let spec = build_reinhardt_app_spec(Some(&config), "dashboard:v1".to_string(), 2, None);
+		let crd = build_reinhardt_app_crd(
+			"dashboard",
+			"production",
+			&spec,
+			"paas.reinhardt-cloud.dev/v1alpha2",
+		);
+
+		// Assert
+		let spec = crd
+			.as_mapping()
+			.unwrap()
+			.get(serde_yaml::Value::String("spec".to_string()))
+			.unwrap()
+			.as_mapping()
+			.unwrap();
+		assert_eq!(
+			spec.get(serde_yaml::Value::String("image".to_string())),
+			Some(&serde_yaml::Value::String("dashboard:v1".to_string()))
+		);
+		assert!(
+			spec.get(serde_yaml::Value::String("database".to_string()))
+				.is_some()
+		);
+		assert!(
+			spec.get(serde_yaml::Value::String("health".to_string()))
+				.is_some()
+		);
+		assert!(
+			spec.get(serde_yaml::Value::String("services".to_string()))
+				.is_some()
+		);
+		assert!(
+			spec.get(serde_yaml::Value::String("scale".to_string()))
+				.is_some()
+		);
+		let env = spec
+			.get(serde_yaml::Value::String("env".to_string()))
+			.unwrap()
+			.as_mapping()
+			.unwrap();
+		assert_eq!(
+			env.get(serde_yaml::Value::String("DATABASE_URL".to_string())),
+			Some(&serde_yaml::Value::String(
+				"secretRef:dashboard/database-url".to_string()
+			))
+		);
+	}
+
+	#[rstest]
 	#[tokio::test]
 	async fn test_kubectl_apply_writes_valid_yaml() {
 		// Arrange
+		let spec = build_reinhardt_app_spec(None, "test:v1".to_string(), 2, None);
 		let crd = build_reinhardt_app_crd(
 			"test-app",
 			"staging",
-			"test:v1",
-			Some(2),
-			None,
+			&spec,
 			"paas.reinhardt-cloud.dev/v1alpha2",
 		);
 		let yaml = serde_yaml::to_string(&crd).unwrap();
@@ -921,12 +1040,11 @@ features:
 	#[tokio::test]
 	async fn test_kubectl_apply_passes_cluster_context() {
 		// Arrange
+		let spec = build_reinhardt_app_spec(None, "ctx:v1".to_string(), 1, None);
 		let crd = build_reinhardt_app_crd(
 			"ctx-app",
 			"prod",
-			"ctx:v1",
-			Some(1),
-			None,
+			&spec,
 			"paas.reinhardt-cloud.dev/v1alpha2",
 		);
 		let yaml = serde_yaml::to_string(&crd).unwrap();

--- a/crates/reinhardt-cloud-cli/src/commands/deploy.rs
+++ b/crates/reinhardt-cloud-cli/src/commands/deploy.rs
@@ -538,9 +538,8 @@ async fn execute_inner(
 		);
 	} else {
 		// API mode: send JSON payload to the dashboard API
-		let crd_yaml = serde_yaml::to_string(&crd)?;
 		match client
-			.deploy(&app_name, &image, args.cluster.as_deref(), Some(&crd_yaml))
+			.deploy(&app_name, &image, args.cluster.as_deref(), Some(&yaml))
 			.await
 		{
 			Ok(response) => {

--- a/crates/reinhardt-cloud-cli/src/dockerfile_generator.rs
+++ b/crates/reinhardt-cloud-cli/src/dockerfile_generator.rs
@@ -229,6 +229,17 @@ mod tests {
 		}
 	}
 
+	fn config_with_source_build(build: Option<BuildSection>) -> ReinhardtCloudToml {
+		ReinhardtCloudToml {
+			source: Some(SourceSection {
+				repository: String::new(),
+				build,
+				..Default::default()
+			}),
+			..Default::default()
+		}
+	}
+
 	// G1
 	#[rstest]
 	fn snapshot_api_minimal() {
@@ -418,15 +429,10 @@ mod tests {
 	fn skip_when_custom_dockerfile_set() {
 		// Arrange
 		let dir = std::env::temp_dir();
-		let mut config = ReinhardtCloudToml::default();
-		config.source = Some(SourceSection {
-			repository: String::new(),
-			build: Some(BuildSection {
-				dockerfile: Some("docker/Dockerfile.prod".to_string()),
-				..Default::default()
-			}),
+		let config = config_with_source_build(Some(BuildSection {
+			dockerfile: Some("docker/Dockerfile.prod".to_string()),
 			..Default::default()
-		});
+		}));
 
 		// Act
 		let result = should_skip_dockerfile(&dir, &config, false);
@@ -484,15 +490,10 @@ mod tests {
 	fn custom_dockerfile_empty_string() {
 		// Arrange
 		let dir = std::env::temp_dir();
-		let mut config = ReinhardtCloudToml::default();
-		config.source = Some(SourceSection {
-			repository: String::new(),
-			build: Some(BuildSection {
-				dockerfile: Some(String::new()),
-				..Default::default()
-			}),
+		let config = config_with_source_build(Some(BuildSection {
+			dockerfile: Some(String::new()),
 			..Default::default()
-		});
+		}));
 
 		// Act
 		let result = should_skip_dockerfile(&dir, &config, false);
@@ -517,15 +518,10 @@ mod tests {
 	fn no_skip_when_default_dockerfile_path() {
 		// Arrange
 		let dir = std::env::temp_dir();
-		let mut config = ReinhardtCloudToml::default();
-		config.source = Some(SourceSection {
-			repository: String::new(),
-			build: Some(BuildSection {
-				dockerfile: Some("Dockerfile".to_string()),
-				..Default::default()
-			}),
+		let config = config_with_source_build(Some(BuildSection {
+			dockerfile: Some("Dockerfile".to_string()),
 			..Default::default()
-		});
+		}));
 
 		// Act
 		let result = should_skip_dockerfile(&dir, &config, false);
@@ -539,15 +535,10 @@ mod tests {
 	fn no_skip_when_dot_slash_dockerfile_path() {
 		// Arrange
 		let dir = std::env::temp_dir();
-		let mut config = ReinhardtCloudToml::default();
-		config.source = Some(SourceSection {
-			repository: String::new(),
-			build: Some(BuildSection {
-				dockerfile: Some("./Dockerfile".to_string()),
-				..Default::default()
-			}),
+		let config = config_with_source_build(Some(BuildSection {
+			dockerfile: Some("./Dockerfile".to_string()),
 			..Default::default()
-		});
+		}));
 
 		// Act
 		let result = should_skip_dockerfile(&dir, &config, false);
@@ -561,12 +552,7 @@ mod tests {
 	fn build_section_missing() {
 		// Arrange
 		let dir = std::env::temp_dir();
-		let mut config = ReinhardtCloudToml::default();
-		config.source = Some(SourceSection {
-			repository: String::new(),
-			build: None,
-			..Default::default()
-		});
+		let config = config_with_source_build(None);
 
 		// Act
 		let result = should_skip_dockerfile(&dir, &config, false);

--- a/crates/reinhardt-cloud-operator/src/error.rs
+++ b/crates/reinhardt-cloud-operator/src/error.rs
@@ -35,6 +35,10 @@ pub(crate) enum Error {
 	#[error("invalid port {port} for field '{field}': must be between 1 and 65535")]
 	InvalidPort { field: &'static str, port: i32 },
 
+	/// A Kubernetes probe period is outside the valid range.
+	#[error("invalid probe period {seconds} for field '{field}': must be at least 1")]
+	InvalidProbePeriod { field: &'static str, seconds: i32 },
+
 	/// Database provisioning failed.
 	/// Used by the inference engine when database resource creation fails.
 	#[allow(dead_code)]
@@ -114,7 +118,7 @@ impl BackoffClass {
 /// Classify a reconciliation error into a `BackoffClass`.
 ///
 /// Heuristics:
-/// - `MissingField`, `InvalidPort`: permanent — user must fix the spec.
+/// - `MissingField`, `InvalidPort`, probe periods: permanent — user must fix the spec.
 /// - `Kube` with HTTP 404/409: dependency not ready (object missing or
 ///   write conflicts) — wait a bit longer before retrying.
 /// - All other errors: transient — short backoff.
@@ -124,6 +128,7 @@ pub(crate) fn backoff_class(error: &Error) -> BackoffClass {
 		// can possibly succeed.
 		Error::MissingField(_)
 		| Error::InvalidPort { .. }
+		| Error::InvalidProbePeriod { .. }
 		| Error::TenantMismatch { .. }
 		| Error::InvalidTenant(_) => BackoffClass::Permanent,
 		Error::Kube(kube_err) => kube_status_class(kube_err),

--- a/crates/reinhardt-cloud-operator/src/resources/deployment.rs
+++ b/crates/reinhardt-cloud-operator/src/resources/deployment.rs
@@ -36,6 +36,12 @@ fn build_main_container_probe(
 	let path = health.path.clone().unwrap_or_else(|| "/health".to_string());
 	let port = validate_port("health.port", health.port.unwrap_or(default_port))?;
 	let period_seconds = health.interval_seconds.unwrap_or(10);
+	if period_seconds < 1 {
+		return Err(Error::InvalidProbePeriod {
+			field: "health.interval_seconds",
+			seconds: period_seconds,
+		});
+	}
 
 	Ok(Some(Probe {
 		http_get: Some(HTTPGetAction {
@@ -479,6 +485,34 @@ mod tests {
 			assert_eq!(http.port, IntOrString::Int(8000));
 			assert_eq!(probe.period_seconds, Some(10));
 		}
+	}
+
+	#[rstest]
+	#[case(0)]
+	#[case(-1)]
+	fn test_build_deployment_rejects_invalid_health_interval(#[case] interval_seconds: i32) {
+		// Arrange
+		let mut app = make_test_app("web", "web:v1", None);
+		app.spec.health = Some(HealthSpec {
+			path: Some("/api/healthz/".to_string()),
+			port: Some(8000),
+			interval_seconds: Some(interval_seconds),
+		});
+
+		// Act
+		let result = build_deployment(&app, None, &Platform::Onpremise);
+
+		// Assert
+		assert!(
+			matches!(
+				result,
+				Err(Error::InvalidProbePeriod {
+					field: "health.interval_seconds",
+					seconds
+				}) if seconds == interval_seconds
+			),
+			"expected invalid probe period error, got {result:?}"
+		);
 	}
 
 	#[rstest]

--- a/crates/reinhardt-cloud-operator/src/resources/deployment.rs
+++ b/crates/reinhardt-cloud-operator/src/resources/deployment.rs
@@ -26,6 +26,28 @@ use crate::inference::env_vars::{
 use crate::inference::pages::ResolvedPagesConfig;
 use crate::inference::platform::Platform;
 
+fn build_main_container_probe(
+	app: &ReinhardtApp,
+	default_port: i32,
+) -> Result<Option<Probe>, Error> {
+	let Some(health) = app.spec.health.as_ref() else {
+		return Ok(None);
+	};
+	let path = health.path.clone().unwrap_or_else(|| "/health".to_string());
+	let port = validate_port("health.port", health.port.unwrap_or(default_port))?;
+	let period_seconds = health.interval_seconds.unwrap_or(10);
+
+	Ok(Some(Probe {
+		http_get: Some(HTTPGetAction {
+			path: Some(path),
+			port: IntOrString::Int(port),
+			..Default::default()
+		}),
+		period_seconds: Some(period_seconds),
+		..Default::default()
+	}))
+}
+
 /// Builds a `Deployment` for the given `ReinhardtApp`.
 ///
 /// Uses the app's own namespace as the single source of truth.
@@ -261,6 +283,7 @@ pub(crate) fn build_deployment(
 	} else {
 		Some(init_containers)
 	};
+	let main_container_probe = build_main_container_probe(app, port)?;
 
 	let mut containers = vec![Container {
 		name: app.name_any(),
@@ -271,6 +294,8 @@ pub(crate) fn build_deployment(
 		}]),
 		env: Some(merged_env),
 		volume_mounts: Some(volume_mounts),
+		readiness_probe: main_container_probe.clone(),
+		liveness_probe: main_container_probe,
 		security_context: if isolated {
 			Some(build_container_security_context())
 		} else {
@@ -339,7 +364,7 @@ mod tests {
 	use kube::api::ObjectMeta;
 	use reinhardt_cloud_types::crd::database::{DatabaseEngine, DatabaseSpec};
 	use reinhardt_cloud_types::crd::isolation::{IsolationLevel, IsolationSpec};
-	use reinhardt_cloud_types::crd::{ReinhardtAppSpec, ServicesSpec};
+	use reinhardt_cloud_types::crd::{HealthSpec, ReinhardtAppSpec, ServicesSpec};
 	use rstest::rstest;
 
 	fn make_test_app(name: &str, image: &str, replicas: Option<i32>) -> ReinhardtApp {
@@ -412,6 +437,48 @@ mod tests {
 		let container = &deploy.spec.unwrap().template.spec.unwrap().containers[0];
 		let port = &container.ports.as_ref().unwrap()[0];
 		assert_eq!(port.container_port, 8000);
+	}
+
+	#[rstest]
+	fn test_build_deployment_omits_main_container_probe_without_health() {
+		// Arrange
+		let app = make_test_app("web", "web:v1", None);
+
+		// Act
+		let deploy =
+			build_deployment(&app, None, &Platform::Onpremise).expect("build should succeed");
+
+		// Assert
+		let container = &deploy.spec.unwrap().template.spec.unwrap().containers[0];
+		assert!(container.readiness_probe.is_none());
+		assert!(container.liveness_probe.is_none());
+	}
+
+	#[rstest]
+	fn test_build_deployment_applies_health_to_main_container_probes() {
+		// Arrange
+		let mut app = make_test_app("web", "web:v1", None);
+		app.spec.health = Some(HealthSpec {
+			path: Some("/api/healthz/".to_string()),
+			port: Some(8000),
+			interval_seconds: Some(10),
+		});
+
+		// Act
+		let deploy =
+			build_deployment(&app, None, &Platform::Onpremise).expect("build should succeed");
+
+		// Assert
+		let container = &deploy.spec.unwrap().template.spec.unwrap().containers[0];
+		for probe in [
+			container.readiness_probe.as_ref().unwrap(),
+			container.liveness_probe.as_ref().unwrap(),
+		] {
+			let http = probe.http_get.as_ref().unwrap();
+			assert_eq!(http.path.as_deref(), Some("/api/healthz/"));
+			assert_eq!(http.port, IntOrString::Int(8000));
+			assert_eq!(probe.period_seconds, Some(10));
+		}
 	}
 
 	#[rstest]

--- a/dashboard/Cargo.toml
+++ b/dashboard/Cargo.toml
@@ -44,6 +44,7 @@ reinhardt-cloud-k8s = { workspace = true }
 reinhardt-cloud-proto = { workspace = true }
 reinhardt-cloud-grpc = { workspace = true }
 prost-types = { workspace = true }
+serde_yaml = { workspace = true }
 tokio = { workspace = true }
 hmac = "0.12"
 sha2 = "0.10"

--- a/dashboard/migrations/deployments/0005_add_reinhardt_app_yaml.rs
+++ b/dashboard/migrations/deployments/0005_add_reinhardt_app_yaml.rs
@@ -1,0 +1,33 @@
+use reinhardt::db::migrations::FieldType;
+use reinhardt::db::migrations::prelude::*;
+
+pub fn migration() -> Migration {
+	Migration {
+		app_label: "deployments".to_string(),
+		name: "0005_add_reinhardt_app_yaml".to_string(),
+		operations: vec![Operation::AddColumn {
+			table: "deployments".to_string(),
+			column: ColumnDefinition {
+				name: "reinhardt_app_yaml".to_string(),
+				type_definition: FieldType::VarChar(65535u32),
+				not_null: false,
+				unique: false,
+				primary_key: false,
+				auto_increment: false,
+				default: None,
+			},
+			mysql_options: None,
+		}],
+		dependencies: vec![(
+			"deployments".to_string(),
+			"0004_replace_user_id_with_organization_id".to_string(),
+		)],
+		atomic: true,
+		replaces: vec![],
+		initial: Some(false),
+		state_only: false,
+		database_only: false,
+		swappable_dependencies: vec![],
+		optional_dependencies: vec![],
+	}
+}

--- a/dashboard/src/apps/deployments/models/deployment.rs
+++ b/dashboard/src/apps/deployments/models/deployment.rs
@@ -29,6 +29,10 @@ pub struct Deployment {
 	#[field(max_length = 512)]
 	pub image: String,
 
+	/// Submitted `ReinhardtApp` manifest YAML for operator-driven deployment.
+	#[field(max_length = 65535)]
+	pub reinhardt_app_yaml: Option<String>,
+
 	/// Deployment creation timestamp
 	#[field(auto_now_add = true)]
 	pub created_at: chrono::DateTime<chrono::Utc>,

--- a/dashboard/src/apps/deployments/serializers/request.rs
+++ b/dashboard/src/apps/deployments/serializers/request.rs
@@ -13,7 +13,7 @@ pub struct CreateDeploymentRequest {
 	#[validate(length(min = 1, max = 512))]
 	pub image: String,
 	#[serde(default)]
-	#[validate(length(max = 65536))]
+	#[validate(length(max = 65535))]
 	pub reinhardt_app_yaml: Option<String>,
 }
 

--- a/dashboard/src/apps/deployments/serializers/request.rs
+++ b/dashboard/src/apps/deployments/serializers/request.rs
@@ -12,6 +12,9 @@ pub struct CreateDeploymentRequest {
 	pub cluster_id: i64,
 	#[validate(length(min = 1, max = 512))]
 	pub image: String,
+	#[serde(default)]
+	#[validate(length(max = 65536))]
+	pub reinhardt_app_yaml: Option<String>,
 }
 
 /// Request body for updating a deployment (all fields optional).

--- a/dashboard/src/apps/deployments/tests/unit/test_deployment_model.rs
+++ b/dashboard/src/apps/deployments/tests/unit/test_deployment_model.rs
@@ -15,6 +15,8 @@ mod tests {
 		let cluster_id = 42i64;
 		let status = "pending".to_string();
 		let image = "ghcr.io/my-app:latest".to_string();
+		let reinhardt_app_yaml =
+			"apiVersion: paas.reinhardt-cloud.dev/v1alpha2\nkind: ReinhardtApp\n".to_string();
 
 		// Act
 		let deployment = Deployment::build()
@@ -23,6 +25,7 @@ mod tests {
 			.cluster_id(cluster_id)
 			.status(status.clone())
 			.image(image.clone())
+			.reinhardt_app_yaml(Some(reinhardt_app_yaml.clone()))
 			.finish();
 
 		// Assert
@@ -31,6 +34,7 @@ mod tests {
 		assert_eq!(deployment.cluster_id, cluster_id);
 		assert_eq!(deployment.status, status);
 		assert_eq!(deployment.image, image);
+		assert_eq!(deployment.reinhardt_app_yaml, Some(reinhardt_app_yaml));
 	}
 
 	/// Deployment::new sets id to None (auto-increment on insert).
@@ -43,6 +47,7 @@ mod tests {
 			.cluster_id(1)
 			.status("pending".to_string())
 			.image("nginx:latest".to_string())
+			.reinhardt_app_yaml(None)
 			.finish();
 
 		// Assert
@@ -63,6 +68,7 @@ mod tests {
 			.cluster_id(1)
 			.status(status.to_string())
 			.image("nginx:latest".to_string())
+			.reinhardt_app_yaml(None)
 			.finish();
 
 		// Assert
@@ -79,6 +85,7 @@ mod tests {
 			.cluster_id(99)
 			.status("running".to_string())
 			.image("ghcr.io/roundtrip:v1".to_string())
+			.reinhardt_app_yaml(None)
 			.finish();
 		deployment.id = Some(7);
 
@@ -93,5 +100,6 @@ mod tests {
 		assert_eq!(restored.cluster_id, deployment.cluster_id);
 		assert_eq!(restored.status, deployment.status);
 		assert_eq!(restored.image, deployment.image);
+		assert_eq!(restored.reinhardt_app_yaml, deployment.reinhardt_app_yaml);
 	}
 }

--- a/dashboard/src/apps/deployments/tests/unit/test_deployment_property.rs
+++ b/dashboard/src/apps/deployments/tests/unit/test_deployment_property.rs
@@ -28,6 +28,7 @@ mod tests {
 					.cluster_id(cluster_id)
 					.status(status)
 					.image(image)
+					.reinhardt_app_yaml(None)
 					.finish();
 				d.id = Some(cluster_id);
 				d

--- a/dashboard/src/apps/deployments/tests/unit/test_request_validation.rs
+++ b/dashboard/src/apps/deployments/tests/unit/test_request_validation.rs
@@ -19,6 +19,7 @@ mod tests {
 			app_name: app_name.to_string(),
 			cluster_id: 1,
 			image: "nginx:latest".to_string(),
+			reinhardt_app_yaml: None,
 		};
 
 		// Act
@@ -44,6 +45,7 @@ mod tests {
 			app_name: "my-app".to_string(),
 			cluster_id,
 			image: "nginx:latest".to_string(),
+			reinhardt_app_yaml: None,
 		};
 
 		// Act
@@ -69,6 +71,7 @@ mod tests {
 			app_name: "my-app".to_string(),
 			cluster_id: 1,
 			image: image.to_string(),
+			reinhardt_app_yaml: None,
 		};
 
 		// Act

--- a/dashboard/src/apps/deployments/tests/unit/test_serializer.rs
+++ b/dashboard/src/apps/deployments/tests/unit/test_serializer.rs
@@ -18,6 +18,7 @@ mod tests {
 			.cluster_id(1)
 			.status("pending".to_string())
 			.image("ghcr.io/my-app:latest".to_string())
+			.reinhardt_app_yaml(None)
 			.finish();
 
 		// Act
@@ -38,6 +39,7 @@ mod tests {
 			.cluster_id(1)
 			.status("pending".to_string())
 			.image("ghcr.io/my-app:latest".to_string())
+			.reinhardt_app_yaml(None)
 			.finish();
 
 		// Act
@@ -58,6 +60,7 @@ mod tests {
 			.cluster_id(1)
 			.status("running".to_string())
 			.image("ghcr.io/my-app:v2".to_string())
+			.reinhardt_app_yaml(None)
 			.finish();
 		deployment.id = Some(42);
 

--- a/dashboard/src/apps/deployments/tests/unit/test_serializer.rs
+++ b/dashboard/src/apps/deployments/tests/unit/test_serializer.rs
@@ -82,5 +82,26 @@ mod tests {
 		assert_eq!(req.app_name, "web");
 		assert_eq!(req.cluster_id, 42);
 		assert_eq!(req.image, "nginx:latest");
+		assert!(req.reinhardt_app_yaml.is_none());
+	}
+
+	#[rstest]
+	fn test_create_deployment_request_accepts_reinhardt_app_yaml() {
+		// Arrange
+		let json = r#"{
+			"app_name": "web",
+			"cluster_id": 42,
+			"image": "nginx:latest",
+			"reinhardt_app_yaml": "apiVersion: paas.reinhardt-cloud.dev/v1alpha2\nkind: ReinhardtApp\n"
+		}"#;
+
+		// Act
+		let req: CreateDeploymentRequest = serde_json::from_str(json).unwrap();
+
+		// Assert
+		assert_eq!(
+			req.reinhardt_app_yaml.as_deref(),
+			Some("apiVersion: paas.reinhardt-cloud.dev/v1alpha2\nkind: ReinhardtApp\n")
+		);
 	}
 }

--- a/dashboard/src/apps/deployments/views/create_deployment.rs
+++ b/dashboard/src/apps/deployments/views/create_deployment.rs
@@ -5,6 +5,7 @@ use reinhardt::core::exception::Error as AppError;
 use reinhardt::core::serde::json;
 use reinhardt::http::ViewResult;
 use reinhardt::{AuthInfo, Json, Path, Response, StatusCode, post};
+use reinhardt_cloud_types::crd::ReinhardtApp;
 use tracing::error;
 use uuid::Uuid;
 
@@ -12,6 +13,23 @@ use crate::apps::clusters::models::Cluster;
 use crate::apps::deployments::models::Deployment;
 use crate::apps::deployments::serializers::{CreateDeploymentRequest, DeploymentResponse};
 use crate::apps::organizations::permissions::{Action, require_permission_for_org};
+
+fn validate_reinhardt_app_yaml(manifest: &str) -> Result<(), AppError> {
+	let app: ReinhardtApp = serde_yaml::from_str(manifest)
+		.map_err(|e| AppError::Validation(format!("Invalid ReinhardtApp YAML: {e}")))?;
+	if let Err(errors) = app.spec.validate() {
+		let messages = errors
+			.into_iter()
+			.map(|e| e.message)
+			.collect::<Vec<_>>()
+			.join("; ");
+		return Err(AppError::Validation(format!(
+			"Invalid ReinhardtApp spec: {messages}"
+		)));
+	}
+
+	Ok(())
+}
 
 /// Create a new deployment (authentication required).
 ///
@@ -47,12 +65,17 @@ pub async fn create_deployment(
 		)));
 	}
 
+	if let Some(manifest) = body.reinhardt_app_yaml.as_deref() {
+		validate_reinhardt_app_yaml(manifest)?;
+	}
+
 	let new_deployment = Deployment::build()
 		.organization_id(organization_id)
 		.app_name(body.app_name.clone())
 		.cluster_id(body.cluster_id)
 		.status("pending".to_string())
 		.image(body.image.clone())
+		.reinhardt_app_yaml(body.reinhardt_app_yaml.clone())
 		.finish();
 	let manager = Deployment::objects();
 	let created = manager.create(&new_deployment).await.map_err(|e| {
@@ -63,4 +86,74 @@ pub async fn create_deployment(
 	Ok(Response::new(StatusCode::CREATED)
 		.with_header("Content-Type", "application/json")
 		.with_body(json::to_vec(&resp)?))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use rstest::rstest;
+
+	#[rstest]
+	fn test_validate_reinhardt_app_yaml_accepts_valid_manifest() {
+		// Arrange
+		let manifest = r#"
+apiVersion: paas.reinhardt-cloud.dev/v1alpha2
+kind: ReinhardtApp
+metadata:
+  name: web
+  namespace: default
+spec:
+  image: ghcr.io/example/web:v1
+  health:
+    path: /healthz
+    port: 8000
+    interval_seconds: 10
+"#;
+
+		// Act
+		let result = validate_reinhardt_app_yaml(manifest);
+
+		// Assert
+		assert!(result.is_ok());
+	}
+
+	#[rstest]
+	fn test_validate_reinhardt_app_yaml_rejects_invalid_manifest() {
+		// Arrange
+		let manifest = "not: [valid";
+
+		// Act
+		let result = validate_reinhardt_app_yaml(manifest);
+
+		// Assert
+		assert!(
+			matches!(result, Err(AppError::Validation(_))),
+			"expected validation error, got {result:?}"
+		);
+	}
+
+	#[rstest]
+	fn test_validate_reinhardt_app_yaml_rejects_invalid_spec() {
+		// Arrange
+		let manifest = r#"
+apiVersion: paas.reinhardt-cloud.dev/v1alpha2
+kind: ReinhardtApp
+metadata:
+  name: web
+  namespace: default
+spec:
+  image: ghcr.io/example/web:v1
+  health:
+    port: 0
+"#;
+
+		// Act
+		let result = validate_reinhardt_app_yaml(manifest);
+
+		// Assert
+		assert!(
+			matches!(result, Err(AppError::Validation(_))),
+			"expected validation error, got {result:?}"
+		);
+	}
 }

--- a/docs/architecture/deployment-flow.md
+++ b/docs/architecture/deployment-flow.md
@@ -45,8 +45,9 @@ operator owns reconciliation end-to-end. See **Agent Path** below.
 
 The CLI's `execute_inner` function in
 `crates/reinhardt-cloud-cli/src/commands/deploy.rs` always builds a
-`ReinhardtApp` CRD via `build_reinhardt_app_crd` (lines 242-299), then
-branches on flags:
+typed `ReinhardtAppSpec` from `reinhardt-cloud.toml`, CLI overrides, and
+optional introspect output, then renders a `ReinhardtApp` CRD via
+`build_reinhardt_app_crd` before branching on flags:
 
 - **`--dry-run`** (`deploy.rs:479-482`) — Serialises the CRD to YAML and
   prints it to stdout. No cluster contact, no API contact. **Status:
@@ -55,14 +56,19 @@ branches on flags:
   `kubectl apply -f -` against the operator's cluster. The operator's
   reconciler picks up the new `ReinhardtApp` resource via its watch and
   produces the owned Kubernetes resources. **Status: Current State.**
-- **default / API mode** (`deploy.rs:501-514`) — POSTs a JSON payload
-  `{app_name, image, cluster_id}` to the dashboard at `/api/deployments/`
-  via `ReinhardtCloudClient::deploy`. The dashboard then takes over.
+- **default / API mode** — POSTs a JSON payload containing `app_name`,
+  `image`, optional `cluster_id`, and the generated `ReinhardtApp` YAML as
+  `reinhardt_app_yaml` to the dashboard at `/api/deployments/` via
+  `ReinhardtCloudClient::deploy`. The dashboard accepts this payload, but
+  the generated CRD is not yet persisted or relayed to the agent.
   **Status: Current State.**
 
-The function signature `build_reinhardt_app_crd(name, namespace, image,
-replicas, introspect, api_version) -> serde_yaml::Value` is the *only*
-place CRD YAML is constructed in the codebase today.
+The function signature `build_reinhardt_app_crd(name, namespace, spec,
+api_version) -> serde_yaml::Value` is the CLI's CRD rendering boundary.
+The conversion from `reinhardt-cloud.toml` to `ReinhardtAppSpec` happens
+before that boundary so typed TOML sections such as `health`, `services`,
+`scale`, `env`, `database`, `cache`, `worker`, `storage`, and `mail` are
+not dropped during manifest construction.
 
 ### Dashboard-Relay Path
 
@@ -76,10 +82,12 @@ the following:
    authenticated user.
 2. Persists a `Deployment` ORM record. The model
    (`dashboard/src/apps/deployments/models/deployment.rs:9-40`) tracks:
-   `id`, `user_id`, `app_name`, `cluster_id`, `status` (one of
+   `id`, `organization_id`, `app_name`, `cluster_id`, `status` (one of
    `pending`/`running`/`failed`/`succeeded`), `image`, `created_at`,
    `updated_at`. Initial `status` is `pending`.
-3. Forwards a deploy command to the registered agent via the gRPC
+3. Accepts the optional `reinhardt_app_yaml` request field. At this stage,
+   the field is an API-boundary payload, not a persisted model column.
+4. Forwards a deploy command to the registered agent via the gRPC
    bidirectional stream that the agent opened on startup.
 
 **Status: Current State.** The dashboard does **not** apply Kubernetes
@@ -148,9 +156,10 @@ sequenceDiagram
         CLI->>Kubectl: kubectl apply -f (ReinhardtApp CRD)
         Kubectl->>Operator: watch event
         Operator->>Kubectl: reconcile -> Deployment, Service, Ingress, ...
-    else default / platform path (deploy.rs:501-514)
-        CLI->>Dashboard: POST /api/deployments/ {app_name, image, cluster_id}
+    else default / platform path
+        CLI->>Dashboard: POST /api/deployments/ {app_name, image, cluster_id, reinhardt_app_yaml}
         Dashboard->>PG: INSERT Deployment (status=pending)
+        Note over Dashboard: Current State: reinhardt_app_yaml is accepted at the API boundary<br/>but not persisted or relayed to Agent yet
         Dashboard->>Agent: gRPC stream command (main.rs:129)
         Note over Agent: Current State: execute_deploy applies a raw Deployment<br/>(NOT a ReinhardtApp CRD) -- main.rs:311-364
         Note over Agent: Intended: agent applies ReinhardtApp CRD; operator reconciles

--- a/docs/development/LOCAL_E2E_TESTING.md
+++ b/docs/development/LOCAL_E2E_TESTING.md
@@ -226,9 +226,11 @@ cargo run -p reinhardt-cloud-cli -- deploy \
   --name demo --image nginx:1.27 --replicas 2
 ```
 
-Expected: the Dashboard returns a 2xx for `POST /deployments`. **The Agent
-binary will not receive the deploy command yet** — see the first item in
-Known limitations.
+Expected: the Dashboard returns a 2xx for `POST /deployments`. The CLI
+includes the generated `ReinhardtApp` YAML in the request body as
+`reinhardt_app_yaml`, but the Dashboard does not yet persist or relay that
+manifest to the Agent. **The Agent binary will not receive the deploy command
+yet** — see the first item in Known limitations.
 
 ## Known limitations
 
@@ -253,7 +255,7 @@ Dashboard → Agent → Operator path. Each has a tracking Issue:
    validates against. Tracked in kent8192/reinhardt-cloud#361.
 
 Until each item is resolved, treat the "Dashboard-mediated deploy" scenario
-(section 8c) as a partial smoke test: HTTP path only.
+(section 8c) as a partial smoke test: HTTP path and payload acceptance only.
 
 ## Troubleshooting
 

--- a/docs/tools/cli.md
+++ b/docs/tools/cli.md
@@ -232,6 +232,7 @@ reinhardt-cloud deploy [--name <NAME>] [--image <IMAGE>] [--replicas <N>]
 | `--dry-run` | — | no | `false` | Print the generated CRD YAML to stdout without applying. |
 | `--direct` | — | no | `false` | Skip the platform API; apply the CRD directly via `kubectl apply`. |
 | `--introspect-only` | — | no | `false` | Run `manage introspect --format yaml`, print the output, and exit without deploying. |
+| `--api-version <GROUP/VERSION>` | — | no | Served CRD storage version for `--direct`; compile-time default otherwise | Override the generated manifest `apiVersion`. Must be fully qualified, for example `paas.reinhardt-cloud.dev/v1alpha2`. |
 
 \* `--name` and `--image` are required at runtime if they cannot be resolved from `manage introspect` output or `reinhardt-cloud.toml` (see resolution order below).
 
@@ -242,18 +243,20 @@ reinhardt-cloud deploy [--name <NAME>] [--image <IMAGE>] [--replicas <N>]
 3. `reinhardt-cloud.toml` (`ReinhardtCloudToml`)
 4. Built-in default: `replicas = 1`
 
+When `reinhardt-cloud.toml` is present, `deploy` converts its typed sections into the generated `ReinhardtAppSpec` before applying CLI overrides. That includes `database`, `auth`, `health`, `services`, `replicas`, `scale`, `cache`, `worker`, `storage`, `mail`, `source`, and `env`. `--name`, `--image`, and `--replicas` still override the corresponding TOML-derived values.
+
 **Three submission modes**
 
 | Mode | Flag(s) | Contacted endpoint | Typical use-case |
 |------|---------|--------------------|-----------------|
-| Default (API) | neither `--dry-run` nor `--direct` | Platform API (`REINHARDT_CLOUD_API_URL`) via `ReinhardtCloudClient::deploy` | Standard developer deploy through the control plane |
+| Default (API) | neither `--dry-run` nor `--direct` | Platform API (`REINHARDT_CLOUD_API_URL`) via `ReinhardtCloudClient::deploy`; payload includes app metadata and generated `ReinhardtApp` YAML | Standard developer deploy through the control plane |
 | Direct (kubectl) | `--direct` | Kubernetes API server via `kubectl apply -f -` | Bypassing the control plane; useful when the platform API is unavailable or during operator bootstrap |
 | Dry run | `--dry-run` | None — YAML is printed to stdout | Pre-flight check, GitOps manifest review, CI validation |
 | Introspect only | `--introspect-only` | Runs `manage introspect` locally; no Kubernetes contact | Debugging introspect output without deploying |
 
-`--dry-run` and `--direct` are mutually exclusive in effect: `--dry-run` is checked first (`deploy.rs:301`) and causes early return before `--direct` is evaluated.
+`--dry-run` and `--direct` are mutually exclusive in effect: `--dry-run` is checked first and causes early return before `--direct` is evaluated.
 
-The generated CRD always carries `apiVersion: paas.reinhardt-cloud.dev/v1alpha2`. Multi-version support is tracked at [#367](https://github.com/kent8192/reinhardt-cloud/issues/367).
+For `--direct`, the CLI discovers the served CRD version from the target cluster unless `--api-version` is provided. For dry-run and API mode, it uses the explicit `--api-version` value when set, otherwise the compile-time default.
 
 **Example: CI pipeline pattern**
 
@@ -285,7 +288,7 @@ The `crd` command reference (covered in a later section of this guide) explains 
 
 > **For App Developers**: Use `--dry-run` before every deploy in CI to catch name or image resolution errors before they reach the cluster. A dry-run exit code of `0` means the CRD YAML is valid and `--name` / `--image` were resolved; it does not guarantee the cluster will accept the resource. Add `--dry-run` to a pre-commit hook or CI step for early feedback.
 
-> **For Platform Operators**: `--direct` bypasses the platform API and calls `kubectl apply` on the developer's machine, which means the developer needs `patch` / `create` RBAC on `reinhardtapps` in the target namespace. Prefer the default API mode to keep RBAC enforcement centralized. When `--direct` is used with `--cluster`, the value is passed as `--context` to `kubectl`; ensure the developer's kubeconfig contains the named context. Note that the CRD `apiVersion` is currently hardcoded to `v1alpha2` in the CLI — if your cluster serves a different storage version, server-side apply conflicts may occur. This is tracked at [#367](https://github.com/kent8192/reinhardt-cloud/issues/367).
+> **For Platform Operators**: `--direct` bypasses the platform API and calls `kubectl apply` on the developer's machine, which means the developer needs `patch` / `create` RBAC on `reinhardtapps` in the target namespace. Prefer the default API mode to keep RBAC enforcement centralized. When `--direct` is used with `--cluster`, the value is passed as `--context` to `kubectl`; ensure the developer's kubeconfig contains the named context. Pass `--api-version` only when discovery is unavailable or you intentionally need to pin a served CRD version.
 
 **Troubleshooting**
 
@@ -578,7 +581,7 @@ spec:
       ...
 ```
 
-> **For Platform Operators**: The `apiVersion` embedded in generated `ReinhardtApp` manifests (produced by `deploy --dry-run` and the operator itself) is currently hardcoded to `paas.reinhardt-cloud.dev/v1alpha2`. This is an active design area — see [#367](https://github.com/kent8192/reinhardt-cloud/issues/367) for the ongoing discussion on multi-version support. If your cluster serves a different storage version, re-generate and re-apply the CRD after each CLI upgrade. Long-lived GitOps repositories that pin the CRD YAML should monitor #367 and update when the storage version changes.
+> **For Platform Operators**: `crd generate` emits the CRD schema compiled into the CLI. `deploy --direct` separately resolves the served `ReinhardtApp` resource `apiVersion` from the target cluster unless you pass `--api-version`. Re-generate and re-apply the CRD schema after CLI upgrades that change the CRD type definitions.
 
 **Troubleshooting**
 
@@ -814,5 +817,3 @@ For the complete and current field list, refer to:
 - `crates/reinhardt-cloud-types/src/reinhardt_cloud_toml.rs` — the schema definition.
 
 The config is generated by analyzing your Reinhardt project's `Cargo.toml`, `Cargo.lock`, and `settings/base.toml` — there is no manual schema file to read. Run `init` on a sample project to see what is produced, then customize as needed.
-
-


### PR DESCRIPTION
## Summary

This PR addresses:

- Preserve typed `reinhardt-cloud.toml` sections when `reinhardt-cloud deploy` renders the `ReinhardtApp` resource.
- Carry the generated `ReinhardtApp` YAML through the Dashboard deploy request boundary.
- Apply `spec.health` to the main application container readiness and liveness probes.
- Keep the targeted CLI clippy gate green by avoiding default field reassignment in dockerfile tests.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

`deploy` previously rebuilt CRD YAML from a narrow ad-hoc map, so valid typed config such as health probes, service ports, scaling, environment, and related deployment sections could be dropped before reaching Kubernetes. The operator also ignored `spec.health` for the main app container.

Fixes #621
Fixes #624

Related to: #620

## How Was This Tested?

- `cargo fmt --check`
- `git diff --check`
- `cargo check -p reinhardt-cloud-cli -p reinhardt-cloud-operator -p reinhardt-cloud-dashboard`
- `cargo test -p reinhardt-cloud-cli test_build_reinhardt_app_crd -- --nocapture`
- `cargo test -p reinhardt-cloud-operator main_container_probe -- --nocapture`
- `cargo test -p reinhardt-cloud-dashboard test_create_deployment_request -- --nocapture`
- `cargo test -p reinhardt-cloud-cli dockerfile_generator::tests:: -- --nocapture`
- `cargo clippy -p reinhardt-cloud-cli -p reinhardt-cloud-operator -p reinhardt-cloud-dashboard --all-targets -- -D warnings`

## Breaking Changes

None.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

<!-- ⚠️ CI CONTROL CHECKBOX - DO NOT EDIT MANUALLY ⚠️
The following checkbox controls CI runner selection.
Checking this option triggers self-hosted runner usage,
which incurs infrastructure costs. Only the repository owner should enable this.
If this checkbox is missing or unchecked, CI defaults to GitHub-hosted runners.
Do NOT modify the checkbox text — CI parses it by exact pattern match. -->
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #621
- Fixes #624
- Refs #620

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [x] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [x] `kubernetes` - Kubernetes resources, controllers, operators
- [x] `deployment` - Application deployment logic
- [ ] `networking` - Ingress, services, network policies
- [ ] `storage` - Persistent volumes, storage classes
- [ ] `auth` - Authentication, authorization, RBAC
- [x] `api` - REST API, serializers, handlers
- [x] `cli` - Command-line interface
- [x] `config` - Configuration management
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [x] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

This intentionally does not close #620 because the umbrella still includes broader inference/policy gaps that need separate issue work.

🤖 Generated with [Codex](https://openai.com/codex)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--api-version` flag to control generated manifest versions in deployment commands
  * CLI deployment now supports optional YAML specification submission to the dashboard
  * Health probe validation with configurable interval settings

* **Documentation**
  * Updated CLI command reference with new deployment flags and options
  * Clarified deployment submission modes and how specifications are handled

<!-- end of auto-generated comment: release notes by coderabbit.ai -->