### PR TITLE
fix(dashboard): hide disabled OAuth providers

### DIFF
--- a/dashboard/src/apps/auth/client/components.rs
+++ b/dashboard/src/apps/auth/client/components.rs
@@ -4,4 +4,4 @@ pub mod auth_layout;
 pub mod oauth_buttons;
 
 pub use auth_layout::auth_layout;
-pub use oauth_buttons::oauth_buttons;
+pub use oauth_buttons::ensure_oauth_buttons_connected;

--- a/dashboard/src/apps/auth/client/components/oauth_buttons.rs
+++ b/dashboard/src/apps/auth/client/components/oauth_buttons.rs
@@ -26,7 +26,7 @@ pub fn ensure_oauth_buttons_connected(container_id: &'static str, verb: &'static
 
 /// Non-WASM stub so native builds can share the same client entry wiring.
 #[cfg(not(wasm))]
-#[allow(dead_code)]
+#[allow(dead_code)] // Called from WASM route wiring only; native builds keep the shared API surface.
 pub fn ensure_oauth_buttons_connected(_container_id: &'static str, _verb: &'static str) {}
 
 #[cfg(wasm)]

--- a/dashboard/src/apps/auth/client/components/oauth_buttons.rs
+++ b/dashboard/src/apps/auth/client/components/oauth_buttons.rs
@@ -5,80 +5,72 @@
 //! navigation, the server issues a 302 to the provider's authorize URL,
 //! and the user lands back on `/api/auth/oauth/{provider}/callback/`.
 
-use reinhardt::pages::component::Page;
-use reinhardt::pages::page;
-use reinhardt::pages::prelude::{ResourceState, use_resource};
-
+#[cfg(wasm)]
 use crate::apps::auth::server::oauth_providers::OAuthProviderInfo;
 #[cfg(wasm)]
 use crate::apps::auth::server::oauth_providers::list_oauth_providers;
 
+/// Populate an OAuth provider mount point from server-side configuration.
 #[cfg(wasm)]
-async fn load_oauth_providers() -> Result<Vec<OAuthProviderInfo>, String> {
-	list_oauth_providers().await.map_err(|e| e.to_string())
-}
-
-#[cfg(not(wasm))]
-async fn load_oauth_providers() -> Result<Vec<OAuthProviderInfo>, String> {
-	Ok(Vec::new())
-}
-
-/// Render the OAuth provider button group below the password form.
-///
-/// `verb` is the leading word ("Sign in" on login, "Sign up" on register)
-/// so the button reads naturally in context.
-pub fn oauth_buttons(verb: &'static str) -> Page {
-	let providers = use_resource(|| async move { self::load_oauth_providers().await }, ());
-
-	page!(|verb: &'static str,
-	       providers: reinhardt::pages::prelude::Resource<Vec<OAuthProviderInfo>, String>| {
-		{
-			match providers.get() {
-				ResourceState::Success(providers) if !providers.is_empty() => {
-					page!(|verb: &'static str, providers: Vec<OAuthProviderInfo>| {
-						div {
-							class: "mt-6",
-							div {
-								class: "relative",
-								div {
-									class: "absolute inset-0 flex items-center",
-									span {
-										class: "w-full border-t border-gray-200",
-									}
-								}
-								div {
-									class: "relative flex justify-center text-xs uppercase",
-									span {
-										class: "bg-white px-2 text-gray-500",
-										"Or continue with"
-									}
-								}
-							}
-							div {
-								class: "mt-4 grid grid-cols-1 gap-2",
-								{
-									providers
-										.clone()
-										.into_iter()
-										.map(|provider| {
-											page!(|verb: &'static str, provider: OAuthProviderInfo| {
-												a {
-													href: format!("/api/auth/oauth/{}/start/", provider.id),
-													class: "inline-flex items-center justify-center w-full py-2.5 text-sm font-medium border border-gray-300 rounded-md hover:bg-gray-50",
-													{
-														format!("{verb} with {}", provider.label)
-													}
-												}
-											})(verb, provider)
-										})
-										.collect::<Vec<_>>()
-								}
-							}
-						}
-					})(verb, providers)
-				}
-				_ => Page::Empty,
-			}
+pub fn ensure_oauth_buttons_connected(container_id: &'static str, verb: &'static str) {
+	wasm_bindgen_futures::spawn_local(async move {
+		let Ok(providers) = list_oauth_providers().await else {
+			return;
+		};
+		if providers.is_empty() {
+			return;
 		}
-	})(verb, providers)
+		render_oauth_buttons(container_id, verb, providers);
+	});
+}
+
+/// Non-WASM stub so native builds can share the same client entry wiring.
+#[cfg(not(wasm))]
+#[allow(dead_code)]
+pub fn ensure_oauth_buttons_connected(_container_id: &'static str, _verb: &'static str) {}
+
+#[cfg(wasm)]
+fn render_oauth_buttons(container_id: &str, verb: &str, providers: Vec<OAuthProviderInfo>) {
+	let Some(document) = web_sys::window().and_then(|window| window.document()) else {
+		return;
+	};
+	let Some(container) = document.get_element_by_id(container_id) else {
+		return;
+	};
+	container.set_inner_html("");
+
+	let Ok(wrapper) = document.create_element("div") else {
+		return;
+	};
+	let _ = wrapper.set_attribute("class", "mt-6");
+
+	let Ok(divider) = document.create_element("div") else {
+		return;
+	};
+	let _ = divider.set_attribute("class", "relative");
+	divider.set_inner_html(
+		r#"<div class="absolute inset-0 flex items-center"><span class="w-full border-t border-gray-200"></span></div><div class="relative flex justify-center text-xs uppercase"><span class="bg-white px-2 text-gray-500">Or continue with</span></div>"#,
+	);
+	let _ = wrapper.append_child(&divider);
+
+	let Ok(grid) = document.create_element("div") else {
+		return;
+	};
+	let _ = grid.set_attribute("class", "mt-4 grid grid-cols-1 gap-2");
+
+	for provider in providers {
+		let Ok(anchor) = document.create_element("a") else {
+			continue;
+		};
+		let _ = anchor.set_attribute("href", &format!("/api/auth/oauth/{}/start/", provider.id));
+		let _ = anchor.set_attribute(
+			"class",
+			"inline-flex items-center justify-center w-full py-2.5 text-sm font-medium border border-gray-300 rounded-md hover:bg-gray-50",
+		);
+		anchor.set_text_content(Some(&format!("{verb} with {}", provider.label)));
+		let _ = grid.append_child(&anchor);
+	}
+
+	let _ = wrapper.append_child(&grid);
+	let _ = container.append_child(&wrapper);
 }

--- a/dashboard/src/apps/auth/client/components/oauth_buttons.rs
+++ b/dashboard/src/apps/auth/client/components/oauth_buttons.rs
@@ -1,56 +1,84 @@
 //! OAuth provider sign-in buttons.
 //!
-//! Renders one anchor per supported provider (today: GitHub only — see
-//! #428 / #440 for GitLab follow-up). Each button is a plain link to
+//! Renders one anchor per enabled provider. Each button is a plain link to
 //! `/api/auth/oauth/{provider}/start/` so the browser performs a normal
 //! navigation, the server issues a 302 to the provider's authorize URL,
 //! and the user lands back on `/api/auth/oauth/{provider}/callback/`.
-//!
-//! The button is unconditionally rendered. If the provider is not
-//! configured server-side (no `REINHARDT_CLOUD_OAUTH_GITHUB_*` env
-//! vars), the `start` endpoint returns 404, surfacing the
-//! misconfiguration to the operator rather than silently hiding the
-//! button. Once #440 lands and we have multiple providers, this should
-//! switch to fetching the discovery endpoint
-//! (`/api/auth/oauth/providers/`) to render only the enabled set.
 
 use reinhardt::pages::component::Page;
 use reinhardt::pages::page;
+use reinhardt::pages::prelude::{ResourceState, use_resource};
+
+use crate::apps::auth::server::oauth_providers::OAuthProviderInfo;
+#[cfg(wasm)]
+use crate::apps::auth::server::oauth_providers::list_oauth_providers;
+
+#[cfg(wasm)]
+async fn load_oauth_providers() -> Result<Vec<OAuthProviderInfo>, String> {
+	list_oauth_providers().await.map_err(|e| e.to_string())
+}
+
+#[cfg(not(wasm))]
+async fn load_oauth_providers() -> Result<Vec<OAuthProviderInfo>, String> {
+	Ok(Vec::new())
+}
 
 /// Render the OAuth provider button group below the password form.
 ///
 /// `verb` is the leading word ("Sign in" on login, "Sign up" on register)
 /// so the button reads naturally in context.
 pub fn oauth_buttons(verb: &'static str) -> Page {
-	page!(|verb: &'static str| {
-		div {
-			class: "mt-6",
-			div {
-				class: "relative",
-				div {
-					class: "absolute inset-0 flex items-center",
-					span {
-						class: "w-full border-t border-gray-200",
-					}
+	let providers = use_resource(|| async move { self::load_oauth_providers().await }, ());
+
+	page!(|verb: &'static str,
+	       providers: reinhardt::pages::prelude::Resource<Vec<OAuthProviderInfo>, String>| {
+		{
+			match providers.get() {
+				ResourceState::Success(providers) if !providers.is_empty() => {
+					page!(|verb: &'static str, providers: Vec<OAuthProviderInfo>| {
+						div {
+							class: "mt-6",
+							div {
+								class: "relative",
+								div {
+									class: "absolute inset-0 flex items-center",
+									span {
+										class: "w-full border-t border-gray-200",
+									}
+								}
+								div {
+									class: "relative flex justify-center text-xs uppercase",
+									span {
+										class: "bg-white px-2 text-gray-500",
+										"Or continue with"
+									}
+								}
+							}
+							div {
+								class: "mt-4 grid grid-cols-1 gap-2",
+								{
+									providers
+										.clone()
+										.into_iter()
+										.map(|provider| {
+											page!(|verb: &'static str, provider: OAuthProviderInfo| {
+												a {
+													href: format!("/api/auth/oauth/{}/start/", provider.id),
+													class: "inline-flex items-center justify-center w-full py-2.5 text-sm font-medium border border-gray-300 rounded-md hover:bg-gray-50",
+													{
+														format!("{verb} with {}", provider.label)
+													}
+												}
+											})(verb, provider)
+										})
+										.collect::<Vec<_>>()
+								}
+							}
+						}
+					})(verb, providers)
 				}
-				div {
-					class: "relative flex justify-center text-xs uppercase",
-					span {
-						class: "bg-white px-2 text-gray-500",
-						"Or continue with"
-					}
-				}
-			}
-			div {
-				class: "mt-4 grid grid-cols-1 gap-2",
-				a {
-					href: "/api/auth/oauth/github/start/",
-					class: "inline-flex items-center justify-center w-full py-2.5 text-sm font-medium border border-gray-300 rounded-md hover:bg-gray-50",
-					{
-						format!("{verb} with GitHub")
-					}
-				}
+				_ => Page::Empty,
 			}
 		}
-	})(verb)
+	})(verb, providers)
 }

--- a/dashboard/src/apps/auth/client/pages/login.rs
+++ b/dashboard/src/apps/auth/client/pages/login.rs
@@ -8,7 +8,6 @@ use reinhardt::pages::component::Page;
 use reinhardt::pages::form;
 use reinhardt::pages::page;
 
-use crate::apps::auth::client::components::oauth_buttons;
 use crate::apps::auth::server::login::login;
 
 /// Render the login page.
@@ -39,22 +38,43 @@ pub fn login_page() -> Page {
 		},
 	};
 	let form_view = login_form.into_page();
-	let oauth_view = oauth_buttons("Sign in");
 
-	let content = page!(|form_view: Page, oauth_view: Page| {
+	page!(|form_view: Page| {
 		div {
-			{ form_view }
-			{ oauth_view }
+			class: "min-h-screen flex items-center justify-center bg-gray-50",
 			div {
-				class: "mt-6 text-center text-sm text-gray-600",
-				"Don't have an account? " a {
-					href: "/register".to_string(),
-					class: "text-blue-600 font-medium hover:underline",
-					"Create one"
+				class: "w-full max-w-md",
+				div {
+					class: "text-center mb-8",
+					h1 {
+						class: "text-3xl font-bold text-blue-600",
+						"Reinhardt Cloud"
+					}
+					p {
+						class: "text-sm text-gray-500 mt-1",
+						"Cloud Platform"
+					}
+				}
+				div {
+					class: "bg-white rounded-lg border border-gray-200 shadow-sm p-8",
+					h2 {
+						class: "text-xl font-semibold text-gray-800 mb-6 text-center",
+						"Sign in to your account"
+					}
+					{ form_view }
+					div {
+						id: "oauth-login-providers",
+					}
+					div {
+						class: "mt-6 text-center text-sm text-gray-600",
+						"Don't have an account? " a {
+							href: "/register".to_string(),
+							class: "text-blue-600 font-medium hover:underline",
+							"Create one"
+						}
+					}
 				}
 			}
 		}
-	})(form_view, oauth_view);
-
-	crate::apps::auth::client::components::auth_layout("Sign in to your account", content)
+	})(form_view)
 }

--- a/dashboard/src/apps/auth/client/pages/register.rs
+++ b/dashboard/src/apps/auth/client/pages/register.rs
@@ -8,7 +8,6 @@ use reinhardt::pages::component::Page;
 use reinhardt::pages::form;
 use reinhardt::pages::page;
 
-use crate::apps::auth::client::components::{auth_layout, oauth_buttons};
 use crate::apps::auth::server::register::register;
 
 /// Render the registration page inside the shared auth layout.
@@ -44,22 +43,43 @@ pub fn register_page() -> Page {
 		},
 	};
 	let form_view = register_form.into_page();
-	let oauth_view = oauth_buttons("Sign up");
 
-	let content = page!(|form_view: Page, oauth_view: Page| {
+	page!(|form_view: Page| {
 		div {
-			{ form_view }
-			{ oauth_view }
+			class: "min-h-screen flex items-center justify-center bg-gray-50",
 			div {
-				class: "mt-6 text-center text-sm text-gray-600",
-				"Already have an account? " a {
-					href: "/login".to_string(),
-					class: "text-blue-600 font-medium hover:underline",
-					"Sign in"
+				class: "w-full max-w-md",
+				div {
+					class: "text-center mb-8",
+					h1 {
+						class: "text-3xl font-bold text-blue-600",
+						"Reinhardt Cloud"
+					}
+					p {
+						class: "text-sm text-gray-500 mt-1",
+						"Cloud Platform"
+					}
+				}
+				div {
+					class: "bg-white rounded-lg border border-gray-200 shadow-sm p-8",
+					h2 {
+						class: "text-xl font-semibold text-gray-800 mb-6 text-center",
+						"Create your account"
+					}
+					{ form_view }
+					div {
+						id: "oauth-register-providers",
+					}
+					div {
+						class: "mt-6 text-center text-sm text-gray-600",
+						"Already have an account? " a {
+							href: "/login".to_string(),
+							class: "text-blue-600 font-medium hover:underline",
+							"Sign in"
+						}
+					}
 				}
 			}
 		}
-	})(form_view, oauth_view);
-
-	auth_layout("Create your account", content)
+	})(form_view)
 }

--- a/dashboard/src/apps/auth/server.rs
+++ b/dashboard/src/apps/auth/server.rs
@@ -8,4 +8,5 @@
 pub mod login;
 pub mod logout;
 pub mod me;
+pub mod oauth_providers;
 pub mod register;

--- a/dashboard/src/apps/auth/server/oauth_providers.rs
+++ b/dashboard/src/apps/auth/server/oauth_providers.rs
@@ -1,0 +1,44 @@
+//! OAuth provider discovery server function for frontend rendering.
+
+use reinhardt::pages::server_fn::{ServerFnError, server_fn};
+use serde::{Deserialize, Serialize};
+
+/// Public OAuth provider metadata safe to expose to the browser.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct OAuthProviderInfo {
+	pub id: String,
+	pub label: String,
+}
+
+#[cfg(native)]
+fn label_for_provider(id: &str) -> &'static str {
+	match id {
+		"github" => "GitHub",
+		_ => "OAuth",
+	}
+}
+
+/// Return the currently enabled OAuth providers.
+#[server_fn]
+pub async fn list_oauth_providers(
+	#[inject] settings: reinhardt::di::Depends<
+		crate::apps::auth::services::oauth::config::OAuthSettings,
+	>,
+) -> Result<Vec<OAuthProviderInfo>, ServerFnError> {
+	#[cfg(native)]
+	{
+		Ok(settings
+			.enabled_provider_ids()
+			.into_iter()
+			.map(|id| OAuthProviderInfo {
+				id: id.to_string(),
+				label: label_for_provider(id).to_string(),
+			})
+			.collect())
+	}
+	#[cfg(wasm)]
+	{
+		let _ = settings;
+		unreachable!("server_fn body is replaced on wasm")
+	}
+}

--- a/dashboard/src/client.rs
+++ b/dashboard/src/client.rs
@@ -36,6 +36,7 @@ mod wasm_entry {
 	use reinhardt::pages::{ClientLauncher, PathCtx};
 
 	use super::router;
+	use crate::apps::auth::client::components as auth_components;
 	use crate::shared::client::{components, state, ws};
 
 	/// WASM entry point — invoked automatically when the module loads.
@@ -59,6 +60,15 @@ mod wasm_entry {
 			.router_client(router::init_router)
 			.on_path("/", |ctx: &PathCtx<'_>| {
 				ctx.ensure_portal("toast-container", components::toast::toast_container);
+			})
+			.on_path("/login", |_ctx: &PathCtx<'_>| {
+				auth_components::ensure_oauth_buttons_connected("oauth-login-providers", "Sign in");
+			})
+			.on_path("/register", |_ctx: &PathCtx<'_>| {
+				auth_components::ensure_oauth_buttons_connected(
+					"oauth-register-providers",
+					"Sign up",
+				);
 			})
 			.launch()?;
 

--- a/dashboard/src/config/urls.rs
+++ b/dashboard/src/config/urls.rs
@@ -299,6 +299,7 @@ async fn make_router(#[inject] infra: Depends<RouterInfrastructure>) -> Dashboar
 					.server_fn(server::register::register::marker)
 					.server_fn(server::logout::logout::marker)
 					.server_fn(server::me::me::marker)
+					.server_fn(server::oauth_providers::list_oauth_providers::marker)
 					.server_fn(crate::apps::clusters::server::list_clusters_for_current_org::marker)
 					.server_fn(crate::apps::clusters::server::create_cluster_for_current_org::marker)
 					.server_fn(crate::apps::clusters::server::update_cluster_for_current_org::marker)


### PR DESCRIPTION
## Summary

This PR addresses:

- Hides OAuth provider buttons when the provider is not configured.
- Adds a small server function that exposes safe provider metadata to the WASM auth pages.
- Keeps the OAuth start endpoint strict, so direct requests to disabled providers still return 404.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

The login page rendered a static `Sign in with GitHub` link even when `REINHARDT_CLOUD_OAUTH_GITHUB_*` credentials were not configured. The provider discovery endpoint already returned an empty provider list, but the UI ignored that state and sent users to `/api/auth/oauth/github/start/`, which correctly returned 404 because GitHub OAuth was disabled.

Fixes #

Related to: #

## How Was This Tested?

- `cargo fmt --check`
- `cargo check -p reinhardt-cloud-dashboard`
- `cargo check -p reinhardt-cloud-dashboard --target wasm32-unknown-unknown`
- `cargo make wasm-build-dev` from `dashboard/`
- Restarted `cargo make runserver`
- Verified `POST /api/server_fn/list_oauth_providers` returns `[]` with same-origin headers when no providers are configured
- Verified served WASM contains `/api/server_fn/list_oauth_providers` and no static `/api/auth/oauth/github/start/` string
- Verified with Playwright that `/login` no longer renders `Sign in with GitHub` when no provider is configured

## Screenshots

### Before

- Login page rendered `Sign in with GitHub` despite no enabled providers.

### After

- Login page renders only the password form and registration link when no OAuth providers are enabled.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

-

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [x] `dashboard` - Dashboard frontend/backend

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [x] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

GitWhy context: `ctx_75658317`

Generated with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth sign-in buttons are now dynamically loaded and rendered in the login and registration flows based on enabled providers.

* **Changes**
  * Login and registration pages have been restructured with custom-tailored layouts.
  * OAuth provider options are now fetched at runtime, allowing for flexible provider configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->