### PR TITLE
refactor(dashboard): align auth forms with reinhardt 0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,6 +947,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5755,6 +5788,7 @@ version = "0.2.0-rc.3"
 source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
 dependencies = [
  "async-trait",
+ "cargo_metadata",
  "chrono",
  "clap",
  "colored",
@@ -7182,6 +7216,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5363,7 +5363,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "reinhardt-admin"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5414,7 +5414,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-apps"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5444,7 +5444,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-auth"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5491,7 +5491,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-auth-macros"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5785,7 +5785,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-commands"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "async-trait",
  "cargo_metadata",
@@ -5842,7 +5842,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-conf"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5870,7 +5870,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-core"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "anyhow",
  "aquamarine 0.6.0",
@@ -5916,7 +5916,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-db"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -5969,7 +5969,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-di"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5993,7 +5993,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-di-macros"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6004,7 +6004,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-forms"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "anyhow",
  "aquamarine 0.5.0",
@@ -6021,7 +6021,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-http"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6042,7 +6042,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-macros"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "ctor 0.8.0",
  "inventory",
@@ -6056,7 +6056,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-mail"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6077,7 +6077,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-manouche"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "aquamarine 0.6.0",
  "convert_case",
@@ -6090,7 +6090,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-middleware"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6123,7 +6123,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-openapi"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "async-trait",
  "reinhardt-http",
@@ -6135,7 +6135,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-openapi-macros"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6146,7 +6146,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-pages"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "aquamarine 0.5.0",
  "async-trait",
@@ -6189,7 +6189,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-pages-ast"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "aquamarine 0.6.0",
  "convert_case",
@@ -6203,7 +6203,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-pages-macros"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "convert_case",
  "darling 0.20.11",
@@ -6217,7 +6217,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-query"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -6231,7 +6231,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-query-macros"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -6242,7 +6242,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-rest"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6292,12 +6292,12 @@ dependencies = [
 [[package]]
 name = "reinhardt-router"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 
 [[package]]
 name = "reinhardt-routers-macros"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6307,7 +6307,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-server"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6328,7 +6328,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-shortcuts"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "bytes",
  "hyper",
@@ -6346,7 +6346,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-test"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "cfg_aliases",
  "reinhardt-auth",
@@ -6366,7 +6366,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-testkit"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "astral-tokio-tar",
  "async-dropper",
@@ -6423,7 +6423,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-testkit-macros"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6433,7 +6433,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-throttling"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -6444,7 +6444,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-urls"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -6478,7 +6478,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-utils"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6514,7 +6514,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-views"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6549,7 +6549,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-web"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6590,7 +6590,7 @@ dependencies = [
 [[package]]
 name = "reinhardt-websockets"
 version = "0.2.0-rc.3"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#b5bae75a5a3f93b42960e756304d01770b3c23c3"
+source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.2.0#48e4168eb583c327d74769a7d1c2c10da97b1158"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/dashboard/src/apps/auth/client/pages/login.rs
+++ b/dashboard/src/apps/auth/client/pages/login.rs
@@ -1,8 +1,8 @@
 //! Login page with username and password form.
 //!
-//! Uses `form!` macro for declarative form rendering with automatic
-//! server function integration. On successful login, the auth state is
-//! updated via `AuthState` and the user is redirected to the dashboard.
+//! Uses `form!` for the static field/server_fn definition. Login success is
+//! persisted by the server-side session cookie, then the form redirects to the
+//! dashboard route.
 
 use reinhardt::pages::component::Page;
 use reinhardt::pages::form;
@@ -16,6 +16,7 @@ pub fn login_page() -> Page {
 	let login_form = form! {
 		name: LoginForm,
 		server_fn: login,
+		method: Post,
 		class: "space-y-4",
 		redirect_on_success: "/",
 		fields: {

--- a/dashboard/src/apps/auth/client/pages/register.rs
+++ b/dashboard/src/apps/auth/client/pages/register.rs
@@ -1,8 +1,8 @@
 //! Register page with username, email, and password form.
 //!
-//! Uses `form!` macro for declarative form rendering with automatic
-//! server function integration. On successful registration, the auth state
-//! is updated via `AuthState` and the user is redirected to the dashboard.
+//! Uses `form!` for the static field/server_fn definition. Registration creates
+//! an inactive account and sends a verification email; it does not establish a
+//! login session.
 
 use reinhardt::pages::component::Page;
 use reinhardt::pages::form;
@@ -16,8 +16,9 @@ pub fn register_page() -> Page {
 	let register_form = form! {
 		name: RegisterForm,
 		server_fn: register,
+		method: Post,
 		class: "space-y-4",
-		redirect_on_success: "/",
+		redirect_on_success: "/login",
 		fields: {
 			username: CharField {
 				required,

--- a/dashboard/src/apps/auth/server/login.rs
+++ b/dashboard/src/apps/auth/server/login.rs
@@ -24,6 +24,7 @@ pub async fn login(
 		use tracing::error;
 
 		use crate::apps::auth::services;
+		use crate::apps::auth::services::session::session_cookie_header;
 		use crate::shared::UserInfo;
 
 		let user = services::verify_credentials(&username, &password)
@@ -48,10 +49,7 @@ pub async fn login(
 		// The server_fn router reads SharedResponseCookies after the handler
 		// and applies them as Set-Cookie response headers.
 		let is_debug = crate::config::settings::get_settings().core.debug;
-		let secure_flag = if is_debug { "" } else { "; Secure" };
-		let cookie = format!(
-			"sessionid={session_id}; HttpOnly; SameSite=Lax; Path=/{secure_flag}; Max-Age=86400"
-		);
+		let cookie = session_cookie_header(&session_id, is_debug);
 		http_request.add_response_cookie(cookie);
 
 		let user_info = UserInfo::from(&user);

--- a/dashboard/src/apps/auth/server/me.rs
+++ b/dashboard/src/apps/auth/server/me.rs
@@ -8,11 +8,11 @@ use crate::shared::UserInfo;
 ///
 /// Authentication is handled by the cookie session middleware which
 /// validates the `sessionid` cookie and sets `AuthState` in request
-/// extensions. `AuthUser<User>` resolves the full user model from
+/// extensions. `CurrentUser<User>` resolves the full user model from
 /// the database via dependency injection.
 #[server_fn]
 pub async fn me(
-	#[inject] reinhardt::AuthUser(user): reinhardt::AuthUser<crate::apps::auth::models::User>,
+	#[inject] reinhardt::CurrentUser(user): reinhardt::CurrentUser<crate::apps::auth::models::User>,
 ) -> Result<UserInfo, ServerFnError> {
 	Ok(UserInfo::from(&user))
 }

--- a/dashboard/src/apps/auth/server/register.rs
+++ b/dashboard/src/apps/auth/server/register.rs
@@ -5,6 +5,9 @@
 
 use reinhardt::pages::server_fn::{ServerFnError, server_fn};
 
+#[cfg(native)]
+use reinhardt::core::exception::Error as AppError;
+
 use crate::shared::AuthResponse;
 
 /// Create a new user account with email verification.
@@ -25,89 +28,12 @@ pub async fn register(
 ) -> Result<AuthResponse, ServerFnError> {
 	#[cfg(native)]
 	{
-		use reinhardt::BaseUser;
-		use reinhardt::db::orm::Model;
-		use tracing::{error, info};
-
-		use crate::apps::auth::models::User;
-		use crate::apps::auth::services::registration::provision_personal_organization;
-		use crate::apps::auth::services::token::{TokenPurpose, generate_token};
+		use crate::apps::auth::services::registration::register_inactive_user;
 		use crate::shared::UserInfo;
 
-		let settings = crate::config::settings::get_settings();
-		let secret_key = settings.core.secret_key.clone();
-
-		// Create user as inactive — requires email verification to activate
-		let mut user = User::build()
-			.username(username.trim().to_string())
-			.email(email.trim().to_lowercase())
-			.first_name(String::new())
-			.last_name(String::new())
-			.password_hash(None)
-			.is_active(false)
-			.is_staff(false)
-			.is_superuser(false)
-			.finish();
-		user.set_password(&password).map_err(|e| {
-			error!("Password hashing failed during registration: {e}");
-			ServerFnError::application("Internal server error")
-		})?;
-
-		// Attempt to create -- database unique constraint prevents duplicates
-		let created = match User::objects().create(&user).await {
-			Ok(user) => user,
-			Err(e) => {
-				let err_lower = e.to_string().to_lowercase();
-				if err_lower.contains("unique") || err_lower.contains("duplicate") {
-					let message = if err_lower.contains("auth_user_email_uniq") {
-						"Email already exists"
-					} else {
-						"Username already exists"
-					};
-					return Err(ServerFnError::application(message));
-				}
-				error!("Failed to create user in database: {e}");
-				return Err(ServerFnError::application("Internal server error"));
-			}
-		};
-
-		// Provision a Personal Organization for the new user (refs #415, #435).
-		// Shared with the REST register flow; slug derivation, retry, and
-		// rollback are handled by the shared service.
-		provision_personal_organization(&created)
+		let created = register_inactive_user(&username, &email, &password, email_service.as_ref())
 			.await
-			.map_err(|e| ServerFnError::application(e.to_string()))?;
-
-		// Generate verification token and send email
-		let token = generate_token(
-			TokenPurpose::EmailVerification,
-			&created.id,
-			"",
-			&secret_key,
-		);
-
-		let port = std::env::var("PORT").unwrap_or_else(|_| "8000".to_string());
-		let base_url = std::env::var("REINHARDT_CLOUD_BASE_URL")
-			.unwrap_or_else(|_| format!("http://localhost:{port}"));
-		let verification_url = format!("{base_url}/api/auth/verify-email/{token}/");
-
-		if let Err(e) = email_service
-			.send_verification_email(&created.email, &created.username, &verification_url)
-			.await
-		{
-			error!(
-				"Failed to send verification email to {}: {e}",
-				created.email
-			);
-			// Roll back user creation to avoid stranding an inactive account
-			if let Err(del_err) = User::objects().delete(created.id).await {
-				error!("Failed to roll back user after email failure: {del_err}");
-			}
-			return Err(ServerFnError::application(
-				"Registration failed — please try again later",
-			));
-		}
-		info!("Verification email sent to {}", created.email);
+			.map_err(server_fn_error_from_app_error)?;
 
 		// No session cookie — user must verify email first
 		let user_info = UserInfo::from(&created);
@@ -123,5 +49,17 @@ pub async fn register(
 		// declaration on both targets.
 		let _ = (username, email, password, _http_request, email_service);
 		unreachable!("server_fn body is replaced on wasm")
+	}
+}
+
+#[cfg(native)]
+fn server_fn_error_from_app_error(err: AppError) -> ServerFnError {
+	match err {
+		AppError::Authentication(message)
+		| AppError::Conflict(message)
+		| AppError::Validation(message)
+		| AppError::Http(message) => ServerFnError::application(message),
+		AppError::Internal(message) => ServerFnError::application(message),
+		_ => ServerFnError::application("Internal server error"),
 	}
 }

--- a/dashboard/src/apps/auth/services/registration.rs
+++ b/dashboard/src/apps/auth/services/registration.rs
@@ -18,15 +18,94 @@
 //! global-state coupling.
 
 use chrono::Utc;
+use reinhardt::BaseUser;
 use reinhardt::core::exception::Error as AppError;
 use reinhardt::db::orm::Model;
-use tracing::error;
+use tracing::{error, info};
 
 use crate::apps::auth::models::User;
+use crate::apps::auth::services::email::EmailService;
+use crate::apps::auth::services::token::{TokenPurpose, generate_token};
 use crate::apps::organizations::models::{Organization, OrganizationMembership};
 use crate::apps::organizations::roles::{
 	MembershipRole, is_reserved_slug, sanitize_username_to_slug, validate_slug,
 };
+
+/// Register an inactive user, provision the personal organization, and send
+/// the verification email.
+pub async fn register_inactive_user(
+	username: &str,
+	email: &str,
+	password: &str,
+	email_service: &EmailService,
+) -> Result<User, AppError> {
+	let settings = crate::config::settings::get_settings();
+	let secret_key = settings.core.secret_key.clone();
+
+	let mut user = User::build()
+		.username(username.trim().to_string())
+		.email(email.trim().to_lowercase())
+		.first_name(String::new())
+		.last_name(String::new())
+		.password_hash(None)
+		.is_active(false)
+		.is_staff(false)
+		.is_superuser(false)
+		.finish();
+	user.set_password(password).map_err(|e| {
+		error!("Password hashing failed during registration: {e}");
+		AppError::Internal("Internal server error".to_string())
+	})?;
+
+	let created = match User::objects().create(&user).await {
+		Ok(user) => user,
+		Err(e) => {
+			let err_lower = e.to_string().to_lowercase();
+			if err_lower.contains("unique") || err_lower.contains("duplicate") {
+				let message = if err_lower.contains("auth_user_email_uniq") {
+					"Email already exists"
+				} else {
+					"Username already exists"
+				};
+				return Err(AppError::Conflict(message.to_string()));
+			}
+			error!("Failed to create user in database: {e}");
+			return Err(AppError::Internal("Internal server error".to_string()));
+		}
+	};
+
+	provision_personal_organization(&created).await?;
+
+	let token = generate_token(
+		TokenPurpose::EmailVerification,
+		&created.id,
+		"",
+		&secret_key,
+	);
+	let port = std::env::var("PORT").unwrap_or_else(|_| "8000".to_string());
+	let base_url = std::env::var("REINHARDT_CLOUD_BASE_URL")
+		.unwrap_or_else(|_| format!("http://localhost:{port}"));
+	let verification_url = format!("{base_url}/api/auth/verify-email/{token}/");
+
+	if let Err(e) = email_service
+		.send_verification_email(&created.email, &created.username, &verification_url)
+		.await
+	{
+		error!(
+			"Failed to send verification email to {}: {e}",
+			created.email
+		);
+		if let Err(del_err) = User::objects().delete(created.id).await {
+			error!("Failed to roll back user after email failure: {del_err}");
+		}
+		return Err(AppError::Internal(
+			"Registration failed - please try again later".to_string(),
+		));
+	}
+	info!("Verification email sent to {}", created.email);
+
+	Ok(created)
+}
 
 /// Create a Personal `Organization` and Owner `OrganizationMembership` for
 /// a freshly-registered user. Rolls the user creation back on failure so

--- a/dashboard/src/apps/auth/services/session.rs
+++ b/dashboard/src/apps/auth/services/session.rs
@@ -109,6 +109,12 @@ impl SessionService {
 	}
 }
 
+/// Build the `Set-Cookie` header value for a persisted session id.
+pub fn session_cookie_header(session_id: &str, debug: bool) -> String {
+	let secure_flag = if debug { "" } else { "; Secure" };
+	format!("sessionid={session_id}; HttpOnly; SameSite=Lax; Path=/{secure_flag}; Max-Age=86400")
+}
+
 /// Validate a session and return `(user_id, username)`.
 ///
 /// Retained as a free-function adapter because the WebSocket

--- a/dashboard/src/apps/auth/views/login.rs
+++ b/dashboard/src/apps/auth/views/login.rs
@@ -2,16 +2,14 @@
 
 use reinhardt::core::exception::Error as AppError;
 use reinhardt::core::serde::json;
-use reinhardt::db::orm::Model;
 use reinhardt::di::Depends;
 use reinhardt::http::ViewResult;
 use reinhardt::post;
-use reinhardt::{BaseUser, Json, Response, StatusCode};
+use reinhardt::{Json, Response, StatusCode};
 use tracing::error;
 
-use crate::apps::auth::models::User;
 use crate::apps::auth::serializers::LoginRequest;
-use crate::apps::auth::services::session::SessionService;
+use crate::apps::auth::services::session::{SessionService, session_cookie_header};
 use crate::shared::AuthResponse;
 
 /// Authenticate user against database and create a session.
@@ -20,30 +18,8 @@ pub async fn login(
 	Json(body): Json<LoginRequest>,
 	#[inject] session_service: Depends<SessionService>,
 ) -> ViewResult<Response> {
-	// Find user by username
-	let user = User::objects()
-		.filter(User::field_username().eq(body.username.trim().to_string()))
-		.first()
-		.await
-		.map_err(|e| {
-			error!("Failed to query user during login: {e}");
-			AppError::Internal("Internal server error".to_string())
-		})?
-		.ok_or_else(|| AppError::Authentication("Invalid credentials".to_string()))?;
-
-	// Verify password
-	let valid = user.check_password(&body.password).map_err(|e| {
-		error!("Password verification failed during login: {e}");
-		AppError::Internal("Internal server error".to_string())
-	})?;
-	if !valid {
-		return Err(AppError::Authentication("Invalid credentials".to_string()));
-	}
-
-	// Check if user is active (use same generic message to prevent user enumeration)
-	if !user.is_active() {
-		return Err(AppError::Authentication("Invalid credentials".to_string()));
-	}
+	let user =
+		crate::apps::auth::services::verify_credentials(&body.username, &body.password).await?;
 
 	// Create session in Redis
 	let session_id = session_service.create_session(&user).await.map_err(|e| {
@@ -58,10 +34,7 @@ pub async fn login(
 
 	// Set session cookie on the response
 	let is_debug = crate::config::settings::get_settings().core.debug;
-	let secure_flag = if is_debug { "" } else { "; Secure" };
-	let cookie = format!(
-		"sessionid={session_id}; HttpOnly; SameSite=Lax; Path=/{secure_flag}; Max-Age=86400"
-	);
+	let cookie = session_cookie_header(&session_id, is_debug);
 
 	Ok(Response::new(StatusCode::OK)
 		.with_header("Content-Type", "application/json")

--- a/dashboard/src/apps/auth/views/register.rs
+++ b/dashboard/src/apps/auth/views/register.rs
@@ -3,20 +3,15 @@
 //! Creates a new user with `is_active = false` and sends a verification
 //! email. The user must verify their email before they can log in.
 
-use reinhardt::core::exception::Error as AppError;
 use reinhardt::core::serde::json;
-use reinhardt::db::orm::Model;
 use reinhardt::di::Depends;
 use reinhardt::http::ViewResult;
 use reinhardt::post;
-use reinhardt::{BaseUser, Json, Response, StatusCode};
-use tracing::{error, info};
+use reinhardt::{Json, Response, StatusCode};
 
-use crate::apps::auth::models::User;
 use crate::apps::auth::serializers::RegisterRequest;
 use crate::apps::auth::services::email::EmailService;
-use crate::apps::auth::services::registration::provision_personal_organization;
-use crate::apps::auth::services::token::{TokenPurpose, generate_token};
+use crate::apps::auth::services::registration::register_inactive_user;
 use crate::shared::AuthResponse;
 
 /// Register new user with email verification required.
@@ -28,84 +23,13 @@ pub async fn register(
 	Json(body): Json<RegisterRequest>,
 	#[inject] email_service: Depends<EmailService>,
 ) -> ViewResult<Response> {
-	let settings = crate::config::settings::get_settings();
-	let secret_key = settings.core.secret_key.clone();
-
-	// Create user as inactive — requires email verification to activate
-	let mut user = User::build()
-		.username(body.username.trim().to_string())
-		.email(body.email.trim().to_lowercase())
-		.first_name(String::new())
-		.last_name(String::new())
-		.password_hash(None)
-		.is_active(false)
-		.is_staff(false)
-		.is_superuser(false)
-		.finish();
-	user.set_password(&body.password).map_err(|e| {
-		error!("Password hashing failed during registration: {e}");
-		AppError::Internal("Internal server error".to_string())
-	})?;
-
-	// Attempt to create -- database unique constraint prevents duplicates
-	let created = match User::objects().create(&user).await {
-		Ok(user) => user,
-		Err(e) => {
-			// Normalize error message to lowercase for case-insensitive matching.
-			// The ORM (reinhardt-db) maps unique constraint violations to
-			// `DatabaseError::QueryError(String)` without a structured variant,
-			// so string matching is the only detection mechanism available.
-			let err_lower = e.to_string().to_lowercase();
-			if err_lower.contains("unique") || err_lower.contains("duplicate") {
-				// Distinguish which field caused the conflict by checking
-				// the PostgreSQL constraint name embedded in the error message.
-				let message = if err_lower.contains("auth_user_email_uniq") {
-					"Email already exists"
-				} else {
-					"Username already exists"
-				};
-				return Err(AppError::Conflict(message.to_string()));
-			}
-			error!("Failed to create user in database: {e}");
-			return Err(AppError::Internal("Internal server error".to_string()));
-		}
-	};
-
-	// Provision a Personal Organization for the new user (refs #415, #435).
-	// Slug derivation, retry, and rollback are handled by the shared service.
-	provision_personal_organization(&created).await?;
-
-	// Generate verification token and send email
-	let token = generate_token(
-		TokenPurpose::EmailVerification,
-		&created.id,
-		"",
-		&secret_key,
-	);
-
-	let port = std::env::var("PORT").unwrap_or_else(|_| "8000".to_string());
-	let base_url = std::env::var("REINHARDT_CLOUD_BASE_URL")
-		.unwrap_or_else(|_| format!("http://localhost:{port}"));
-	let verification_url = format!("{base_url}/api/auth/verify-email/{token}/");
-
-	if let Err(e) = email_service
-		.send_verification_email(&created.email, &created.username, &verification_url)
-		.await
-	{
-		error!(
-			"Failed to send verification email to {}: {e}",
-			created.email
-		);
-		// Roll back user creation to avoid stranding an inactive account
-		// with no way to receive the activation link.
-		if let Err(del_err) = User::objects().delete(created.id).await {
-			error!("Failed to roll back user after email failure: {del_err}");
-		}
-		return Err(AppError::Internal(
-			"Registration failed — please try again later".to_string(),
-		));
-	}
-	info!("Verification email sent to {}", created.email);
+	let created = register_inactive_user(
+		&body.username,
+		&body.email,
+		&body.password,
+		email_service.as_ref(),
+	)
+	.await?;
 
 	let resp = AuthResponse {
 		success: true,


### PR DESCRIPTION
## Summary

This PR addresses:

- Aligns dashboard auth form usage with reinhardt-web v0.2.0 conventions.
- Keeps static login/register pages on `form!` instead of introducing unnecessary runtime `use_form` state.
- Shares login session-cookie and inactive-registration logic between server_fn handlers and REST views.
- Redirects successful registration to `/login` because newly registered users remain inactive until email verification.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

- Dashboard auth pages were already structurally close to the reinhardt-web v0.2.0 form model, but the implementation still had duplicated REST/server_fn business logic and stale comments around login/registration behavior.
- The form boundary matters: `form!` is the right fit for static field/server_fn definitions, while `use_form` should be reserved for runtime-dynamic form configuration.

Related to: reinhardt-web v0.2.0 dashboard migration

## How Was This Tested?

- `CARGO_TARGET_DIR=/tmp/reinhardt-cloud-dashboard-auth-form-target cargo check --manifest-path dashboard/Cargo.toml --all-features`
- `CARGO_TARGET_DIR=/tmp/reinhardt-cloud-dashboard-auth-form-target cargo make clippy-check` from `dashboard/`
- `REINHARDT_ENV=ci CARGO_TARGET_DIR=/tmp/reinhardt-cloud-dashboard-auth-form-target cargo test --all-features test_register_creates_inactive_user -- --nocapture`
- `REINHARDT_ENV=ci CARGO_TARGET_DIR=/tmp/reinhardt-cloud-dashboard-auth-form-target cargo test --all-features test_register_records_created_by_on_personal_org -- --nocapture`
- `REINHARDT_ENV=ci CARGO_TARGET_DIR=/tmp/reinhardt-cloud-dashboard-auth-form-target cargo test --all-features test_register_duplicate_email_returns_conflict -- --nocapture`
- `REINHARDT_ENV=ci CARGO_TARGET_DIR=/tmp/reinhardt-cloud-dashboard-auth-form-target cargo test --all-features test_unverified_user_cannot_login -- --nocapture`
- `REINHARDT_ENV=ci CARGO_TARGET_DIR=/tmp/reinhardt-cloud-dashboard-auth-form-target cargo test --all-features test_login_wrong_password_fails -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/reinhardt-cloud-dashboard-auth-form-target cargo make wasm-spa-test` from `dashboard/`
- `git diff --check`
- `reinhardt-admin fmt --check` on touched dashboard auth files

Known local caveats:

- Running auth tests without `REINHARDT_ENV=ci` fails because uncommitted local settings are not present and `core.secret_key` is required.
- `test_login_returns_session_cookie` returned HTTP 500 in this local environment while the wrong-password and unverified-user login paths passed, which points at session backend/environment sensitivity rather than the shared credential path changed here.
- Full `cargo make fmt-check` still reports pre-existing unrelated formatting drift outside this PR's touched files.

## Performance Impact

Not performance-related.

## Breaking Changes

None.

## Screenshots

Not applicable; no visual UI redesign.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

<!-- CI runner selection; leave unchecked unless the repository owner explicitly chooses self-hosted CI. -->
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- reinhardt-web v0.2.0 dashboard migration

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [x] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [ ] `kubernetes` - Kubernetes resources, controllers, operators
- [ ] `deployment` - Application deployment logic
- [ ] `networking` - Ingress, services, network policies
- [ ] `storage` - Persistent volumes, storage classes
- [x] `auth` - Authentication, authorization, RBAC
- [x] `api` - REST API, serializers, handlers
- [ ] `cli` - Command-line interface
- [ ] `config` - Configuration management
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [x] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

GitWhy context: `ctx_1cfc0e7e`

Generated with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Registration page now redirects new users to the login page after account creation, ensuring they complete email verification before accessing the application.

* **Refactoring**
  * Enhanced authentication system architecture by consolidating shared operations into reusable services, including session management, credential verification, and user registration workflows for improved code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->