### PR TITLE
fix(dashboard): align dev origins and websocket startup

### DIFF
--- a/dashboard/src/client.rs
+++ b/dashboard/src/client.rs
@@ -39,6 +39,12 @@ mod wasm_entry {
 	use crate::apps::auth::client::components as auth_components;
 	use crate::shared::client::{components, state, ws};
 
+	fn ensure_notifications_for_path(ctx: &PathCtx<'_>) {
+		if ws::should_connect_notifications_for_path(ctx.path()) {
+			ws::ensure_notifications_connected();
+		}
+	}
+
 	/// WASM entry point — invoked automatically when the module loads.
 	#[wasm_bindgen(start)]
 	pub(super) fn main() -> Result<(), JsValue> {
@@ -56,11 +62,13 @@ mod wasm_entry {
 		// on every entry to "/".
 		ClientLauncher::new("#app")
 			.before_launch(state::init_app_state)
-			.before_launch(ws::ensure_notifications_connected)
 			.router_client(router::init_router)
 			.on_path("/", |ctx: &PathCtx<'_>| {
 				ctx.ensure_portal("toast-container", components::toast::toast_container);
+				ensure_notifications_for_path(ctx);
 			})
+			.on_path("/clusters", ensure_notifications_for_path)
+			.on_path("/deployments", ensure_notifications_for_path)
 			.on_path("/login", |_ctx: &PathCtx<'_>| {
 				auth_components::ensure_oauth_buttons_connected("oauth-login-providers", "Sign in");
 			})

--- a/dashboard/src/config/urls.rs
+++ b/dashboard/src/config/urls.rs
@@ -84,17 +84,36 @@ pub(crate) struct AllowedOrigins(pub Vec<String>);
 #[injectable_factory(scope = "singleton")]
 async fn create_allowed_origins() -> AllowedOrigins {
 	let settings = crate::config::settings::get_settings();
-	let mut origins = settings.cors.allow_origins.clone();
-	origins.retain(|o| o != "*");
-	if origins.is_empty() {
-		let port = std::env::var("PORT").unwrap_or("8000".to_string());
-		AllowedOrigins(vec![
+	let port = std::env::var("PORT").ok();
+	AllowedOrigins(build_allowed_origins(
+		&settings.cors.allow_origins,
+		settings.core.debug,
+		port.as_deref(),
+	))
+}
+
+#[cfg(native)]
+fn build_allowed_origins(configured: &[String], debug: bool, port: Option<&str>) -> Vec<String> {
+	let mut origins = Vec::new();
+	for origin in configured {
+		if origin != "*" && !origins.contains(origin) {
+			origins.push(origin.clone());
+		}
+	}
+
+	if debug {
+		let port = port.unwrap_or("8000");
+		for origin in [
 			format!("http://localhost:{port}"),
 			format!("http://127.0.0.1:{port}"),
-		])
-	} else {
-		AllowedOrigins(origins)
+		] {
+			if !origins.contains(&origin) {
+				origins.push(origin);
+			}
+		}
 	}
+
+	origins
 }
 
 /// Application-specific cookie session configuration.
@@ -362,5 +381,58 @@ mod tests {
 
 		// Assert
 		assert_eq!(url, "/api/static/admin/main.js");
+	}
+
+	#[rstest::rstest]
+	fn debug_allowed_origins_include_configured_and_active_port() {
+		// Arrange
+		let configured = vec![
+			"http://localhost:8000".to_string(),
+			"http://127.0.0.1:8000".to_string(),
+		];
+
+		// Act
+		let origins = build_allowed_origins(&configured, true, Some("8001"));
+
+		// Assert
+		assert_eq!(
+			origins,
+			vec![
+				"http://localhost:8000".to_string(),
+				"http://127.0.0.1:8000".to_string(),
+				"http://localhost:8001".to_string(),
+				"http://127.0.0.1:8001".to_string(),
+			]
+		);
+	}
+
+	#[rstest::rstest]
+	fn debug_allowed_origins_fall_back_when_configured_only_wildcard() {
+		// Arrange
+		let configured = vec!["*".to_string()];
+
+		// Act
+		let origins = build_allowed_origins(&configured, true, Some("8001"));
+
+		// Assert
+		assert_eq!(
+			origins,
+			vec![
+				"http://localhost:8001".to_string(),
+				"http://127.0.0.1:8001".to_string(),
+			]
+		);
+	}
+
+	#[rstest::rstest]
+	fn production_allowed_origins_do_not_add_localhost_fallbacks() {
+		// Arrange
+		let configured = vec!["https://reinhardt-cloud.dev".to_string()];
+
+		// Act
+		let origins = build_allowed_origins(&configured, false, Some("8001"));
+
+		// Assert
+		assert_eq!(origins, vec!["https://reinhardt-cloud.dev".to_string()]);
 	}
 }

--- a/dashboard/src/shared/client/ws.rs
+++ b/dashboard/src/shared/client/ws.rs
@@ -41,6 +41,12 @@ thread_local! {
 #[cfg(wasm)]
 const MAX_RECONNECT_ATTEMPTS: u32 = 10;
 
+/// Return whether a SPA path should keep the authenticated notifications
+/// WebSocket connected.
+pub fn should_connect_notifications_for_path(path: &str) -> bool {
+	matches!(path, "/" | "/clusters" | "/deployments")
+}
+
 /// Open a WebSocket to `/ws/notifications` and wire up event handlers.
 ///
 /// Session cookies are sent automatically with the WebSocket handshake,
@@ -211,4 +217,28 @@ fn update_deployment_badge(payload: &DeploymentStatusPayload) {
 		)
 		.unwrap();
 	badge.set_text_content(Some(label));
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use rstest::rstest;
+
+	#[rstest]
+	#[case::home("/", true)]
+	#[case::clusters("/clusters", true)]
+	#[case::deployments("/deployments", true)]
+	#[case::login("/login", false)]
+	#[case::register("/register", false)]
+	#[case::unknown("/missing", false)]
+	fn notification_connection_paths_match_authenticated_spa_routes(
+		#[case] path: &str,
+		#[case] expected: bool,
+	) {
+		// Arrange + Act
+		let should_connect = should_connect_notifications_for_path(path);
+
+		// Assert
+		assert_eq!(should_connect, expected);
+	}
 }

--- a/docs/development/LOCAL_E2E_TESTING.md
+++ b/docs/development/LOCAL_E2E_TESTING.md
@@ -83,6 +83,13 @@ Useful overrides:
 | `DASHBOARD_SELF_DEPLOY_PORT_FORWARD_PORT` | `18080` | Local port used for Dashboard health, login, and authenticated page checks. |
 | `DASHBOARD_SELF_DEPLOY_ORIGIN` | `http://127.0.0.1:8000` | Origin/Referer used for server function POSTs. The default matches the CI `OriginGuardMiddleware` allow-list. |
 
+When running the Dashboard development server on a port other than 8000,
+set `PORT` to the served port or add the exact origin under
+`[cors].allow_origins`. In debug profiles the router augments configured
+origins with `http://localhost:$PORT` and `http://127.0.0.1:$PORT` so
+same-origin server-function POSTs do not fail OriginGuard validation after
+switching to ports such as 8001.
+
 On failure the harness writes events, live `ReinhardtApp` YAML, owned resource
 YAML, Pod logs, Operator logs, and the generated CRD YAML under the artifact
 directory before cleanup. Login responses, cookies, and authenticated page


### PR DESCRIPTION
## Summary

This PR addresses:

- Dashboard server-function 403s when local development runs on a port such as `127.0.0.1:8001` while configured CORS origins only name port 8000.
- Repeated unauthenticated `/ws/notifications` connection attempts on login and register pages.
- Local E2E documentation for aligning `PORT` / `[cors].allow_origins` with non-default Dashboard ports.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

The pasted browser log showed repeated 403 responses from Dashboard server functions and repeated notification WebSocket failures at `127.0.0.1:8001`. Code inspection showed `OriginGuardMiddleware` was behaving as designed; the Dashboard debug allowed-origin construction did not include the active local port when explicit origins were already configured. The client also opened the authenticated notifications WebSocket during global startup, including on unauthenticated auth pages.

Fixes #661

Related to: #655

## How Was This Tested?

- `cargo test -p reinhardt-cloud-dashboard debug_allowed_origins --all-features`
- `cargo test -p reinhardt-cloud-dashboard notification_connection_paths_match_authenticated_spa_routes --all-features`
- `cargo test -p reinhardt-cloud-dashboard production_allowed_origins_do_not_add_localhost_fallbacks --all-features`
- `cd dashboard && cargo check --all-features`
- `cargo make fmt-check`
- `cd dashboard && cargo clippy --all-features -- -D warnings`

## Performance Impact

No meaningful runtime impact. The origin list is built once through the existing DI singleton path, and WebSocket startup is reduced on unauthenticated pages.

## Breaking Changes

None.

**Migration Guide:**

No migration required. Developers running the Dashboard on non-8000 local ports should set `PORT` or explicitly configure `[cors].allow_origins` as documented.

## Screenshots

Not applicable; this is startup/configuration behavior and console-noise cleanup.

### Before

- Login/register pages attempted `/ws/notifications` before authentication.
- Local non-8000 same-origin server-function POSTs could be rejected when the configured allow-list only named port 8000.

### After

- Login/register pages do not start the notification WebSocket.
- Debug origin construction includes the active `PORT` local origins while preserving configured origins.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

<!-- ⚠️ CI CONTROL CHECKBOX - DO NOT EDIT MANUALLY ⚠️
The following checkbox controls CI runner selection.
Checking this option triggers self-hosted runner usage,
which incurs infrastructure costs. Only the repository owner should enable this.
If this checkbox is missing or unchecked, CI defaults to GitHub-hosted runners.
Do NOT modify the checkbox text — CI parses it by exact pattern match. -->
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #661
- Related to #655

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [ ] `kubernetes` - Kubernetes resources, controllers, operators
- [ ] `deployment` - Application deployment logic
- [ ] `networking` - Ingress, services, network policies
- [ ] `storage` - Persistent volumes, storage classes
- [x] `auth` - Authentication, authorization, RBAC
- [x] `api` - REST API, serializers, handlers
- [ ] `cli` - Command-line interface
- [x] `config` - Configuration management
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
<!-- Maintainers will apply priority labels during triage -->
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

No reinhardt-web issue was created because the current evidence points to reinhardt-cloud configuration/startup behavior, not a framework bug. GitWhy context: `ctx_a51fca9b`.

🤖 Generated with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized notification WebSocket connections to activate only on relevant dashboard pages for improved resource efficiency.

* **Documentation**
  * Updated development guidelines with guidance for running the dashboard on custom ports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->