### PR TITLE
fix(operator): narrow dashboard deployment selector

### DIFF
--- a/crates/reinhardt-cloud-operator/src/resources/deployment.rs
+++ b/crates/reinhardt-cloud-operator/src/resources/deployment.rs
@@ -342,10 +342,13 @@ pub(crate) fn build_deployment(
 		spec: Some(DeploymentSpec {
 			replicas: Some(replicas),
 			selector: LabelSelector {
-				match_labels: Some(BTreeMap::from([(
-					"app.kubernetes.io/name".to_string(),
-					app.name_any(),
-				)])),
+				match_labels: Some(BTreeMap::from([
+					("app.kubernetes.io/name".to_string(), app.name_any()),
+					(
+						"app.kubernetes.io/component".to_string(),
+						Component::Web.as_str().to_string(),
+					),
+				])),
 				..Default::default()
 			},
 			template: PodTemplateSpec {
@@ -465,6 +468,43 @@ mod tests {
 		let container = &deploy.spec.unwrap().template.spec.unwrap().containers[0];
 		let port = &container.ports.as_ref().unwrap()[0];
 		assert_eq!(port.container_port, 8000);
+	}
+
+	#[rstest]
+	fn test_build_deployment_selector_targets_web_component() {
+		// Arrange
+		let app = make_test_app("web", "web:v1", None);
+
+		// Act
+		let deploy =
+			build_deployment(&app, None, &Platform::Onpremise).expect("build should succeed");
+		let spec = deploy.spec.expect("deployment spec");
+		let selector = spec.selector.match_labels.expect("selector labels");
+		let template_labels = spec
+			.template
+			.metadata
+			.expect("template metadata")
+			.labels
+			.expect("template labels");
+
+		// Assert
+		assert_eq!(selector.len(), 2);
+		assert_eq!(
+			selector.get("app.kubernetes.io/name").map(String::as_str),
+			Some("web")
+		);
+		assert_eq!(
+			selector
+				.get("app.kubernetes.io/component")
+				.map(String::as_str),
+			Some("web")
+		);
+		assert_eq!(
+			template_labels
+				.get("app.kubernetes.io/component")
+				.map(String::as_str),
+			Some("web")
+		);
 	}
 
 	#[rstest]


### PR DESCRIPTION
## Summary

This PR addresses:

- Narrows the operator-managed web Deployment selector to `app.kubernetes.io/name` + `app.kubernetes.io/component=web`.
- Keeps Redis pods grouped under the same app name while preventing deployment-scoped operations from selecting cache pods.
- Adds a regression test for the web Deployment selector and template component label.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

The dashboard web Deployment selector only matched `app.kubernetes.io/name`, which is shared by related components such as Redis. That made `kubectl logs deployment/reinhardt-cloud-dashboard` ambiguous because Kubernetes could choose a Redis pod behind the same app name.

Fixes #656

Related to: #642

## How Was This Tested?

- [x] `cargo fmt --check`
- [x] `cargo test -p reinhardt-cloud-operator test_build_deployment_selector_targets_web_component`
- [x] `cargo check -p reinhardt-cloud-operator`
- [x] `cargo clippy -p reinhardt-cloud-operator --all-targets -- -D warnings`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

<!-- ⚠️ CI CONTROL CHECKBOX - DO NOT EDIT MANUALLY ⚠️
The following checkbox controls CI runner selection.
Checking this option triggers self-hosted runner usage,
which incurs infrastructure costs. Only the repository owner should enable this.
If this checkbox is missing or unchecked, CI defaults to GitHub-hosted runners.
Do NOT modify the checkbox text — CI parses it by exact pattern match. -->
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #656
- Related to #642

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [x] `kubernetes` - Kubernetes resources, controllers, operators
- [x] `deployment` - Application deployment logic
- [ ] `networking` - Ingress, services, network policies
- [ ] `storage` - Persistent volumes, storage classes
- [ ] `auth` - Authentication, authorization, RBAC
- [ ] `api` - REST API, serializers, handlers
- [ ] `cli` - Command-line interface
- [ ] `config` - Configuration management
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The selector remains intentionally minimal because Deployment selectors are immutable once applied.

🤖 Generated with [Codex](https://openai.com/codex)
