### PR TITLE
fix(dashboard): serve notifications websocket route

### DIFF
--- a/dashboard/src/client.rs
+++ b/dashboard/src/client.rs
@@ -36,7 +36,7 @@ mod wasm_entry {
 	use reinhardt::pages::{ClientLauncher, PathCtx};
 
 	use super::router;
-	use crate::shared::client::{components, state};
+	use crate::shared::client::{components, state, ws};
 
 	/// WASM entry point — invoked automatically when the module loads.
 	#[wasm_bindgen(start)]
@@ -55,6 +55,7 @@ mod wasm_entry {
 		// on every entry to "/".
 		ClientLauncher::new("#app")
 			.before_launch(state::init_app_state)
+			.before_launch(ws::ensure_notifications_connected)
 			.router_client(router::init_router)
 			.on_path("/", |ctx: &PathCtx<'_>| {
 				ctx.ensure_portal("toast-container", components::toast::toast_container);

--- a/dashboard/src/server.rs
+++ b/dashboard/src/server.rs
@@ -3,7 +3,8 @@
 //!
 //! The functions here boot the HTTP server the same way the production
 //! container does: register the URL router from the `#[routes]`
-//! inventory, then drive `RunServerCommand::execute`. Sharing this code
+//! inventory, register WebSocket routes, then drive
+//! `RunServerCommand::execute`. Sharing this code
 //! lets tests assert that the binary's startup path actually wires up a
 //! router instead of duplicating reconnaissance into a parallel
 //! implementation that drifts from production.
@@ -111,6 +112,7 @@ async fn initialize_orm_database() -> Result<(), Box<dyn Error>> {
 /// `RunServerCommand`.
 pub async fn run(bind_addr: &str) -> Result<(), Box<dyn Error>> {
 	register_router_from_inventory().await?;
+	crate::config::urls::init_websocket_routes().await;
 	initialize_orm_database().await?;
 
 	let ctx = build_context(bind_addr);

--- a/dashboard/tests/server_startup.rs
+++ b/dashboard/tests/server_startup.rs
@@ -13,9 +13,41 @@
 #![cfg(not(target_arch = "wasm32"))]
 
 use reinhardt::urls::routers::{clear_router, is_router_registered};
+use reinhardt::{clear_websocket_router, get_websocket_router, reverse_websocket_url};
 use reinhardt_cloud_dashboard::server;
 use rstest::rstest;
 use serial_test::serial;
+
+struct EnvVarGuard {
+	key: &'static str,
+	previous: Option<String>,
+}
+
+impl EnvVarGuard {
+	fn set(key: &'static str, value: &str) -> Self {
+		let previous = std::env::var(key).ok();
+		// SAFETY: these tests run in the `router_global` serial group before
+		// spawning server tasks, so no concurrent test in this file reads or
+		// mutates the same environment variable.
+		unsafe {
+			std::env::set_var(key, value);
+		}
+		Self { key, previous }
+	}
+}
+
+impl Drop for EnvVarGuard {
+	fn drop(&mut self) {
+		// SAFETY: this guard restores process environment during serial test
+		// cleanup, before any server task has been spawned.
+		unsafe {
+			match &self.previous {
+				Some(value) => std::env::set_var(self.key, value),
+				None => std::env::remove_var(self.key),
+			}
+		}
+	}
+}
 
 /// `register_router_from_inventory` is what the binary's
 /// `server::run` calls before `RunServerCommand::execute`. Asserting
@@ -32,6 +64,7 @@ async fn register_router_from_inventory_populates_global_router_slot()
 	// test may have left a router registered (or another integration
 	// test running serially in the same group), so reset to a clean
 	// "no router" state before exercising the helper.
+	let _env = EnvVarGuard::set("REINHARDT_ENV", "ci");
 	clear_router();
 	assert!(
 		!is_router_registered(),
@@ -55,6 +88,46 @@ async fn register_router_from_inventory_populates_global_router_slot()
 
 	// Cleanup — leave the global slot empty for the next serial test.
 	clear_router();
+
+	Ok(())
+}
+
+/// `server::run` also needs to register the dashboard's WebSocket routes
+/// before `RunServerCommand::execute`, otherwise `/ws/notifications` falls
+/// through to the pages fallback and the browser sees an HTTP 200 response
+/// instead of a WebSocket upgrade.
+#[rstest]
+#[tokio::test]
+#[serial(router_global)]
+async fn init_websocket_routes_registers_notifications_endpoint()
+-> Result<(), Box<dyn std::error::Error>> {
+	// Arrange
+	clear_websocket_router().await;
+	assert!(
+		get_websocket_router().await.is_none(),
+		"precondition: global WebSocket router slot must be empty"
+	);
+
+	// Act
+	reinhardt_cloud_dashboard::config::urls::init_websocket_routes().await;
+
+	// Assert
+	let router = get_websocket_router()
+		.await
+		.expect("init_websocket_routes must register a WebSocket router");
+	assert!(
+		router.has_route("/ws/notifications").await,
+		"WebSocket router must serve /ws/notifications; \
+		 see kent8192/reinhardt-cloud#655"
+	);
+	assert_eq!(
+		reverse_websocket_url(&router, "websocket:notifications").await,
+		Some("/ws/notifications".to_string()),
+		"named notifications route must reverse to the served WebSocket path"
+	);
+
+	// Cleanup
+	clear_websocket_router().await;
 
 	Ok(())
 }

--- a/dashboard/tests/wasm/test_spa_navigation_smoke.rs
+++ b/dashboard/tests/wasm/test_spa_navigation_smoke.rs
@@ -39,10 +39,10 @@ fn ensure_mount_point(document: &web_sys::Document, body: &web_sys::HtmlElement)
 }
 
 /// Launch the dashboard's client just like `dashboard/src/client.rs`
-/// does in production, minus the `on_path` hooks that depend on a live
-/// notifications WebSocket. Reuses the same `init_router()` and the same
-/// `before_launch(state::init_app_state)` hook so route names, patterns,
-/// and launcher topology match production byte-for-byte —
+/// does in production, minus the notification WebSocket bootstrap and
+/// `on_path` hooks that depend on the deployed dashboard runtime. Reuses
+/// the same `init_router()` and the same `before_launch(state::init_app_state)`
+/// hook so route names, patterns, and launcher topology match production —
 /// `UnifiedRouter::register_globally()` inside `init_router` installs
 /// the `ClientUrlReverser` used by client-side route reversal.
 fn launch_dashboard_for_test() {


### PR DESCRIPTION
## Summary

This PR addresses:

- Registers the dashboard WebSocket router in the deployed production server entrypoint before `RunServerCommand::execute`.
- Re-enables the WASM notification WebSocket bootstrap now that `/ws/notifications` is served by that path.
- Adds a server startup regression test for the named `/ws/notifications` route and keeps test env mutation scoped with an RAII guard.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

The deployed dashboard binary registers the HTTP router before calling `RunServerCommand` directly, but it skipped the separate WebSocket router registration. As a result, `/ws/notifications` fell through to the SPA fallback and returned HTTP 200 instead of upgrading the connection.

Fixes #655

Related to: #653

## How Was This Tested?

- [x] `cargo check --manifest-path dashboard/Cargo.toml --all-features`
- [x] `CARGO_TARGET_DIR=/tmp/reinhardt-cloud-issue-655-target cargo test --manifest-path dashboard/Cargo.toml --test server_startup --all-features`
- [x] `CARGO_TARGET_DIR=/tmp/reinhardt-cloud-issue-655-wasm-target cargo check --manifest-path dashboard/Cargo.toml --target wasm32-unknown-unknown --features wasm-spa-test`

## Performance Impact

Not performance-related. The change registers one existing WebSocket route during dashboard server startup.

## Breaking Changes

None.

## Screenshots

Not applicable. This is a server route wiring fix plus client bootstrap restoration.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #655
- Related to #653

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [ ] `kubernetes` - Kubernetes resources, controllers, operators
- [ ] `deployment` - Application deployment logic
- [ ] `networking` - Ingress, services, network policies
- [ ] `storage` - Persistent volumes, storage classes
- [ ] `auth` - Authentication, authorization, RBAC
- [ ] `api` - REST API, serializers, handlers
- [ ] `cli` - Command-line interface
- [x] `config` - Configuration management
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

GitWhy context saved locally as `ctx_ce256dfa`.

🤖 Generated with [Codex](https://openai.com/codex)