### PR TITLE
fix(operator): narrow app service selector to web pods

### DIFF
--- a/crates/reinhardt-cloud-operator/src/resources/service.rs
+++ b/crates/reinhardt-cloud-operator/src/resources/service.rs
@@ -69,10 +69,13 @@ pub(crate) fn build_service(app: &ReinhardtApp, pages_enabled: bool) -> Result<S
 			..Default::default()
 		},
 		spec: Some(ServiceSpec {
-			selector: Some(BTreeMap::from([(
-				"app.kubernetes.io/name".to_string(),
-				app.name_any(),
-			)])),
+			selector: Some(BTreeMap::from([
+				("app.kubernetes.io/name".to_string(), app.name_any()),
+				(
+					"app.kubernetes.io/component".to_string(),
+					Component::Web.as_str().to_string(),
+				),
+			])),
 			ports: Some(ports),
 			..Default::default()
 		}),
@@ -137,6 +140,28 @@ mod tests {
 		let svc_port = &svc_spec.ports.as_ref().unwrap()[0];
 		assert_eq!(svc_port.port, 80);
 		assert_eq!(svc_port.target_port, Some(IntOrString::Int(8000)));
+	}
+
+	#[rstest]
+	fn test_build_service_selects_web_component() {
+		// Arrange
+		let app = make_test_app("web", "web:v1", None);
+
+		// Act
+		let svc = build_service(&app, false).expect("build should succeed");
+
+		// Assert
+		let selector = svc.spec.unwrap().selector.expect("selector");
+		assert_eq!(
+			selector.get("app.kubernetes.io/name").map(String::as_str),
+			Some("web")
+		);
+		assert_eq!(
+			selector
+				.get("app.kubernetes.io/component")
+				.map(String::as_str),
+			Some("web")
+		);
 	}
 
 	#[rstest]


### PR DESCRIPTION
## Summary

This PR addresses:

- Narrows the operator-generated app `Service` selector to web pods by adding `app.kubernetes.io/component=web`.
- Adds a regression test so Redis and database pods cannot be selected by the app HTTP Service through the shared app name label alone.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

The dashboard self-deploy E2E reached `Ready=True`, but Service-level HTTP verification could fail because `svc/reinhardt-cloud-dashboard` selected web, Redis, and PostgreSQL pods. The Service selector only matched `app.kubernetes.io/name`, while all owned resources share that label.

Fixes #642

Related to: #638

## How Was This Tested?

- `cargo fmt --check`
- `cargo test -p reinhardt-cloud-operator resources::service --locked`
- `cargo check -p reinhardt-cloud-operator --locked`
- `DASHBOARD_SELF_DEPLOY_NAMESPACE=rcd-e2e-642 DASHBOARD_SELF_DEPLOY_KEEP_RESOURCES=1 DASHBOARD_SELF_DEPLOY_TIMEOUT=600s DASHBOARD_SELF_DEPLOY_BUILD_IMAGE=0 scripts/dashboard_self_deploy_e2e.sh`
- Verified `kubectl -n rcd-e2e-642 get endpoints reinhardt-cloud-dashboard` contains only the web pod endpoint.
- Verified Service-level port-forward to `svc/reinhardt-cloud-dashboard:80` returns `200` from `/api/healthz/` with `{"status":"ok","db":"ok","grpc":"ok"}`.

## Performance Impact

Not performance-related.

## Breaking Changes

None.

## Screenshots

Not UI-related.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #642
- Related to #638

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [x] `kubernetes` - Kubernetes resources, controllers, operators
- [x] `deployment` - Application deployment logic
- [x] `networking` - Ingress, services, network policies
- [ ] `storage` - Persistent volumes, storage classes
- [ ] `auth` - Authentication, authorization, RBAC
- [ ] `api` - REST API, serializers, handlers
- [ ] `cli` - Command-line interface
- [ ] `config` - Configuration management
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The self-deploy script still logs a `manage introspect` 30-second timeout and falls back to zero-config inference. That warning is separate from the Service selector bug fixed here.

Generated with Codex.
