### PR TITLE
fix(dashboard): verify self-deploy authenticated flows

### DIFF
--- a/dashboard/settings/ci.example.toml
+++ b/dashboard/settings/ci.example.toml
@@ -16,8 +16,8 @@
 jwt_secret = "ci-only-jwt-secret-not-for-production"
 
 # Redis URL for cookie session storage. Resolved by
-# `dashboard::config::settings::get_redis_url()`, which reads this TOML key
-# first and falls back to the `REINHARDT_CLOUD_REDIS_URL` env var.
+# `dashboard::config::settings::get_redis_url()`, which reads
+# `REINHARDT_CLOUD_REDIS_URL` first and falls back to this TOML key.
 # In CI, the env var typically points to a Redis service container or
 # TestContainers-managed instance.
 redis_url = "redis://localhost:6379/0"

--- a/dashboard/settings/local.example.toml
+++ b/dashboard/settings/local.example.toml
@@ -15,8 +15,8 @@
 jwt_secret = "CHANGE-ME-to-a-random-string"
 
 # Redis URL for cookie session storage. Resolved by
-# `dashboard::config::settings::get_redis_url()`, which reads this TOML key
-# first and falls back to the `REINHARDT_CLOUD_REDIS_URL` env var.
+# `dashboard::config::settings::get_redis_url()`, which reads
+# `REINHARDT_CLOUD_REDIS_URL` first and falls back to this TOML key.
 #
 # `${RC_REDIS_HOST:-localhost}` expands to the env var if set (the
 # `.devcontainer/` sets `RC_REDIS_HOST=redis` to point at the compose

--- a/dashboard/src/apps/auth/services/registration.rs
+++ b/dashboard/src/apps/auth/services/registration.rs
@@ -117,6 +117,19 @@ pub async fn register_inactive_user(
 /// - On unique-violation (rare race between two simultaneous registrations),
 ///   retry once with a 6-char uuid suffix appended to the slug
 pub async fn provision_personal_organization(created: &User) -> Result<(), AppError> {
+	provision_personal_organization_inner(created, true).await
+}
+
+/// Create a Personal `Organization` and Owner membership for an existing
+/// active user without rolling the user back on failure.
+pub async fn ensure_personal_organization(user: &User) -> Result<(), AppError> {
+	provision_personal_organization_inner(user, false).await
+}
+
+async fn provision_personal_organization_inner(
+	created: &User,
+	rollback_on_failure: bool,
+) -> Result<(), AppError> {
 	let now = Utc::now();
 	let mut slug = sanitize_username_to_slug(&created.username);
 	if is_reserved_slug(&slug) || validate_slug(&slug).is_err() {
@@ -158,7 +171,9 @@ pub async fn provision_personal_organization(created: &User) -> Result<(), AppEr
 							"Failed to provision Personal Org for user {} after retry: {e2}",
 							created.id
 						);
-						rollback_user(created).await;
+						if rollback_on_failure {
+							rollback_user(created).await;
+						}
 						return Err(AppError::Internal("Internal server error".to_string()));
 					}
 				}
@@ -167,7 +182,9 @@ pub async fn provision_personal_organization(created: &User) -> Result<(), AppEr
 					"Failed to provision Personal Org for user {}: {e}",
 					created.id
 				);
-				rollback_user(created).await;
+				if rollback_on_failure {
+					rollback_user(created).await;
+				}
 				return Err(AppError::Internal("Internal server error".to_string()));
 			}
 		}
@@ -196,7 +213,9 @@ pub async fn provision_personal_organization(created: &User) -> Result<(), AppEr
 		{
 			error!("Failed to roll back Organization after membership failure: {del_err}");
 		}
-		rollback_user(created).await;
+		if rollback_on_failure {
+			rollback_user(created).await;
+		}
 		return Err(AppError::Internal("Internal server error".to_string()));
 	}
 

--- a/dashboard/src/bin/manage.rs
+++ b/dashboard/src/bin/manage.rs
@@ -18,7 +18,9 @@
 //! target. Refs `kent8192/reinhardt-cloud#574`.
 
 #[cfg(not(target_arch = "wasm32"))]
-use reinhardt::commands::execute_from_command_line_with_settings;
+use reinhardt::commands::{CommandRegistry, execute_from_command_line_with_registry_and_settings};
+#[cfg(not(target_arch = "wasm32"))]
+use reinhardt_cloud_dashboard::config::management::SeedSelfDeployUserCommand;
 #[cfg(not(target_arch = "wasm32"))]
 use reinhardt_cloud_dashboard::config::settings::get_settings;
 #[cfg(not(target_arch = "wasm32"))]
@@ -36,7 +38,12 @@ async fn main() {
 		);
 	}
 
-	if let Err(e) = execute_from_command_line_with_settings(get_settings()).await {
+	let mut registry = CommandRegistry::new();
+	registry.register(Box::new(SeedSelfDeployUserCommand));
+
+	if let Err(e) =
+		execute_from_command_line_with_registry_and_settings(registry, get_settings()).await
+	{
 		eprintln!("Error: {e}");
 		process::exit(1);
 	}

--- a/dashboard/src/config.rs
+++ b/dashboard/src/config.rs
@@ -10,6 +10,8 @@ pub mod grpc_client;
 #[cfg(native)]
 pub mod hooks;
 #[cfg(native)]
+pub mod management;
+#[cfg(native)]
 pub mod middleware;
 #[cfg(native)]
 pub mod settings;

--- a/dashboard/src/config/management.rs
+++ b/dashboard/src/config/management.rs
@@ -102,6 +102,7 @@ async fn upsert_active_user(username: &str, password: &str, email: &str) -> Comm
 		.await
 		.map_err(|e| CommandError::ExecutionError(format!("failed to query E2E user: {e}")))?;
 
+	let user_exists = existing.is_some();
 	let mut user = existing.unwrap_or_else(|| {
 		User::build()
 			.username(username.to_string())
@@ -123,7 +124,7 @@ async fn upsert_active_user(username: &str, password: &str, email: &str) -> Comm
 		CommandError::ExecutionError(format!("failed to hash E2E user password: {e}"))
 	})?;
 
-	if existing_user_exists(&user).await? {
+	if user_exists {
 		User::objects()
 			.update(&user)
 			.await
@@ -134,15 +135,6 @@ async fn upsert_active_user(username: &str, password: &str, email: &str) -> Comm
 			.await
 			.map_err(|e| CommandError::ExecutionError(format!("failed to create E2E user: {e}")))
 	}
-}
-
-async fn existing_user_exists(user: &User) -> CommandResult<bool> {
-	User::objects()
-		.filter(User::field_id().eq(user.id.to_string()))
-		.first()
-		.await
-		.map(|maybe| maybe.is_some())
-		.map_err(|e| CommandError::ExecutionError(format!("failed to check E2E user id: {e}")))
 }
 
 async fn ensure_membership(user: &User) -> CommandResult<()> {

--- a/dashboard/src/config/management.rs
+++ b/dashboard/src/config/management.rs
@@ -1,0 +1,164 @@
+//! Dashboard-specific management commands.
+
+use async_trait::async_trait;
+use reinhardt::BaseUser;
+use reinhardt::commands::{BaseCommand, CommandContext, CommandError, CommandResult};
+use reinhardt::db::orm::Model;
+
+use crate::apps::auth::models::User;
+use crate::apps::auth::services::registration::ensure_personal_organization;
+use crate::apps::organizations::models::OrganizationMembership;
+
+const DEFAULT_E2E_USERNAME: &str = "e2e-user";
+const DEFAULT_E2E_PASSWORD: &str = "e2e-password-123456";
+const DEFAULT_E2E_EMAIL: &str = "e2e@example.test";
+
+/// Seed the deployed dashboard with a deterministic authenticated user.
+pub struct SeedSelfDeployUserCommand;
+
+#[async_trait]
+impl BaseCommand for SeedSelfDeployUserCommand {
+	fn name(&self) -> &str {
+		"seed-self-deploy-user"
+	}
+
+	fn description(&self) -> &str {
+		"Seed the Dashboard self-deploy E2E user and Personal Organization"
+	}
+
+	fn requires_system_checks(&self) -> bool {
+		false
+	}
+
+	async fn execute(&self, ctx: &CommandContext) -> CommandResult<()> {
+		initialize_orm_database().await?;
+
+		let username = command_value(
+			ctx,
+			0,
+			"DASHBOARD_SELF_DEPLOY_E2E_USERNAME",
+			DEFAULT_E2E_USERNAME,
+		);
+		let password = command_value(
+			ctx,
+			1,
+			"DASHBOARD_SELF_DEPLOY_E2E_PASSWORD",
+			DEFAULT_E2E_PASSWORD,
+		);
+		let email = command_value(ctx, 2, "DASHBOARD_SELF_DEPLOY_E2E_EMAIL", DEFAULT_E2E_EMAIL);
+
+		let user = upsert_active_user(&username, &password, &email).await?;
+		ensure_membership(&user).await?;
+
+		ctx.success(&format!(
+			"Seeded Dashboard self-deploy user username={} email={}",
+			user.username, user.email
+		));
+		Ok(())
+	}
+}
+
+fn command_value(ctx: &CommandContext, index: usize, env_key: &str, default: &str) -> String {
+	ctx.arg(index)
+		.cloned()
+		.or_else(|| std::env::var(env_key).ok())
+		.unwrap_or_else(|| default.to_string())
+}
+
+async fn initialize_orm_database() -> CommandResult<()> {
+	let settings = crate::config::settings::get_settings();
+	let env_database_url = std::env::var("DATABASE_URL").ok();
+	let url = match env_database_url.as_deref() {
+		Some(url) => url.to_string(),
+		None => settings
+			.core
+			.databases
+			.get("default")
+			.map(|database| database.to_url())
+			.ok_or_else(|| {
+				CommandError::ExecutionError(
+					"database configuration `core.databases.default` not found".to_string(),
+				)
+			})?,
+	};
+
+	if env_database_url.as_deref() != Some(url.as_str()) {
+		// SAFETY: This management command runs before spawning application tasks.
+		unsafe {
+			std::env::set_var("DATABASE_URL", &url);
+		}
+	}
+
+	reinhardt::db::orm::init_database(&url)
+		.await
+		.map_err(|e| CommandError::ExecutionError(format!("failed to initialize ORM: {e}")))?;
+	Ok(())
+}
+
+async fn upsert_active_user(username: &str, password: &str, email: &str) -> CommandResult<User> {
+	let existing = User::objects()
+		.filter(User::field_username().eq(username.to_string()))
+		.first()
+		.await
+		.map_err(|e| CommandError::ExecutionError(format!("failed to query E2E user: {e}")))?;
+
+	let mut user = existing.unwrap_or_else(|| {
+		User::build()
+			.username(username.to_string())
+			.email(email.to_string())
+			.first_name(String::new())
+			.last_name(String::new())
+			.password_hash(None)
+			.is_active(true)
+			.is_staff(false)
+			.is_superuser(false)
+			.finish()
+	});
+
+	user.email = email.to_string();
+	user.is_active = true;
+	user.is_staff = false;
+	user.is_superuser = false;
+	user.set_password(password).map_err(|e| {
+		CommandError::ExecutionError(format!("failed to hash E2E user password: {e}"))
+	})?;
+
+	if existing_user_exists(&user).await? {
+		User::objects()
+			.update(&user)
+			.await
+			.map_err(|e| CommandError::ExecutionError(format!("failed to update E2E user: {e}")))
+	} else {
+		User::objects()
+			.create(&user)
+			.await
+			.map_err(|e| CommandError::ExecutionError(format!("failed to create E2E user: {e}")))
+	}
+}
+
+async fn existing_user_exists(user: &User) -> CommandResult<bool> {
+	User::objects()
+		.filter(User::field_id().eq(user.id.to_string()))
+		.first()
+		.await
+		.map(|maybe| maybe.is_some())
+		.map_err(|e| CommandError::ExecutionError(format!("failed to check E2E user id: {e}")))
+}
+
+async fn ensure_membership(user: &User) -> CommandResult<()> {
+	let membership = OrganizationMembership::objects()
+		.filter(OrganizationMembership::field_user_id().eq(user.id.to_string()))
+		.first()
+		.await
+		.map_err(|e| {
+			CommandError::ExecutionError(format!("failed to query E2E user membership: {e}"))
+		})?;
+
+	if membership.is_some() {
+		return Ok(());
+	}
+
+	ensure_personal_organization(user)
+		.await
+		.map_err(|e| CommandError::ExecutionError(format!("failed to provision E2E org: {e}")))
+}

--- a/dashboard/src/config/settings.rs
+++ b/dashboard/src/config/settings.rs
@@ -184,12 +184,12 @@ async fn create_project_settings() -> ProjectSettings {
 /// Get Redis URL from settings or environment.
 ///
 /// Priority (highest to lowest):
-/// 1. `redis_url` key in the active TOML settings file
-/// 2. `REINHARDT_CLOUD_REDIS_URL` environment variable (fallback for CI/container overrides)
+/// 1. `REINHARDT_CLOUD_REDIS_URL` environment variable (container/operator override)
+/// 2. `redis_url` key in the active TOML settings file
 ///
 /// Returns `None` if the Redis URL is not configured in either source.
 pub fn get_redis_url() -> Option<String> {
-	get_top_level_string("redis_url", "REINHARDT_CLOUD_REDIS_URL")
+	get_env_or_top_level_string("REINHARDT_CLOUD_REDIS_URL", "redis_url")
 }
 
 /// Get the JWT signing secret from settings or environment.
@@ -232,6 +232,17 @@ fn get_top_level_string(key: &str, env_var: &str) -> Option<String> {
 	}
 
 	env::var(env_var).ok()
+}
+
+/// Resolve an environment variable with a top-level TOML string fallback.
+///
+/// Containerized deployments inject runtime infrastructure endpoints after
+/// TOML settings are selected, so these env vars must be able to override
+/// profile defaults such as `ci.toml`.
+fn get_env_or_top_level_string(env_var: &str, key: &str) -> Option<String> {
+	env::var(env_var)
+		.ok()
+		.or_else(|| get_top_level_string(key, env_var))
 }
 
 #[cfg(test)]
@@ -447,6 +458,33 @@ allow_origins = ["http://localhost:8000"]
 		// Assert
 		assert!(secret.is_some(), "expected jwt_secret from local.toml");
 		assert!(!secret.unwrap().is_empty());
+	}
+
+	#[rstest]
+	#[serial(env_settings_load)]
+	fn test_get_redis_url_prefers_runtime_env_over_profile_toml() {
+		// Arrange — `ci.toml` contains a localhost Redis fallback, but deployed
+		// pods receive the real Redis endpoint from the operator at runtime.
+		let watched = [
+			"REINHARDT_CLOUD_CONFIG_DIR",
+			"REINHARDT_ENV",
+			"REINHARDT_CLOUD_REDIS_URL",
+		];
+		let _guard = EnvSnapshot::new(&watched);
+
+		// SAFETY: `#[serial(env_settings_load)]` provides the cross-test
+		// exclusion that `set_var`/`remove_var` need.
+		unsafe {
+			env::remove_var("REINHARDT_CLOUD_CONFIG_DIR");
+			env::set_var("REINHARDT_ENV", "ci");
+			env::set_var("REINHARDT_CLOUD_REDIS_URL", "redis://operator-redis:6379/0");
+		}
+
+		// Act
+		let redis_url = get_redis_url();
+
+		// Assert
+		assert_eq!(redis_url.as_deref(), Some("redis://operator-redis:6379/0"));
 	}
 
 	/// `production.toml` rewritten in #588 must fail-fast at startup if any

--- a/docs/development/LOCAL_E2E_TESTING.md
+++ b/docs/development/LOCAL_E2E_TESTING.md
@@ -54,7 +54,10 @@ when no in-cluster Operator is already installed, generates the Dashboard
 `ReinhardtApp` with `reinhardt-cloud deploy --dir dashboard --dry-run`, requires
 Dashboard `manage introspect` to succeed, applies the same contract through
 `--direct`, waits for the Operator-owned Deployment, Service, cache/database
-resources, Pods, and live `ReinhardtApp`, then removes the temporary namespace.
+resources, Pods, and live `ReinhardtApp`, seeds an active Dashboard user with
+its Personal Organization, verifies login through the deployed frontend server
+function, checks authenticated Dashboard pages, then removes the temporary
+namespace.
 
 Useful overrides:
 
@@ -74,12 +77,19 @@ Useful overrides:
 | `DASHBOARD_SELF_DEPLOY_ARTIFACT_DIR` | `target/dashboard-self-deploy-e2e/<namespace>` | Failure diagnostics and generated YAML. |
 | `DASHBOARD_SELF_DEPLOY_KUBECTL_CONTEXT` | current context | Kubernetes context for `kubectl`. |
 | `DASHBOARD_SELF_DEPLOY_KIND_CLUSTER` | inferred from `kind-*` context | Explicit `kind load docker-image` target. |
+| `DASHBOARD_SELF_DEPLOY_E2E_USERNAME` | `e2e-user` | Username seeded inside the deployed Dashboard Pod for authenticated flow checks. |
+| `DASHBOARD_SELF_DEPLOY_E2E_PASSWORD` | `e2e-password-123456` | Password assigned to the seeded Dashboard user. |
+| `DASHBOARD_SELF_DEPLOY_E2E_EMAIL` | `e2e@example.test` | Email assigned to the seeded Dashboard user. |
+| `DASHBOARD_SELF_DEPLOY_PORT_FORWARD_PORT` | `18080` | Local port used for Dashboard health, login, and authenticated page checks. |
+| `DASHBOARD_SELF_DEPLOY_ORIGIN` | `http://127.0.0.1:8000` | Origin/Referer used for server function POSTs. The default matches the CI `OriginGuardMiddleware` allow-list. |
 
 On failure the harness writes events, live `ReinhardtApp` YAML, owned resource
 YAML, Pod logs, Operator logs, and the generated CRD YAML under the artifact
-directory before cleanup. This harness validates the generated-config →
-`--direct` → Operator reconciliation contract. The Dashboard → Agent relay is
-still limited as described in [Known limitations](#known-limitations).
+directory before cleanup. Login responses, cookies, and authenticated page
+responses are also preserved there. This harness validates the generated-config
+→ `--direct` → Operator reconciliation → authenticated Dashboard contract. The
+Dashboard → Agent relay is still limited as described in
+[Known limitations](#known-limitations).
 
 ## 1. Bring up a local Kubernetes cluster
 

--- a/scripts/dashboard_self_deploy_e2e.sh
+++ b/scripts/dashboard_self_deploy_e2e.sh
@@ -472,6 +472,23 @@ start_dashboard_port_forward() {
 	die "dashboard health endpoint was not reachable through port-forward"
 }
 
+fetch_authenticated_dashboard_page() {
+	local base_url="$1"
+	local cookie_jar="$2"
+	local path="$3"
+	local output="$4"
+	local marker="$5"
+	local status
+
+	status="$(curl -sS -L -o "${output}" -w "%{http_code}" \
+		-b "${cookie_jar}" "${base_url}${path}" || true)"
+	[[ "${status}" == "200" ]] \
+		|| die "authenticated ${path} page returned HTTP ${status}; see ${output}"
+
+	grep -Fq -- "${marker}" "${output}" \
+		|| die "authenticated ${path} page did not render ${marker}; see ${output}"
+}
+
 verify_authenticated_frontend_flows() {
 	local base_url="http://127.0.0.1:${PORT_FORWARD_PORT}"
 	local cookie_jar="${ARTIFACT_DIR}/dashboard-cookie.jar"
@@ -496,12 +513,10 @@ verify_authenticated_frontend_flows() {
 	grep -Eq '"success"[[:space:]]*:[[:space:]]*true' "${login_body}" \
 		|| die "login server function did not return success=true; see ${login_body}"
 
-	curl -fsS -b "${cookie_jar}" "${base_url}/clusters" \
-		>"${ARTIFACT_DIR}/clusters.html" \
-		|| die "authenticated /clusters request failed"
-	curl -fsS -b "${cookie_jar}" "${base_url}/deployments" \
-		>"${ARTIFACT_DIR}/deployments.html" \
-		|| die "authenticated /deployments request failed"
+	fetch_authenticated_dashboard_page \
+		"${base_url}" "${cookie_jar}" "/clusters/" "${ARTIFACT_DIR}/clusters.html" "Cluster Inventory"
+	fetch_authenticated_dashboard_page \
+		"${base_url}" "${cookie_jar}" "/deployments/" "${ARTIFACT_DIR}/deployments.html" "Deployment Inventory"
 }
 
 main() {

--- a/scripts/dashboard_self_deploy_e2e.sh
+++ b/scripts/dashboard_self_deploy_e2e.sh
@@ -21,9 +21,16 @@ MANAGE_ENV="${DASHBOARD_SELF_DEPLOY_REINHARDT_ENV:-${REINHARDT_ENV:-ci}}"
 RUNTIME_SECRET="${DASHBOARD_SELF_DEPLOY_RUNTIME_SECRET:-reinhardt-cloud-dashboard-secrets}"
 KUBECTL_CONTEXT="${DASHBOARD_SELF_DEPLOY_KUBECTL_CONTEXT:-}"
 KIND_CLUSTER="${DASHBOARD_SELF_DEPLOY_KIND_CLUSTER:-}"
+E2E_USERNAME="${DASHBOARD_SELF_DEPLOY_E2E_USERNAME:-e2e-user}"
+E2E_PASSWORD="${DASHBOARD_SELF_DEPLOY_E2E_PASSWORD:-e2e-password-123456}"
+E2E_EMAIL="${DASHBOARD_SELF_DEPLOY_E2E_EMAIL:-e2e@example.test}"
+PORT_FORWARD_PORT="${DASHBOARD_SELF_DEPLOY_PORT_FORWARD_PORT:-18080}"
+E2E_ORIGIN="${DASHBOARD_SELF_DEPLOY_ORIGIN:-http://127.0.0.1:8000}"
 
 OPERATOR_PID=""
+PORT_FORWARD_PID=""
 OPERATOR_LOG="${ARTIFACT_DIR}/operator.log"
+PORT_FORWARD_LOG="${ARTIFACT_DIR}/port-forward.log"
 DRY_RUN_YAML="${ARTIFACT_DIR}/reinhardt-app.yaml"
 CREATED_NAMESPACE=0
 
@@ -94,6 +101,12 @@ cleanup() {
 		wait "${OPERATOR_PID}" >/dev/null 2>&1 || true
 	fi
 
+	if [[ -n "${PORT_FORWARD_PID}" ]]; then
+		log "stopping port-forward process ${PORT_FORWARD_PID}"
+		stop_process_tree "${PORT_FORWARD_PID}"
+		wait "${PORT_FORWARD_PID}" >/dev/null 2>&1 || true
+	fi
+
 	if [[ "${KEEP_RESOURCES}" == "1" ]]; then
 		log "keeping namespace ${NAMESPACE} and artifacts ${ARTIFACT_DIR}"
 		exit "${status}"
@@ -114,6 +127,7 @@ require_prerequisites() {
 	command_exists docker || die "docker is required"
 	command_exists kubectl || die "kubectl is required"
 	command_exists cargo || die "cargo is required"
+	command_exists curl || die "curl is required"
 
 	docker info >/dev/null || die "Docker is not reachable"
 	kubectl_cmd version --client >/dev/null || die "kubectl client is not usable"
@@ -152,12 +166,16 @@ ensure_runtime_secret() {
 			if [[ -z "${secret_name}" || -z "${secret_key}" ]]; then
 				continue
 			fi
+			local secret_value="e2e-placeholder"
+			if [[ "${secret_name}" == "${RUNTIME_SECRET}" && "${secret_key}" == "email-host" ]]; then
+				secret_value="localhost"
+			fi
 			kubectl_cmd create secret generic "${secret_name}" -n "${NAMESPACE}" \
 				--from-literal=placeholder=unused \
 				--dry-run=client -o yaml | kubectl_cmd apply -f -
 			kubectl_cmd patch secret "${secret_name}" -n "${NAMESPACE}" \
 				--type merge \
-				-p "{\"stringData\":{\"${secret_key}\":\"e2e-placeholder\"}}" >/dev/null
+				-p "{\"stringData\":{\"${secret_key}\":\"${secret_value}\"}}" >/dev/null
 		done
 }
 
@@ -398,6 +416,94 @@ wait_for_reconciliation() {
 		-l "app.kubernetes.io/name=${APP_NAME}" -o wide >"${ARTIFACT_DIR}/ready-resources.txt"
 }
 
+dashboard_pod_name() {
+	local deadline
+	local pods
+	deadline=$((SECONDS + $(timeout_seconds)))
+
+	while (( SECONDS < deadline )); do
+		pods="$(kubectl_cmd get pod -n "${NAMESPACE}" \
+			-l "app.kubernetes.io/name=${APP_NAME},app.kubernetes.io/component=web" \
+			-o go-template='{{range .items}}{{ $name := .metadata.name }}{{ if not .metadata.deletionTimestamp }}{{ range .status.conditions }}{{ if and (eq .type "Ready") (eq .status "True") }}{{ $name }}{{ "\n" }}{{ end }}{{ end }}{{ end }}{{ end }}' \
+			2>/dev/null || true)"
+		if [[ -n "${pods}" ]]; then
+			printf '%s\n' "${pods}" | head -n 1
+			return
+		fi
+		sleep 3
+	done
+}
+
+seed_authenticated_user() {
+	local pod
+	pod="$(dashboard_pod_name)"
+	if [[ -z "${pod}" ]]; then
+		die "could not find dashboard web pod"
+	fi
+
+	log "seeding authenticated dashboard user in pod ${pod}"
+	kubectl_cmd exec -n "${NAMESPACE}" "${pod}" -c "${APP_NAME}" -- env \
+		DASHBOARD_SELF_DEPLOY_E2E_USERNAME="${E2E_USERNAME}" \
+		DASHBOARD_SELF_DEPLOY_E2E_PASSWORD="${E2E_PASSWORD}" \
+		DASHBOARD_SELF_DEPLOY_E2E_EMAIL="${E2E_EMAIL}" \
+		/app/manage seed-self-deploy-user
+}
+
+start_dashboard_port_forward() {
+	mkdir -p "${ARTIFACT_DIR}"
+	log "starting dashboard port-forward on 127.0.0.1:${PORT_FORWARD_PORT}; logs: ${PORT_FORWARD_LOG}"
+	kubectl_cmd port-forward -n "${NAMESPACE}" "service/${APP_NAME}" "${PORT_FORWARD_PORT}:80" \
+		>"${PORT_FORWARD_LOG}" 2>&1 &
+	PORT_FORWARD_PID=$!
+
+	local deadline
+	deadline=$((SECONDS + 30))
+	while ((SECONDS < deadline)); do
+		if curl -fsS "http://127.0.0.1:${PORT_FORWARD_PORT}/api/healthz/" \
+			>"${ARTIFACT_DIR}/healthz.json" 2>"${ARTIFACT_DIR}/healthz.err"; then
+			return
+		fi
+		if ! kill -0 "${PORT_FORWARD_PID}" >/dev/null 2>&1; then
+			die "dashboard port-forward exited during startup; see ${PORT_FORWARD_LOG}"
+		fi
+		sleep 1
+	done
+
+	die "dashboard health endpoint was not reachable through port-forward"
+}
+
+verify_authenticated_frontend_flows() {
+	local base_url="http://127.0.0.1:${PORT_FORWARD_PORT}"
+	local cookie_jar="${ARTIFACT_DIR}/dashboard-cookie.jar"
+	local login_body="${ARTIFACT_DIR}/login-response.json"
+	local login_error="${ARTIFACT_DIR}/login.err"
+	local login_status
+
+	log "verifying authenticated dashboard frontend flows"
+	login_status="$(curl -sS -o "${login_body}" -w "%{http_code}" -c "${cookie_jar}" \
+		-H "Content-Type: application/x-www-form-urlencoded" \
+		-H "Origin: ${E2E_ORIGIN}" \
+		-H "Referer: ${E2E_ORIGIN}/login" \
+		--data-urlencode "username=${E2E_USERNAME}" \
+		--data-urlencode "password=${E2E_PASSWORD}" \
+		"${base_url}/api/server_fn/login" \
+		2>"${login_error}" \
+		|| true)"
+	if [[ "${login_status}" != "200" ]]; then
+		die "login server function returned HTTP ${login_status}; see ${login_error} and ${login_body}"
+	fi
+
+	grep -Eq '"success"[[:space:]]*:[[:space:]]*true' "${login_body}" \
+		|| die "login server function did not return success=true; see ${login_body}"
+
+	curl -fsS -b "${cookie_jar}" "${base_url}/clusters" \
+		>"${ARTIFACT_DIR}/clusters.html" \
+		|| die "authenticated /clusters request failed"
+	curl -fsS -b "${cookie_jar}" "${base_url}/deployments" \
+		>"${ARTIFACT_DIR}/deployments.html" \
+		|| die "authenticated /deployments request failed"
+}
+
 main() {
 	log "namespace=${NAMESPACE}"
 	log "app=${APP_NAME}"
@@ -416,6 +522,9 @@ main() {
 	generate_reinhardt_app_yaml
 	apply_reinhardt_app_direct
 	wait_for_reconciliation
+	seed_authenticated_user
+	start_dashboard_port_forward
+	verify_authenticated_frontend_flows
 
 	log "completed successfully"
 	log "artifacts kept at ${ARTIFACT_DIR}"


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds a deterministic `seed-self-deploy-user` dashboard management command for self-deploy E2E auth setup.
- Extends the dashboard self-deploy harness to seed a user, log in through the deployed server function, and verify authenticated `/clusters` and `/deployments` pages.
- Prefers the operator-injected `REINHARDT_CLOUD_REDIS_URL` over profile TOML Redis defaults so deployed session storage uses the reconciled Redis service.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

The self-deploy harness previously proved only the generated-config to Operator reconciliation contract. It could not prove that the deployed dashboard could authenticate and load authenticated frontend pages. Registration is not deterministic in self-deploy because placeholder mail settings can break email delivery, and `createsuperuser` does not create the Personal Organization membership needed by dashboard pages.

Fixes #654

Related to: #638, #642, #644

## How Was This Tested?

- [x] `cargo fmt`
- [x] `cargo fmt --check`
- [x] `bash -n scripts/dashboard_self_deploy_e2e.sh`
- [x] `cargo check -p reinhardt-cloud-dashboard --all-targets`
- [x] `cargo test -p reinhardt-cloud-dashboard --lib config::settings::tests::test_get_redis_url_prefers_runtime_env_over_profile_toml`
- [x] `git diff --check`
- [x] `cargo make dashboard-self-deploy-e2e`
- [x] `DASHBOARD_SELF_DEPLOY_BUILD_IMAGE=0 cargo make dashboard-self-deploy-e2e`

## Performance Impact

Not performance-related. The new seed command only runs when explicitly invoked by the E2E harness.

## Breaking Changes

None.

## Screenshots

Not a UI rendering change.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

<!-- ⚠️ CI CONTROL CHECKBOX - DO NOT EDIT MANUALLY ⚠️
The following checkbox controls CI runner selection.
Checking this option triggers self-hosted runner usage,
which incurs infrastructure costs. Only the repository owner should enable this.
If this checkbox is missing or unchecked, CI defaults to GitHub-hosted runners.
Do NOT modify the checkbox text — CI parses it by exact pattern match. -->
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #654
- Related to #638
- Related to #642
- Related to #644

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [ ] `kubernetes` - Kubernetes resources, controllers, operators
- [x] `deployment` - Application deployment logic
- [ ] `networking` - Ingress, services, network policies
- [ ] `storage` - Persistent volumes, storage classes
- [x] `auth` - Authentication, authorization, RBAC
- [ ] `api` - REST API, serializers, handlers
- [ ] `cli` - Command-line interface
- [x] `config` - Configuration management
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

GitWhy context saved locally: `ctx_db89837d`.

Generated with OpenAI Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI command to seed dashboard users for self-deploy scenarios with configurable credentials
  * Enhanced end-to-end testing with authenticated user provisioning and frontend deployment verification

* **Documentation**
  * Clarified Redis URL configuration: environment variable now takes priority over TOML settings
  * Expanded testing guide with setup procedures and validation steps

* **Refactor**
  * Improved organization provisioning with conditional rollback handling
  * Reorganized command infrastructure for better maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->