### PR TITLE
fix(cli): require self-deploy introspection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6496,6 +6496,7 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2 0.10.9",
  "sqlx",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ rustls = { version = "0.23", default-features = false, features = ["ring"] }
 # Reinhardt — umbrella crate providing: HTTP server, auth (JWT + Argon2), database (SeaQuery),
 # configuration, DI container, middleware, OpenAPI, and management commands.
 # Direct hyper/jsonwebtoken/argon2/sea-query deps are NOT needed — reinhardt provides them.
-reinhardt = { package = "reinhardt-web", git = "https://github.com/kent8192/reinhardt-web", branch = "develop/0.2.0", features = ["database", "db-postgres", "auth", "auth-jwt", "argon2-hasher", "core", "conf", "server", "di", "middleware", "middleware-security", "middleware-auth-jwt", "rest", "openapi", "openapi-router", "commands", "test", "testcontainers", "pages", "websockets", "admin", "sessions", "session-redis", "mail", "client-router"] }
+reinhardt = { package = "reinhardt-web", git = "https://github.com/kent8192/reinhardt-web", branch = "develop/0.2.0", features = ["database", "db-postgres", "auth", "auth-jwt", "argon2-hasher", "core", "conf", "server", "di", "middleware", "middleware-security", "middleware-auth-jwt", "rest", "openapi", "openapi-router", "commands", "introspect", "test", "testcontainers", "pages", "websockets", "admin", "sessions", "session-redis", "mail", "client-router"] }
 
 # PostgreSQL driver (sea-query is available via reinhardt::prelude — no direct dep needed)
 tokio-postgres = { version = "0.7", features = ["with-serde_json-1"] }
@@ -103,4 +103,3 @@ reinhardt-test = { package = "reinhardt-test", git = "https://github.com/kent819
 
 [workspace.lints.clippy]
 module_name_repetitions = "allow"
-

--- a/crates/reinhardt-cloud-cli/src/commands/deploy.rs
+++ b/crates/reinhardt-cloud-cli/src/commands/deploy.rs
@@ -57,6 +57,14 @@ pub(crate) struct DeployArgs {
 	#[arg(long)]
 	pub introspect_only: bool,
 
+	/// Path to the project manage binary used for introspection
+	#[arg(long)]
+	pub manage_bin: Option<PathBuf>,
+
+	/// Fail deploy when manage introspect is unavailable instead of using zero-config fallback
+	#[arg(long)]
+	pub require_introspect: bool,
+
 	/// Kubernetes namespace
 	#[arg(long, default_value = "default")]
 	pub namespace: String,
@@ -222,12 +230,36 @@ fn parse_introspect_output(yaml: &str) -> Result<IntrospectOutput, String> {
 	serde_yaml::from_str(yaml).map_err(|e| format!("Failed to parse introspect YAML: {e}"))
 }
 
-fn manage_introspect_command(project_dir: &Path) -> Command {
-	let mut command = Command::new("manage");
+fn manage_introspect_command(manage_bin: &Path, project_dir: &Path) -> Command {
+	let mut command = Command::new(manage_bin);
 	command
 		.args(["introspect", "--format", "yaml"])
 		.current_dir(project_dir);
 	command
+}
+
+fn resolve_manage_bin_path(manage_bin: &Path) -> PathBuf {
+	if manage_bin.is_absolute() {
+		manage_bin.to_path_buf()
+	} else {
+		std::env::current_dir()
+			.unwrap_or_else(|_| PathBuf::from("."))
+			.join(manage_bin)
+	}
+}
+
+fn project_manage_bin(project_dir: &Path) -> Option<PathBuf> {
+	let candidate = project_dir.join("manage");
+	if !candidate.is_file() {
+		return None;
+	}
+	Some(candidate.canonicalize().unwrap_or(candidate))
+}
+
+fn path_manage_introspect_command(project_dir: &Path) -> Option<Command> {
+	project_manage_bin(project_dir)
+		.as_ref()
+		.map(|manage_bin| manage_introspect_command(manage_bin, project_dir))
 }
 
 fn cargo_manage_introspect_command(project_dir: &Path) -> Command {
@@ -258,6 +290,10 @@ fn introspect_timeout() -> Option<Duration> {
 	std::env::var(INTROSPECT_TIMEOUT_ENV)
 		.ok()
 		.and_then(|raw| parse_introspect_timeout_seconds(&raw))
+}
+
+fn should_fail_on_introspect_error(args: &DeployArgs) -> bool {
+	args.introspect_only || args.require_introspect
 }
 
 fn terminate_child(child: &mut std::process::Child) {
@@ -331,12 +367,38 @@ fn command_output_with_optional_timeout(
 ///
 /// Tries the production binary first, then falls back to
 /// `cargo run -- introspect --format yaml` for development mode.
-fn run_manage_introspect(project_dir: &Path) -> Result<String, String> {
+fn run_manage_introspect(project_dir: &Path, manage_bin: Option<&Path>) -> Result<String, String> {
 	let timeout = introspect_timeout();
 
-	// Try production binary first
+	if let Some(manage_bin) = manage_bin {
+		let manage_bin = resolve_manage_bin_path(manage_bin);
+		let output = command_output_with_optional_timeout(
+			manage_introspect_command(&manage_bin, project_dir),
+			"manage introspect",
+			timeout,
+		)?;
+		return if output.status.success() {
+			String::from_utf8(output.stdout)
+				.map_err(|e| format!("Invalid UTF-8 in manage output: {e}"))
+		} else {
+			let stderr = String::from_utf8_lossy(&output.stderr);
+			Err(format!("manage introspect failed: {stderr}"))
+		};
+	}
+
+	if let Some(command) = path_manage_introspect_command(project_dir) {
+		let output = command_output_with_optional_timeout(command, "manage introspect", timeout)?;
+		return if output.status.success() {
+			String::from_utf8(output.stdout)
+				.map_err(|e| format!("Invalid UTF-8 in manage output: {e}"))
+		} else {
+			let stderr = String::from_utf8_lossy(&output.stderr);
+			Err(format!("manage introspect failed: {stderr}"))
+		};
+	}
+
 	let result = command_output_with_optional_timeout(
-		manage_introspect_command(project_dir),
+		manage_introspect_command(Path::new("manage"), project_dir),
 		"manage introspect",
 		timeout,
 	);
@@ -562,7 +624,7 @@ async fn execute_inner(
 	let project_dir = args.dir.clone().unwrap_or_else(|| PathBuf::from("."));
 
 	// Step 1: Try to run manage introspect
-	let introspect = match run_manage_introspect(&project_dir) {
+	let introspect = match run_manage_introspect(&project_dir, args.manage_bin.as_deref()) {
 		Ok(yaml_output) => {
 			if args.introspect_only {
 				println!("{yaml_output}");
@@ -571,7 +633,7 @@ async fn execute_inner(
 			Some(parse_introspect_output(&yaml_output)?)
 		}
 		Err(e) => {
-			if args.introspect_only {
+			if should_fail_on_introspect_error(args) {
 				return Err(e.into());
 			}
 			eprintln!("Warning: manage introspect failed: {e}");
@@ -949,14 +1011,16 @@ features:
 	fn test_manage_introspect_commands_use_project_dir() {
 		// Arrange
 		let dir = tempfile::tempdir().unwrap();
+		let manage_bin = dir.path().join("custom-manage");
 
 		// Act
-		let manage = manage_introspect_command(dir.path());
+		let manage = manage_introspect_command(&manage_bin, dir.path());
 		let cargo = cargo_manage_introspect_command(dir.path());
 
 		// Assert
 		assert_eq!(manage.get_current_dir(), Some(dir.path()));
 		assert_eq!(cargo.get_current_dir(), Some(dir.path()));
+		assert_eq!(manage.get_program(), manage_bin.as_os_str());
 		let manage_args: Vec<String> = manage
 			.get_args()
 			.map(|arg| arg.to_string_lossy().into_owned())
@@ -978,6 +1042,98 @@ features:
 				"yaml"
 			]
 		);
+	}
+
+	#[rstest]
+	fn test_path_manage_introspect_command_prefers_project_manage_binary() {
+		// Arrange
+		let dir = tempfile::tempdir().unwrap();
+		let manage_bin = dir.path().join("manage");
+		std::fs::write(&manage_bin, "").unwrap();
+		let expected_manage_bin = manage_bin.canonicalize().unwrap();
+
+		// Act
+		let command = path_manage_introspect_command(dir.path())
+			.expect("project manage binary should be detected");
+
+		// Assert
+		assert_eq!(command.get_current_dir(), Some(dir.path()));
+		assert_eq!(command.get_program(), expected_manage_bin.as_os_str());
+		let args: Vec<String> = command
+			.get_args()
+			.map(|arg| arg.to_string_lossy().into_owned())
+			.collect();
+		assert_eq!(args, vec!["introspect", "--format", "yaml"]);
+	}
+
+	#[rstest]
+	fn test_path_manage_introspect_command_absent_without_project_manage_binary() {
+		// Arrange
+		let dir = tempfile::tempdir().unwrap();
+
+		// Act
+		let command = path_manage_introspect_command(dir.path());
+
+		// Assert
+		assert!(command.is_none());
+	}
+
+	#[rstest]
+	fn test_resolve_manage_bin_path_absolutizes_relative_paths() {
+		// Arrange
+		let manage_bin = Path::new("target/debug/manage");
+
+		// Act
+		let resolved = resolve_manage_bin_path(manage_bin);
+
+		// Assert
+		assert!(resolved.is_absolute());
+		assert!(resolved.ends_with(manage_bin));
+	}
+
+	#[rstest]
+	fn test_resolve_manage_bin_path_preserves_absolute_paths() {
+		// Arrange
+		let manage_bin = Path::new("/tmp/reinhardt-cloud-manage");
+
+		// Act
+		let resolved = resolve_manage_bin_path(manage_bin);
+
+		// Assert
+		assert_eq!(resolved, manage_bin);
+	}
+
+	#[rstest]
+	#[case::regular_deploy(false, false, false)]
+	#[case::introspect_only(true, false, true)]
+	#[case::require_introspect(false, true, true)]
+	#[case::both(true, true, true)]
+	fn test_should_fail_on_introspect_error(
+		#[case] introspect_only: bool,
+		#[case] require_introspect: bool,
+		#[case] expected: bool,
+	) {
+		// Arrange
+		let args = DeployArgs {
+			name: None,
+			image: None,
+			replicas: None,
+			dir: None,
+			dry_run: false,
+			direct: false,
+			introspect_only,
+			manage_bin: None,
+			require_introspect,
+			namespace: "default".to_string(),
+			cluster: None,
+			api_version: None,
+		};
+
+		// Act
+		let actual = should_fail_on_introspect_error(&args);
+
+		// Assert
+		assert_eq!(actual, expected);
 	}
 
 	#[rstest]

--- a/docs/development/LOCAL_E2E_TESTING.md
+++ b/docs/development/LOCAL_E2E_TESTING.md
@@ -51,10 +51,10 @@ cargo make dashboard-self-deploy-e2e
 The task builds or selects the Dashboard image, applies the `ReinhardtApp`
 CRD, creates a temporary namespace and runtime Secret, starts a local Operator
 when no in-cluster Operator is already installed, generates the Dashboard
-`ReinhardtApp` with `reinhardt-cloud deploy --dir dashboard --dry-run`, applies
-the same contract through `--direct`, waits for the Operator-owned Deployment,
-Service, cache/database resources, Pods, and live `ReinhardtApp`, then removes
-the temporary namespace.
+`ReinhardtApp` with `reinhardt-cloud deploy --dir dashboard --dry-run`, requires
+Dashboard `manage introspect` to succeed, applies the same contract through
+`--direct`, waits for the Operator-owned Deployment, Service, cache/database
+resources, Pods, and live `ReinhardtApp`, then removes the temporary namespace.
 
 Useful overrides:
 
@@ -67,8 +67,10 @@ Useful overrides:
 | `DASHBOARD_SELF_DEPLOY_OPERATOR_METRICS_ADDR` | `127.0.0.1:19090` | Metrics/health bind address for the local Operator process. |
 | `DASHBOARD_SELF_DEPLOY_OPERATOR_BIN` | `target/debug/reinhardt-cloud-operator` | Override the local Operator binary path. |
 | `DASHBOARD_SELF_DEPLOY_CLI_BIN` | `target/debug/reinhardt-cloud` | Override the local CLI binary path. |
+| `DASHBOARD_SELF_DEPLOY_MANAGE_BIN` | `target/debug/manage` | Override the Dashboard `manage` binary used for strict introspection. |
+| `DASHBOARD_SELF_DEPLOY_REINHARDT_ENV` | `ci` | `REINHARDT_ENV` used by local Dashboard `manage introspect`. |
 | `DASHBOARD_SELF_DEPLOY_KEEP_RESOURCES` | `0` | Set to `1` to keep the namespace after the run. |
-| `DASHBOARD_SELF_DEPLOY_INTROSPECT_TIMEOUT_SECONDS` | `30` | Timeout for each CLI `manage introspect` attempt before zero-config fallback. |
+| `DASHBOARD_SELF_DEPLOY_INTROSPECT_TIMEOUT_SECONDS` | `30` | Timeout for each CLI `manage introspect` attempt. The harness fails instead of using zero-config fallback. |
 | `DASHBOARD_SELF_DEPLOY_ARTIFACT_DIR` | `target/dashboard-self-deploy-e2e/<namespace>` | Failure diagnostics and generated YAML. |
 | `DASHBOARD_SELF_DEPLOY_KUBECTL_CONTEXT` | current context | Kubernetes context for `kubectl`. |
 | `DASHBOARD_SELF_DEPLOY_KIND_CLUSTER` | inferred from `kind-*` context | Explicit `kind load docker-image` target. |

--- a/docs/tools/cli.md
+++ b/docs/tools/cli.md
@@ -232,6 +232,7 @@ Build a `ReinhardtApp` CRD from `reinhardt-cloud.toml` and apply it.
 ```
 reinhardt-cloud deploy [--name <NAME>] [--image <IMAGE>] [--replicas <N>]
                        [--dir <PATH>] [--namespace <NS>] [--cluster <NAME>]
+                       [--manage-bin <PATH>] [--require-introspect]
                        [--dry-run] [--direct] [--introspect-only]
 ```
 
@@ -248,6 +249,8 @@ reinhardt-cloud deploy [--name <NAME>] [--image <IMAGE>] [--replicas <N>]
 | `--dry-run` | — | no | `false` | Print the generated CRD YAML to stdout without applying. |
 | `--direct` | — | no | `false` | Skip the platform API; apply the CRD directly via `kubectl apply`. |
 | `--introspect-only` | — | no | `false` | Run `manage introspect --format yaml`, print the output, and exit without deploying. |
+| `--manage-bin <PATH>` | — | no | — | Use a specific project `manage` binary for introspection instead of PATH or `cargo run` discovery. |
+| `--require-introspect` | — | no | `false` | Fail deploy when `manage introspect` fails instead of continuing with zero-config inference. Useful for CI and self-deploy contract checks. |
 | `--api-version <GROUP/VERSION>` | — | no | Served CRD storage version for `--direct`; compile-time default otherwise | Override the generated manifest `apiVersion`. Must be fully qualified, for example `paas.reinhardt-cloud.dev/v1alpha2`. |
 
 \* `--name` and `--image` are required at runtime if they cannot be resolved from `manage introspect` output or `reinhardt-cloud.toml` (see resolution order below).
@@ -258,6 +261,8 @@ reinhardt-cloud deploy [--name <NAME>] [--image <IMAGE>] [--replicas <N>]
 2. `manage introspect --format yaml` output (`IntrospectOutput`)
 3. `reinhardt-cloud.toml` (`ReinhardtCloudToml`)
 4. Built-in default: `replicas = 1`
+
+For introspection, `deploy` uses `--manage-bin` when provided, then a `manage` binary in the project directory, then `manage` on `PATH`, and finally `cargo run --bin manage -- introspect --format yaml` for development checkouts. Pass `--require-introspect` when a fallback manifest would hide a broken management command.
 
 When `reinhardt-cloud.toml` is present, `deploy` converts its typed sections into the generated `ReinhardtAppSpec` before applying CLI overrides. That includes `database`, `auth`, `health`, `services`, `replicas`, `scale`, `cache`, `worker`, `storage`, `mail`, `source`, `infrastructure`, and `env`. `--name`, `--image`, and `--replicas` still override the corresponding TOML-derived values.
 
@@ -313,7 +318,7 @@ The `crd` command reference (covered in a later section of this guide) explains 
 - **`failed to run kubectl (is it installed?): ...`** — `--direct` was used but `kubectl` is not on `PATH`. Install `kubectl` and ensure it is accessible.
 - **`kubectl apply failed: ...`** — The apply was rejected by the API server. Common causes: the `ReinhardtApp` CRD is not installed in the cluster (`kubectl apply -f charts/reinhardt-cloud-operator/crds/`), the namespace does not exist, or the resource spec violates a validation rule. Inspect the `kubectl` error message for the specific field that failed.
 - **`failed to deploy via API: ...`** — The platform API returned an error or was unreachable. Check that `REINHARDT_CLOUD_API_URL` is set correctly and the Dashboard server is running. The default is `http://localhost:8000`.
-- **`manage introspect failed: ...` warning, then deploy continues** — `deploy` treats introspect failure as non-fatal. If the deploy then fails with `--name is required`, run `reinhardt-cloud deploy --introspect-only` to diagnose the introspect error separately before retrying.
+- **`manage introspect failed: ...` warning, then deploy continues** — `deploy` treats introspect failure as non-fatal unless `--require-introspect` is set. If the deploy then fails with `--name is required`, run `reinhardt-cloud deploy --introspect-only` to diagnose the introspect error separately before retrying. In CI, pass `--require-introspect` so fallback manifests cannot mask a broken management command.
 - **`replicas value N exceeds i32::MAX`** — The `--replicas` value is larger than `2147483647`. Use a sane replica count.
 
 ---
@@ -814,7 +819,7 @@ This table lists all flags accepted by each command.
 |---------|-------|
 | `init` | `--dir`, `--force` |
 | `sync` | `--dir`, `--force` |
-| `deploy` | `--name`, `--image`, `--replicas`, `--dir`, `--namespace`, `--cluster`, `--dry-run`, `--direct`, `--introspect-only` |
+| `deploy` | `--name`, `--image`, `--replicas`, `--dir`, `--namespace`, `--cluster`, `--dry-run`, `--direct`, `--introspect-only`, `--manage-bin`, `--require-introspect` |
 | `status` | `--name`, `--namespace`, `--cluster` |
 | `login` | `--username` |
 | `terraform generate` | `--app`, `--provider`, `--output`, `--app-crd` |

--- a/scripts/dashboard_self_deploy_e2e.sh
+++ b/scripts/dashboard_self_deploy_e2e.sh
@@ -16,6 +16,8 @@ OPERATOR_MODE="${DASHBOARD_SELF_DEPLOY_OPERATOR_MODE:-auto}"
 OPERATOR_METRICS_ADDR="${DASHBOARD_SELF_DEPLOY_OPERATOR_METRICS_ADDR:-127.0.0.1:19090}"
 OPERATOR_BIN="${DASHBOARD_SELF_DEPLOY_OPERATOR_BIN:-${ROOT_DIR}/target/debug/reinhardt-cloud-operator}"
 CLI_BIN="${DASHBOARD_SELF_DEPLOY_CLI_BIN:-${ROOT_DIR}/target/debug/reinhardt-cloud}"
+MANAGE_BIN="${DASHBOARD_SELF_DEPLOY_MANAGE_BIN:-${ROOT_DIR}/target/debug/manage}"
+MANAGE_ENV="${DASHBOARD_SELF_DEPLOY_REINHARDT_ENV:-${REINHARDT_ENV:-ci}}"
 RUNTIME_SECRET="${DASHBOARD_SELF_DEPLOY_RUNTIME_SECRET:-reinhardt-cloud-dashboard-secrets}"
 KUBECTL_CONTEXT="${DASHBOARD_SELF_DEPLOY_KUBECTL_CONTEXT:-}"
 KIND_CLUSTER="${DASHBOARD_SELF_DEPLOY_KIND_CLUSTER:-}"
@@ -185,11 +187,18 @@ build_dashboard_image() {
 
 build_local_binaries() {
 	local packages=()
+	local build_manage=0
 
 	if [[ -z "${DASHBOARD_SELF_DEPLOY_CLI_BIN:-}" ]]; then
 		packages+=(-p reinhardt-cloud-cli)
 	else
 		log "using CLI binary ${CLI_BIN}"
+	fi
+
+	if [[ -z "${DASHBOARD_SELF_DEPLOY_MANAGE_BIN:-}" ]]; then
+		build_manage=1
+	else
+		log "using dashboard manage binary ${MANAGE_BIN}"
 	fi
 
 	if [[ -z "${DASHBOARD_SELF_DEPLOY_OPERATOR_BIN:-}" && "${OPERATOR_MODE}" != "existing" && "${OPERATOR_MODE}" != "skip" ]]; then
@@ -198,15 +207,21 @@ build_local_binaries() {
 		log "using operator binary ${OPERATOR_BIN}"
 	fi
 
-	if [[ "${#packages[@]}" -eq 0 ]]; then
-		return
+	if [[ "${#packages[@]}" -ne 0 ]]; then
+		log "building local cloud binaries"
+		(
+			cd "${ROOT_DIR}"
+			cargo build --locked "${packages[@]}"
+		)
 	fi
 
-	log "building local binaries"
-	(
-		cd "${ROOT_DIR}"
-		cargo build --locked "${packages[@]}"
-	)
+	if [[ "${build_manage}" == "1" ]]; then
+		log "building dashboard manage binary"
+		(
+			cd "${ROOT_DIR}"
+			cargo build --locked -p reinhardt-cloud-dashboard --bin manage
+		)
+	fi
 }
 
 operator_deployment_exists() {
@@ -259,11 +274,14 @@ generate_reinhardt_app_yaml() {
 	log "generating dry-run ReinhardtApp YAML"
 	(
 		cd "${ROOT_DIR}"
+		export REINHARDT_ENV="${MANAGE_ENV}"
 		"${CLI_BIN}" deploy \
 			--dir "${PROJECT_DIR}" \
 			--name "${APP_NAME}" \
 			--image "${IMAGE}" \
 			--namespace "${NAMESPACE}" \
+			--manage-bin "${MANAGE_BIN}" \
+			--require-introspect \
 			--dry-run
 	) >"${DRY_RUN_YAML}"
 
@@ -274,11 +292,14 @@ apply_reinhardt_app_direct() {
 	log "applying ReinhardtApp through the CLI --direct path"
 	(
 		cd "${ROOT_DIR}"
+		export REINHARDT_ENV="${MANAGE_ENV}"
 		"${CLI_BIN}" deploy \
 			--dir "${PROJECT_DIR}" \
 			--name "${APP_NAME}" \
 			--image "${IMAGE}" \
 			--namespace "${NAMESPACE}" \
+			--manage-bin "${MANAGE_BIN}" \
+			--require-introspect \
 			"${cli_cluster_args[@]}" \
 			--direct
 	)
@@ -379,6 +400,7 @@ main() {
 	log "namespace=${NAMESPACE}"
 	log "app=${APP_NAME}"
 	log "image=${IMAGE}"
+	log "manage-env=${MANAGE_ENV}"
 	log "artifacts=${ARTIFACT_DIR}"
 	export REINHARDT_CLOUD_DEPLOY_INTROSPECT_TIMEOUT_SECONDS="${INTROSPECT_TIMEOUT_SECONDS}"
 


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds strict deploy introspection mode for contract tests.
- Lets `deploy` use an explicit project `manage` binary.
- Updates the Dashboard self-deploy harness to build and use the real Dashboard `manage introspect` path.
- Enables Reinhardt's `introspect` feature so the Dashboard `manage` binary registers the subcommand.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

Dashboard self-deploy E2E could pass through zero-config inference when `manage introspect` timed out or failed. That made the harness validate a fallback manifest rather than the real dashboard configuration-to-deployment contract.

Fixes #644

Related to: #642

## How Was This Tested?

- `cargo fmt --check`
- `cargo test -p reinhardt-cloud-cli commands::deploy --locked`
- `cargo check -p reinhardt-cloud-cli --locked`
- `cargo build --locked -p reinhardt-cloud-dashboard --bin manage`
- Strict dashboard dry-run with `REINHARDT_ENV=ci`, `--manage-bin target/debug/manage`, and `--require-introspect`
- `DASHBOARD_SELF_DEPLOY_NAMESPACE=rcd-e2e-644-fix DASHBOARD_SELF_DEPLOY_TIMEOUT=600s cargo make dashboard-self-deploy-e2e`

## Performance Impact

Not performance-related.

## Breaking Changes

None.

## Screenshots

Not UI-related.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

<!-- ⚠️ CI CONTROL CHECKBOX - DO NOT EDIT MANUALLY ⚠️
The following checkbox controls CI runner selection.
Checking this option triggers self-hosted runner usage,
which incurs infrastructure costs. Only the repository owner should enable this.
If this checkbox is missing or unchecked, CI defaults to GitHub-hosted runners.
Do NOT modify the checkbox text — CI parses it by exact pattern match. -->
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #644
- Related to #642

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [ ] `kubernetes` - Kubernetes resources, controllers, operators
- [x] `deployment` - Application deployment logic
- [ ] `networking` - Ingress, services, network policies
- [ ] `storage` - Persistent volumes, storage classes
- [ ] `auth` - Authentication, authorization, RBAC
- [ ] `api` - REST API, serializers, handlers
- [x] `cli` - Command-line interface
- [x] `config` - Configuration management
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

GitWhy context: `ctx_777c4276`

Generated with Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--manage-bin` flag to deploy command for specifying a custom manage binary path
  * Added `--require-introspect` flag to fail deployment when introspection fails instead of using inference fallback

* **Documentation**
  * Updated deploy command documentation with new introspection options
  * Updated E2E testing documentation to reflect required manage introspection behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->