### PR TITLE
chore(deps): update reinhardt-web lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,39 +68,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "aligned"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
-dependencies = [
- "as-slice",
-]
-
-[[package]]
-name = "aligned-vec"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
-dependencies = [
- "equator",
-]
-
-[[package]]
-name = "alloc-no-stdlib"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
-dependencies = [
- "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -270,15 +231,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-dependencies = [
- "derive_arbitrary",
-]
-
-[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,17 +244,6 @@ name = "arcstr"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
-
-[[package]]
-name = "arg_enum_proc_macro"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "argon2"
@@ -321,15 +262,6 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
-name = "as-slice"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
-dependencies = [
- "stable_deref_trait",
-]
 
 [[package]]
 name = "asn1-rs"
@@ -633,49 +565,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "av-scenechange"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
-dependencies = [
- "aligned",
- "anyhow",
- "arg_enum_proc_macro",
- "arrayvec",
- "log",
- "num-rational",
- "num-traits",
- "pastey",
- "rayon",
- "thiserror 2.0.18",
- "v_frame",
- "y4m",
-]
-
-[[package]]
-name = "av1-grain"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
-dependencies = [
- "anyhow",
- "arrayvec",
- "log",
- "nom 8.0.0",
- "num-rational",
- "v_frame",
-]
-
-[[package]]
-name = "avif-serialize"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
-dependencies = [
- "arrayvec",
-]
-
-[[package]]
 name = "aws-lc-rs"
 version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -800,15 +689,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -824,33 +704,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
-name = "bit_field"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "bitstream-io"
-version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
-dependencies = [
- "core2",
 ]
 
 [[package]]
@@ -922,7 +781,7 @@ checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
- "bitflags 2.11.0",
+ "bitflags",
  "bollard-buildkit-proto",
  "bollard-stubs",
  "bytes",
@@ -1038,27 +897,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "brotli"
-version = "8.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
-]
-
-[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,12 +905,6 @@ dependencies = [
  "memchr",
  "serde",
 ]
-
-[[package]]
-name = "built"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
 
 [[package]]
 name = "bumpalo"
@@ -1103,61 +935,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "bytemuck"
-version = "1.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
-
-[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
-name = "byteorder-lite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
-
-[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
-name = "camino"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
-dependencies = [
- "serde",
- "serde_core",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
-]
 
 [[package]]
 name = "cast"
@@ -1348,12 +1135,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "color_quant"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
-
-[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1365,7 +1146,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1496,15 +1277,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1542,15 +1314,6 @@ name = "crc16"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
-
-[[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "critical-section"
@@ -1591,12 +1354,6 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -1861,17 +1618,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1961,7 +1707,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2191,26 +1937,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "equator"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
-dependencies = [
- "equator-macro",
-]
-
-[[package]]
-name = "equator-macro"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2223,7 +1949,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2287,21 +2013,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "exr"
-version = "1.74.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
-dependencies = [
- "bit_field",
- "half",
- "lebe",
- "miniz_oxide",
- "rayon-core",
- "smallvec",
- "zune-inflate",
-]
-
-[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2312,35 +2023,6 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
-name = "fax"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
-dependencies = [
- "fax_derive",
-]
-
-[[package]]
-name = "fax_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "fdeflate"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
-dependencies = [
- "simd-adler32",
-]
 
 [[package]]
 name = "ferroid"
@@ -2391,17 +2073,6 @@ name = "flagset"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
-
-[[package]]
-name = "flate2"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
- "zlib-rs",
-]
 
 [[package]]
 name = "flume"
@@ -2480,15 +2151,6 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
-name = "fsevent-sys"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "funty"
@@ -2699,16 +2361,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gif"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
-dependencies = [
- "color_quant",
- "weezl",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2733,7 +2385,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "ignore",
  "walkdir",
 ]
@@ -2778,17 +2430,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
-]
-
-[[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "zerocopy",
 ]
 
 [[package]]
@@ -3266,46 +2907,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "image"
-version = "0.25.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
-dependencies = [
- "bytemuck",
- "byteorder-lite",
- "color_quant",
- "exr",
- "gif",
- "image-webp",
- "moxcms",
- "num-traits",
- "png",
- "qoi",
- "ravif",
- "rayon",
- "rgb",
- "tiff",
- "zune-core",
- "zune-jpeg",
-]
-
-[[package]]
-name = "image-webp"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
-dependencies = [
- "byteorder-lite",
- "quick-error 2.0.1",
-]
-
-[[package]]
-name = "imgref"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
-
-[[package]]
 name = "include_dir"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3361,26 +2962,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inotify"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
-dependencies = [
- "bitflags 2.11.0",
- "inotify-sys",
- "libc",
-]
-
-[[package]]
-name = "inotify-sys"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3388,17 +2969,6 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array",
-]
-
-[[package]]
-name = "interpolate_name"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -3636,26 +3206,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kqueue"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
-dependencies = [
- "kqueue-sys",
- "libc",
-]
-
-[[package]]
-name = "kqueue-sys"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
-]
-
-[[package]]
 name = "kube"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3798,12 +3348,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
-name = "lebe"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
-
-[[package]]
 name = "lettre"
 version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3840,16 +3384,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
-name = "libfuzzer-sys"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
-dependencies = [
- "arbitrary",
- "cc",
-]
-
-[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3861,7 +3395,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "libc",
  "plain",
  "redox_syscall 0.7.4",
@@ -3938,15 +3472,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "loop9"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
-dependencies = [
- "imgref",
-]
-
-[[package]]
 name = "lru-cache"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3981,16 +3506,6 @@ name = "matchit"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8863b587001c1b9a8a4e36008cebc6b3612cb1226fe2de94858e06092687b608"
-
-[[package]]
-name = "maybe-rayon"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
-dependencies = [
- "cfg-if",
- "rayon",
-]
 
 [[package]]
 name = "md-5"
@@ -4061,23 +3576,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
- "simd-adler32",
-]
-
-[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
- "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
@@ -4106,16 +3610,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "moxcms"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
-dependencies = [
- "num-traits",
- "pxfm",
 ]
 
 [[package]]
@@ -4159,18 +3653,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -4196,45 +3684,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "noop_proc_macro"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
-
-[[package]]
-name = "notify"
-version = "8.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
-dependencies = [
- "bitflags 2.11.0",
- "fsevent-sys",
- "inotify",
- "kqueue",
- "libc",
- "log",
- "mio",
- "notify-types",
- "walkdir",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "notify-types"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
-dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4293,17 +3748,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4360,7 +3804,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -4400,28 +3844,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d11de466f4a3006fe8a5e7ec84e93b79c70cb992ae0aa0eb631ad2df8abfe2"
 
 [[package]]
-name = "onig"
-version = "6.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
-dependencies = [
- "bitflags 2.11.0",
- "libc",
- "once_cell",
- "onig_sys",
-]
-
-[[package]]
-name = "onig_sys"
-version = "69.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
 name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4439,7 +3861,7 @@ version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -4688,12 +4110,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pastey"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "pbkdf2"
@@ -5014,32 +4430,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
-name = "plist"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
-dependencies = [
- "base64 0.22.1",
- "indexmap 2.14.0",
- "quick-xml",
- "serde",
- "time",
-]
-
-[[package]]
-name = "png"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
-dependencies = [
- "bitflags 2.11.0",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
-]
-
-[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5267,25 +4657,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "profiling"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
-dependencies = [
- "profiling-procmacros",
-]
-
-[[package]]
-name = "profiling-procmacros"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
-dependencies = [
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "prometheus"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5308,7 +4679,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.0",
+ "bitflags",
  "num-traits",
  "rand 0.9.3",
  "rand_chacha 0.9.0",
@@ -5486,7 +4857,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "memchr",
  "unicase",
 ]
@@ -5501,31 +4872,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pxfm"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
-
-[[package]]
-name = "qoi"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
-name = "quick-error"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -5712,56 +5062,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rav1e"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
-dependencies = [
- "aligned-vec",
- "arbitrary",
- "arg_enum_proc_macro",
- "arrayvec",
- "av-scenechange",
- "av1-grain",
- "bitstream-io",
- "built",
- "cfg-if",
- "interpolate_name",
- "itertools 0.14.0",
- "libc",
- "libfuzzer-sys",
- "log",
- "maybe-rayon",
- "new_debug_unreachable",
- "noop_proc_macro",
- "num-derive",
- "num-traits",
- "paste",
- "profiling",
- "rand 0.9.3",
- "rand_chacha 0.9.0",
- "simd_helpers",
- "thiserror 2.0.18",
- "v_frame",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "ravif"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
-dependencies = [
- "avif-serialize",
- "imgref",
- "loop9",
- "quick-error 2.0.1",
- "rav1e",
- "rayon",
- "rgb",
-]
-
-[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5891,7 +5191,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -5900,7 +5200,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -6029,8 +5329,8 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reinhardt-admin"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6080,16 +5380,14 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-apps"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "anyhow",
  "async-trait",
- "brotli",
  "bytes",
  "cfg_aliases",
  "chrono",
- "flate2",
  "futures",
  "http-body-util",
  "hyper",
@@ -6112,8 +5410,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-auth"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "argon2",
  "async-trait",
@@ -6159,8 +5457,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-auth-macros"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6270,6 +5568,8 @@ dependencies = [
  "reinhardt-cloud-k8s",
  "reinhardt-cloud-proto",
  "reinhardt-cloud-types",
+ "reinhardt-commands",
+ "reinhardt-utils",
  "reinhardt-web",
  "reqwest 0.12.28",
  "rstest",
@@ -6451,11 +5751,10 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-commands"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "async-trait",
- "cargo_metadata",
  "chrono",
  "clap",
  "colored",
@@ -6468,7 +5767,6 @@ dependencies = [
  "hyper-util",
  "inventory",
  "nix",
- "notify",
  "prettyplease",
  "proc-macro2",
  "quote",
@@ -6508,8 +5806,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-conf"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -6536,25 +5834,22 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-core"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "anyhow",
  "aquamarine 0.6.0",
  "async-trait",
  "base64 0.22.1",
- "brotli",
  "bytes",
  "cfg_aliases",
  "chrono",
- "flate2",
  "futures-util",
  "getrandom 0.3.4",
  "hex",
  "hmac 0.12.1",
  "http",
  "hyper",
- "image",
  "inventory",
  "ipnet",
  "mime",
@@ -6585,8 +5880,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-db"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -6599,9 +5894,7 @@ dependencies = [
  "console",
  "dashmap",
  "dialoguer",
- "flate2",
  "futures",
- "image",
  "indexmap 2.14.0",
  "indicatif",
  "lazy_static",
@@ -6640,8 +5933,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-di"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6664,8 +5957,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-di-macros"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6675,8 +5968,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-forms"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "anyhow",
  "aquamarine 0.5.0",
@@ -6692,8 +5985,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-http"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6713,8 +6006,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-macros"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "ctor 0.8.0",
  "inventory",
@@ -6727,8 +6020,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-mail"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6748,8 +6041,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-manouche"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "aquamarine 0.6.0",
  "convert_case",
@@ -6761,16 +6054,14 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-middleware"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
- "brotli",
  "bytes",
  "chrono",
  "colored",
- "flate2",
  "hex",
  "httpdate",
  "hyper",
@@ -6784,7 +6075,6 @@ dependencies = [
  "reinhardt-core",
  "reinhardt-di",
  "reinhardt-http",
- "reinhardt-mail",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -6797,8 +6087,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-openapi"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "async-trait",
  "reinhardt-http",
@@ -6809,8 +6099,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-openapi-macros"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6820,8 +6110,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-pages"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "aquamarine 0.5.0",
  "async-trait",
@@ -6863,8 +6153,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-pages-ast"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "aquamarine 0.6.0",
  "convert_case",
@@ -6877,8 +6167,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-pages-macros"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "convert_case",
  "darling 0.20.11",
@@ -6891,8 +6181,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-query"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -6905,8 +6195,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-query-macros"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -6916,8 +6206,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-rest"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6961,19 +6251,18 @@ dependencies = [
  "typed-arena",
  "urlencoding",
  "utoipa",
- "utoipa-swagger-ui",
  "uuid",
 ]
 
 [[package]]
 name = "reinhardt-router"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 
 [[package]]
 name = "reinhardt-routers-macros"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6982,8 +6271,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-server"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7003,8 +6292,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-shortcuts"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "bytes",
  "hyper",
@@ -7021,8 +6310,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-test"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "cfg_aliases",
  "reinhardt-auth",
@@ -7041,8 +6330,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-testkit"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "astral-tokio-tar",
  "async-dropper",
@@ -7098,8 +6387,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-testkit-macros"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7108,8 +6397,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-throttling"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -7119,8 +6408,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-urls"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -7135,7 +6424,6 @@ dependencies = [
  "once_cell",
  "regex",
  "reinhardt-core",
- "reinhardt-db",
  "reinhardt-di",
  "reinhardt-http",
  "reinhardt-middleware",
@@ -7154,17 +6442,15 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-utils"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
- "brotli",
  "bytes",
  "chrono",
  "chrono-tz 0.10.4",
- "flate2",
  "futures",
  "glob",
  "hex",
@@ -7192,8 +6478,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-views"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7217,7 +6503,6 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sqlx",
- "syntect",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7228,8 +6513,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-web"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7260,7 +6545,6 @@ dependencies = [
  "reinhardt-shortcuts",
  "reinhardt-test",
  "reinhardt-urls",
- "reinhardt-utils",
  "reinhardt-views",
  "reinhardt-websockets",
  "thiserror 2.0.18",
@@ -7270,8 +6554,8 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-websockets"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#a0da074caf478af055aff9b30274defe9cda58f3"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7398,12 +6682,6 @@ dependencies = [
  "hmac 0.12.1",
  "subtle",
 ]
-
-[[package]]
-name = "rgb"
-version = "0.8.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
 name = "ring"
@@ -7618,11 +6896,11 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7705,7 +6983,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7739,7 +7017,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
 dependencies = [
  "fnv",
- "quick-error 1.2.3",
+ "quick-error",
  "tempfile",
  "wait-timeout",
 ]
@@ -7881,7 +7159,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -7903,10 +7181,6 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-dependencies = [
- "serde",
- "serde_core",
-]
 
 [[package]]
 name = "serde"
@@ -8198,21 +7472,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simd-adler32"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
-
-[[package]]
-name = "simd_helpers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
-dependencies = [
- "quote",
-]
-
-[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8416,7 +7675,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.11.0",
+ "bitflags",
  "byteorder",
  "bytes",
  "chrono",
@@ -8461,7 +7720,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.11.0",
+ "bitflags",
  "byteorder",
  "chrono",
  "crc",
@@ -8635,33 +7894,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "syntect"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
-dependencies = [
- "bincode",
- "flate2",
- "fnv",
- "once_cell",
- "onig",
- "plist",
- "regex-syntax 0.8.10",
- "serde",
- "serde_derive",
- "serde_json",
- "thiserror 2.0.18",
- "walkdir",
- "yaml-rust",
-]
-
-[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -8706,7 +7944,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8824,20 +8062,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "tiff"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
-dependencies = [
- "fax",
- "flate2",
- "half",
- "quick-error 2.0.1",
- "weezl",
- "zune-jpeg",
 ]
 
 [[package]]
@@ -9310,7 +8534,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "base64 0.22.1",
- "bitflags 2.11.0",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
@@ -9668,29 +8892,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utoipa-swagger-ui"
-version = "9.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
-dependencies = [
- "base64 0.22.1",
- "mime_guess",
- "regex",
- "rust-embed",
- "serde",
- "serde_json",
- "utoipa",
- "utoipa-swagger-ui-vendored",
- "zip",
-]
-
-[[package]]
-name = "utoipa-swagger-ui-vendored"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
-
-[[package]]
 name = "uuid"
 version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9700,17 +8901,6 @@ dependencies = [
  "js-sys",
  "serde_core",
  "sha1_smol",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "v_frame"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
-dependencies = [
- "aligned-vec",
- "num-traits",
  "wasm-bindgen",
 ]
 
@@ -9937,7 +9127,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -9991,12 +9181,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "weezl"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
-
-[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10041,7 +9225,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10158,15 +9342,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -10213,28 +9388,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -10256,12 +9414,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10278,12 +9430,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -10304,22 +9450,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -10340,12 +9474,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10362,12 +9490,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -10388,12 +9510,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10410,12 +9526,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -10516,7 +9626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags",
  "indexmap 2.14.0",
  "log",
  "serde",
@@ -10605,21 +9715,6 @@ name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
-
-[[package]]
-name = "y4m"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
-]
 
 [[package]]
 name = "yasna"
@@ -10748,63 +9843,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "zip"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
-dependencies = [
- "arbitrary",
- "crc32fast",
- "flate2",
- "indexmap 2.14.0",
- "memchr",
- "zopfli",
-]
-
-[[package]]
-name = "zlib-rs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
-
-[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zopfli"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
-dependencies = [
- "bumpalo",
- "crc32fast",
- "log",
- "simd-adler32",
-]
-
-[[package]]
-name = "zune-core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
-
-[[package]]
-name = "zune-inflate"
-version = "0.2.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
-dependencies = [
- "simd-adler32",
-]
-
-[[package]]
-name = "zune-jpeg"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
-dependencies = [
- "zune-core",
-]

--- a/dashboard/Cargo.toml
+++ b/dashboard/Cargo.toml
@@ -38,6 +38,12 @@ reinhardt = { workspace = true }
 # Direct dependency on reinhardt-auth so we can enable the `social` feature,
 # which is not exposed through the reinhardt meta-crate's auth-* features.
 reinhardt-auth = { package = "reinhardt-auth", git = "https://github.com/kent8192/reinhardt-web", branch = "develop/0.2.0", features = ["social"] }
+# Runserver hook types live behind the command crate's server feature.
+reinhardt-commands = { package = "reinhardt-commands", git = "https://github.com/kent8192/reinhardt-web", branch = "develop/0.2.0", default-features = false, features = ["server"] }
+# Static resolver configuration is provided by reinhardt-utils; enabling the
+# umbrella crate's static-files feature would make deploy fallback infer
+# managed object storage for this local dashboard asset path.
+reinhardt-utils = { package = "reinhardt-utils", git = "https://github.com/kent8192/reinhardt-web", branch = "develop/0.2.0", default-features = false, features = ["staticfiles"] }
 reinhardt-cloud-types = { workspace = true }
 reinhardt-cloud-core = { workspace = true }
 reinhardt-cloud-k8s = { workspace = true }

--- a/dashboard/src/config/hooks.rs
+++ b/dashboard/src/config/hooks.rs
@@ -9,8 +9,8 @@
 use std::error::Error;
 
 use async_trait::async_trait;
-use reinhardt::commands::{RunserverContext, RunserverHook, RunserverHookRegistration};
 use reinhardt_cloud_grpc::config::GrpcServerConfig;
+use reinhardt_commands::{RunserverContext, RunserverHook, RunserverHookRegistration};
 
 use super::grpc::start_grpc_server;
 use super::settings::get_redis_url;

--- a/dashboard/src/config/urls.rs
+++ b/dashboard/src/config/urls.rs
@@ -236,7 +236,7 @@ pub async fn routes(
 #[cfg(native)]
 fn initialize_dashboard_static_resolver() {
 	reinhardt::pages::init_static_resolver(
-		reinhardt::utils::staticfiles::TemplateStaticConfig::new(
+		reinhardt_utils::staticfiles::TemplateStaticConfig::new(
 			DASHBOARD_STATIC_URL_PREFIX.to_string(),
 		),
 	);


### PR DESCRIPTION
## Summary

This PR addresses:

- Updates `Cargo.lock` to consume `reinhardt-web` `develop/0.2.0` at `b5bae75a` / `0.2.0-rc.3` after the upstream merge.
- Adds direct dashboard dependencies for upstream feature boundaries that are no longer exported through the `reinhardt` umbrella crate.
- Keeps dashboard static resolver configuration out of the workspace-level `reinhardt` feature list so deploy fallback does not infer unsupported managed local storage.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

The dashboard self-deploy E2E needs the merged `reinhardt-web` fix. Updating only the lockfile exposed two upstream feature-boundary changes:

- `RunserverContext`, `RunserverHook`, and `RunserverHookRegistration` now require `reinhardt-commands/server` directly.
- `TemplateStaticConfig` should be used from `reinhardt-utils/staticfiles` directly; enabling the umbrella `static-files` feature at the workspace level makes zero-config deploy fallback infer managed object storage for the dashboard's local static path.

Fixes #646

Related to: kent8192/reinhardt-web#5187

## How Was This Tested?

- `cargo fmt --check`
- `cargo check -p reinhardt-cloud-dashboard`
- `cargo make dashboard-self-deploy-e2e`

The E2E run built the dashboard image, applied the generated `ReinhardtApp` through the CLI `--direct` path, waited for operator-owned dashboard, Redis, and database resources, and reached the `Ready` condition.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

<!-- ⚠️ CI CONTROL CHECKBOX - DO NOT EDIT MANUALLY ⚠️
The following checkbox controls CI runner selection.
Checking this option triggers self-hosted runner usage,
which incurs infrastructure costs. Only the repository owner should enable this.
If this checkbox is missing or unchecked, CI defaults to GitHub-hosted runners.
Do NOT modify the checkbox text — CI parses it by exact pattern match. -->
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #646
- kent8192/reinhardt-web#5187

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [ ] `kubernetes` - Kubernetes resources, controllers, operators
- [x] `deployment` - Application deployment logic
- [ ] `networking` - Ingress, services, network policies
- [ ] `storage` - Persistent volumes, storage classes
- [ ] `auth` - Authentication, authorization, RBAC
- [ ] `api` - REST API, serializers, handlers
- [ ] `cli` - Command-line interface
- [x] `config` - Configuration management
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
<!-- Maintainers will apply priority labels during triage -->
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The deploy command still logs the existing `manage introspect` missing `core.secret_key` fallback path in local E2E, but the generated fallback manifest is valid and the self-deploy flow completes successfully.

🤖 Generated with [Codex](https://openai.com/codex)
