### PR TITLE
fix(dashboard): load dotenv settings before TOML

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5588,6 +5588,7 @@ dependencies = [
  "gloo-timers",
  "hex",
  "hmac 0.12.1",
+ "indexmap 2.14.0",
  "inventory",
  "js-sys",
  "lettre",

--- a/dashboard/Cargo.toml
+++ b/dashboard/Cargo.toml
@@ -28,6 +28,7 @@ wasm-spa-test = []
 
 [dependencies]
 reinhardt = { workspace = true }
+indexmap = "2"
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/dashboard/settings/local.example.toml
+++ b/dashboard/settings/local.example.toml
@@ -22,7 +22,7 @@ jwt_secret = "CHANGE-ME-to-a-random-string"
 # `.devcontainer/` sets `RC_REDIS_HOST=redis` to point at the compose
 # service) and falls back to `localhost` for host-native development.
 # The `RC_*` prefix is intentionally outside the `REINHARDT_*` namespace
-# consumed by `HighPriorityEnvSource` so interpolation helpers do not
+# consumed by the dashboard `EnvSource` so interpolation helpers do not
 # leak into the merged settings as unknown top-level keys.
 redis_url = "redis://${RC_REDIS_HOST:-localhost}:6379/1"
 
@@ -50,7 +50,7 @@ secure_hsts_preload = false
 # Numeric/bool fields (port) keep their native types and are overridden
 # via the `REINHARDT_CORE__DATABASES__DEFAULT__PORT` env var when needed.
 # The `RC_*` prefix is intentionally outside the `REINHARDT_*` namespace
-# consumed by `HighPriorityEnvSource` so interpolation helpers do not
+# consumed by the dashboard `EnvSource` so interpolation helpers do not
 # leak into the merged settings as unknown top-level keys.
 [core.databases.default]
 engine = "postgresql"

--- a/dashboard/settings/production.example.toml
+++ b/dashboard/settings/production.example.toml
@@ -17,7 +17,7 @@
 # ${VAR:?message} interpolation that fails fast at startup if the env var is
 # missing. Optional fields use ${VAR:-default} so deployers can override
 # without forking the file. Numeric, boolean, and array fields keep TOML
-# literals here and are overridden by the HighPriorityEnvSource layer
+# literals here and are overridden by the dashboard `EnvSource` layer
 # (env vars take precedence over TOML) when the corresponding REINHARDT_*
 # env var is set.
 #
@@ -34,7 +34,7 @@
 #   REINHARDT_DATABASE_USER                          — [core.databases.default].user and [database].user (default: reinhardt)
 #   REINHARDT_EMAIL__FROM_EMAIL                      — [email].from_email (default: noreply@reinhardt-cloud.dev)
 #
-# Overrides via HighPriorityEnvSource (env vars take precedence over TOML):
+# Overrides via the dashboard `EnvSource` (env vars take precedence over TOML):
 #   REINHARDT_CORE__ALLOWED_HOSTS                    — [core].allowed_hosts (Vec<String>; pass JSON-array literal)
 #   REINHARDT_DATABASE_PORT                          — [core.databases.default].port and [database].port (u16)
 #   REINHARDT_EMAIL__BACKEND                         — backend type (string, e.g., "smtp")

--- a/dashboard/settings/production.toml
+++ b/dashboard/settings/production.toml
@@ -11,7 +11,7 @@
 # ${VAR:?message} interpolation that fails fast at startup if the env var
 # is missing. Optional fields use ${VAR:-default} so deployers can override
 # without forking this file. Numeric, boolean, and array fields keep TOML
-# literals here and are overridden by the HighPriorityEnvSource layer
+# literals here and are overridden by the dashboard `EnvSource` layer
 # (env vars take precedence over TOML) when the corresponding REINHARDT_*
 # env var is set — see dashboard/src/config/settings.rs for the source order.
 #

--- a/dashboard/settings/staging.example.toml
+++ b/dashboard/settings/staging.example.toml
@@ -20,9 +20,8 @@
 # ${VAR:?message} interpolation that fails fast at startup if the env var is
 # missing. Optional fields use ${VAR:-default} so deployers can override
 # without forking the file. Numeric, boolean, and array fields keep TOML
-# literals here and are overridden at the HighPriorityEnvSource layer
-# (priority 60 > TomlFileSource priority 50) when the corresponding REINHARDT_*
-# env var is set.
+# literals here and are overridden at the dashboard `EnvSource` layer
+# when the corresponding REINHARDT_* env var is set.
 #
 # Required env vars (no default — startup fails if unset):
 #   REINHARDT_CLOUD_JWT_SECRET                       — top-level jwt_secret
@@ -37,7 +36,7 @@
 #   REINHARDT_DATABASE_USER                          — [core.databases.default].user and [database].user (default: reinhardt)
 #   REINHARDT_EMAIL__FROM_EMAIL                      — [email].from_email (default: noreply@staging.reinhardt-cloud.dev)
 #
-# Numeric/boolean/array overrides via HighPriorityEnvSource:
+# Numeric/boolean/array overrides via the dashboard `EnvSource`:
 #   REINHARDT_CORE__ALLOWED_HOSTS                    — [core].allowed_hosts (Vec<String>; pass JSON-array literal)
 #   REINHARDT_DATABASE_PORT                          — [core.databases.default].port and [database].port (u16)
 #   REINHARDT_EMAIL__BACKEND                         — backend type (e.g., "smtp")

--- a/dashboard/settings/staging.toml
+++ b/dashboard/settings/staging.toml
@@ -12,7 +12,7 @@
 # ${VAR:?message} interpolation that fails fast at startup if the env var
 # is missing. Optional fields use ${VAR:-default} so deployers can override
 # without forking this file. Numeric, boolean, and array fields keep TOML
-# literals here and are overridden by the HighPriorityEnvSource layer
+# literals here and are overridden by the dashboard `EnvSource` layer
 # (env vars take precedence over TOML) when the corresponding REINHARDT_*
 # env var is set — see dashboard/src/config/settings.rs for the source order.
 #

--- a/dashboard/src/config/settings.rs
+++ b/dashboard/src/config/settings.rs
@@ -14,10 +14,14 @@
 //! ## Priority Order
 //!
 //! Settings are merged with the following priority (highest to lowest):
-//! 1. Environment-specific TOML file (e.g., `production.toml`)
-//! 2. Base TOML file (`base.toml`)
-//! 3. Environment variables with `REINHARDT_` prefix
+//! 1. Environment variables with `REINHARDT_` prefix
+//! 2. Environment-specific TOML file (e.g., `production.toml`)
+//! 3. Base TOML file (`base.toml`)
 //! 4. Default values
+//!
+//! `.env.<profile>` and `.env` files in the dashboard crate root are loaded
+//! before TOML files so `${VAR}` interpolation can consume local dotenv values.
+//! Existing process environment variables are never overwritten by dotenv files.
 //!
 //! ## Settings Directory Resolution
 //!
@@ -36,7 +40,9 @@
 //! If `REINHARDT_ENV` is not set, it defaults to `local`.
 
 use reinhardt::conf::settings::profile::Profile;
-use reinhardt::conf::settings::sources::{DefaultSource, HighPriorityEnvSource, TomlFileSource};
+use reinhardt::conf::settings::sources::{
+	ConfigSource, DefaultSource, DotEnvSource, EnvSource, SourceError, TomlFileSource,
+};
 use reinhardt::conf::{
 	ContactSettings, EmailSettings, I18nSettings, MediaSettings, StaticSettings,
 	settings::builder::{BuildError, SettingsBuilder},
@@ -45,7 +51,7 @@ use reinhardt::conf::{
 use reinhardt::di::injectable_factory;
 use reinhardt::settings;
 use std::env;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Composable project settings using the `#[settings]` macro.
 ///
@@ -70,6 +76,13 @@ fn resolve_settings_dir() -> PathBuf {
 		Ok(dir) => PathBuf::from(dir),
 		Err(_) => PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("settings"),
 	}
+}
+
+fn resolve_dotenv_dir(settings_dir: &Path) -> PathBuf {
+	settings_dir
+		.parent()
+		.map(Path::to_path_buf)
+		.unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")))
 }
 
 /// Get the active environment profile name.
@@ -108,28 +121,74 @@ fn default_project_settings_source() -> DefaultSource {
 		)
 }
 
+struct DashboardDotEnvSource {
+	path: PathBuf,
+}
+
+impl DashboardDotEnvSource {
+	fn new(path: impl Into<PathBuf>) -> Self {
+		Self { path: path.into() }
+	}
+}
+
+impl ConfigSource for DashboardDotEnvSource {
+	fn load(&self) -> Result<indexmap::IndexMap<String, serde_json::Value>, SourceError> {
+		DotEnvSource::new().with_path(&self.path).load()
+	}
+
+	fn priority(&self) -> u8 {
+		20
+	}
+
+	fn description(&self) -> String {
+		format!("Dashboard dotenv file: {}", self.path.display())
+	}
+}
+
+fn add_dashboard_dotenv_sources(
+	builder: SettingsBuilder,
+	dotenv_dir: &Path,
+	profile_str: &str,
+) -> SettingsBuilder {
+	let profile_path = dotenv_dir.join(format!(".env.{profile_str}"));
+	builder
+		.add_source(DashboardDotEnvSource::new(profile_path))
+		.add_source(DashboardDotEnvSource::new(dotenv_dir.join(".env")))
+}
+
+fn load_dashboard_dotenv_files(settings_dir: &Path, profile_str: &str) -> Result<(), SourceError> {
+	let dotenv_dir = resolve_dotenv_dir(settings_dir);
+	DashboardDotEnvSource::new(dotenv_dir.join(format!(".env.{profile_str}"))).load()?;
+	DashboardDotEnvSource::new(dotenv_dir.join(".env")).load()?;
+	Ok(())
+}
+
 /// Build merged settings from all configuration sources, returning errors
 /// for missing required env vars (so callers — including tests — can
 /// distinguish a startup misconfiguration from an unrelated panic).
 ///
 /// Sources are merged in priority order (lowest to highest):
 /// 1. Default values (CoreSettings provides its own defaults via serde)
-/// 2. Base TOML file (`base.toml`)
-/// 3. Environment-specific TOML file (e.g., `local.toml`)
-/// 4. Environment variables with `REINHARDT_` prefix (highest)
+/// 2. Dashboard dotenv files (`.env`, `.env.<profile>`)
+/// 3. Base TOML file (`base.toml`)
+/// 4. Environment-specific TOML file (e.g., `local.toml`)
+/// 5. Environment variables with `REINHARDT_` prefix (highest)
 fn try_build_settings() -> Result<ProjectSettings, BuildError> {
 	let profile_str = profile_name();
 	let settings_dir = resolve_settings_dir();
+	let dotenv_dir = resolve_dotenv_dir(&settings_dir);
 
-	SettingsBuilder::new()
+	let builder = add_dashboard_dotenv_sources(SettingsBuilder::new(), &dotenv_dir, &profile_str);
+
+	builder
 		.profile(Profile::parse(&profile_str))
 		.add_source(default_project_settings_source())
 		.add_source(TomlFileSource::new(settings_dir.join("base.toml")))
 		.add_source(TomlFileSource::new(
 			settings_dir.join(format!("{}.toml", profile_str)),
 		))
-		// Highest priority: Environment variables (for container/CI overrides)
-		.add_source(HighPriorityEnvSource::new().with_prefix("REINHARDT_"))
+		// Highest priority: process environment values for container/CI overrides.
+		.add_source(EnvSource::new().with_prefix("REINHARDT_"))
 		.build_composed()
 }
 
@@ -213,7 +272,10 @@ pub fn get_jwt_secret() -> Option<String> {
 fn get_top_level_string(key: &str, env_var: &str) -> Option<String> {
 	let profile_str = profile_name();
 	let settings_dir = resolve_settings_dir();
-	let from_toml = SettingsBuilder::new()
+	let dotenv_dir = resolve_dotenv_dir(&settings_dir);
+	let builder = add_dashboard_dotenv_sources(SettingsBuilder::new(), &dotenv_dir, &profile_str);
+
+	let from_toml = builder
 		.add_source(TomlFileSource::new(settings_dir.join("base.toml")))
 		.add_source(TomlFileSource::new(
 			settings_dir.join(format!("{}.toml", profile_str)),
@@ -240,6 +302,10 @@ fn get_top_level_string(key: &str, env_var: &str) -> Option<String> {
 /// TOML settings are selected, so these env vars must be able to override
 /// profile defaults such as `ci.toml`.
 fn get_env_or_top_level_string(env_var: &str, key: &str) -> Option<String> {
+	let profile_str = profile_name();
+	let settings_dir = resolve_settings_dir();
+	let _ = load_dashboard_dotenv_files(&settings_dir, &profile_str);
+
 	env::var(env_var)
 		.ok()
 		.or_else(|| get_top_level_string(key, env_var))
@@ -295,6 +361,44 @@ mod tests {
 				}
 			}
 		}
+	}
+
+	fn write_minimal_local_settings(config_dir: &Path, secret_key_expr: &str) {
+		fs::create_dir_all(config_dir).expect("temporary settings directory should be created");
+		fs::write(
+			config_dir.join("local.toml"),
+			format!(
+				r#"
+[core]
+debug = true
+secret_key = "{secret_key_expr}"
+allowed_hosts = ["localhost"]
+root_urlconf = ""
+middleware = []
+
+[core.security]
+append_slash = true
+session_cookie_secure = false
+csrf_cookie_secure = false
+secure_ssl_redirect = false
+secure_hsts_include_subdomains = false
+secure_hsts_preload = false
+
+[core.databases.default]
+engine = "postgresql"
+host = "localhost"
+port = 5432
+name = "test"
+user = "postgres"
+password = {{ secret = "test-password" }}
+options = {{}}
+
+[cors]
+allow_origins = ["http://localhost:8000"]
+"#
+			),
+		)
+		.expect("local settings file should be written");
 	}
 
 	#[rstest]
@@ -445,6 +549,137 @@ allow_origins = ["http://localhost:8000"]
 		assert_eq!(settings.static_files.url, "/static/");
 		assert_eq!(settings.media.url, "/media/");
 		assert_eq!(settings.email.port, 25);
+	}
+
+	#[rstest]
+	#[serial(env_settings_load)]
+	fn dotenv_profile_file_feeds_toml_interpolation() {
+		// Arrange
+		let watched: Vec<&'static str> = vec![
+			"REINHARDT_CLOUD_CONFIG_DIR",
+			"REINHARDT_ENV",
+			"REINHARDT_CORE__SECRET_KEY",
+		];
+		let _guard = EnvSnapshot::new(&watched);
+		let unique = SystemTime::now()
+			.duration_since(UNIX_EPOCH)
+			.expect("system time should be after UNIX_EPOCH")
+			.as_nanos();
+		let root = env::temp_dir().join(format!("reinhardt-cloud-dotenv-local-{unique}"));
+		let config_dir = root.join("settings");
+		write_minimal_local_settings(
+			&config_dir,
+			"${REINHARDT_CORE__SECRET_KEY:?missing test secret}",
+		);
+		fs::write(
+			root.join(".env.local"),
+			"REINHARDT_CORE__SECRET_KEY=dotenv-profile-secret\n",
+		)
+		.expect("profile dotenv file should be written");
+
+		// SAFETY: `#[serial(env_settings_load)]` provides the cross-test
+		// exclusion that `set_var`/`remove_var` need.
+		unsafe {
+			env::set_var("REINHARDT_CLOUD_CONFIG_DIR", &config_dir);
+			env::set_var("REINHARDT_ENV", "local");
+			env::remove_var("REINHARDT_CORE__SECRET_KEY");
+		}
+
+		// Act
+		let outcome = try_build_settings();
+		let _ = fs::remove_dir_all(&root);
+
+		// Assert
+		let settings = outcome.expect(".env.local should feed TOML interpolation");
+		assert_eq!(settings.core.secret_key, "dotenv-profile-secret");
+	}
+
+	#[rstest]
+	#[serial(env_settings_load)]
+	fn process_env_overrides_dotenv_profile_file() {
+		// Arrange
+		let watched: Vec<&'static str> = vec![
+			"REINHARDT_CLOUD_CONFIG_DIR",
+			"REINHARDT_ENV",
+			"REINHARDT_CORE__SECRET_KEY",
+		];
+		let _guard = EnvSnapshot::new(&watched);
+		let unique = SystemTime::now()
+			.duration_since(UNIX_EPOCH)
+			.expect("system time should be after UNIX_EPOCH")
+			.as_nanos();
+		let root = env::temp_dir().join(format!("reinhardt-cloud-dotenv-direct-{unique}"));
+		let config_dir = root.join("settings");
+		write_minimal_local_settings(
+			&config_dir,
+			"${REINHARDT_CORE__SECRET_KEY:?missing test secret}",
+		);
+		fs::write(
+			root.join(".env.local"),
+			"REINHARDT_CORE__SECRET_KEY=dotenv-profile-secret\n",
+		)
+		.expect("profile dotenv file should be written");
+
+		// SAFETY: `#[serial(env_settings_load)]` provides the cross-test
+		// exclusion that `set_var` needs.
+		unsafe {
+			env::set_var("REINHARDT_CLOUD_CONFIG_DIR", &config_dir);
+			env::set_var("REINHARDT_ENV", "local");
+			env::set_var("REINHARDT_CORE__SECRET_KEY", "direct-env-secret");
+		}
+
+		// Act
+		let outcome = try_build_settings();
+		let _ = fs::remove_dir_all(&root);
+
+		// Assert
+		let settings = outcome.expect("direct env should survive dotenv loading");
+		assert_eq!(settings.core.secret_key, "direct-env-secret");
+	}
+
+	#[rstest]
+	#[serial(env_settings_load)]
+	fn get_redis_url_prefers_dotenv_env_over_profile_toml() {
+		// Arrange
+		let watched: Vec<&'static str> = vec![
+			"REINHARDT_CLOUD_CONFIG_DIR",
+			"REINHARDT_ENV",
+			"REINHARDT_CLOUD_REDIS_URL",
+		];
+		let _guard = EnvSnapshot::new(&watched);
+		let unique = SystemTime::now()
+			.duration_since(UNIX_EPOCH)
+			.expect("system time should be after UNIX_EPOCH")
+			.as_nanos();
+		let root = env::temp_dir().join(format!("reinhardt-cloud-dotenv-redis-{unique}"));
+		let config_dir = root.join("settings");
+		fs::create_dir_all(&config_dir).expect("temporary settings directory should be created");
+		fs::write(
+			config_dir.join("local.toml"),
+			r#"redis_url = "redis://toml-redis:6379/0"
+"#,
+		)
+		.expect("local settings file should be written");
+		fs::write(
+			root.join(".env.local"),
+			"REINHARDT_CLOUD_REDIS_URL=redis://dotenv-redis:6379/0\n",
+		)
+		.expect("profile dotenv file should be written");
+
+		// SAFETY: `#[serial(env_settings_load)]` provides the cross-test
+		// exclusion that `set_var`/`remove_var` need.
+		unsafe {
+			env::set_var("REINHARDT_CLOUD_CONFIG_DIR", &config_dir);
+			env::set_var("REINHARDT_ENV", "local");
+			env::remove_var("REINHARDT_CLOUD_REDIS_URL");
+		}
+
+		// Act
+		let redis_url = get_redis_url();
+		let _ = fs::remove_dir_all(&root);
+
+		// Assert
+		assert_eq!(redis_url.as_deref(), Some("redis://dotenv-redis:6379/0"));
 	}
 
 	#[rstest]

--- a/docs/development/LOCAL_E2E_TESTING.md
+++ b/docs/development/LOCAL_E2E_TESTING.md
@@ -90,6 +90,11 @@ origins with `http://localhost:$PORT` and `http://127.0.0.1:$PORT` so
 same-origin server-function POSTs do not fail OriginGuard validation after
 switching to ports such as 8001.
 
+Dashboard startup also loads `.env.<profile>` and `.env` from the Dashboard
+crate root before TOML interpolation. For the default local profile, values in
+`dashboard/.env.local` such as `PORT=8001` are available without exporting them
+manually; variables already present in the shell still take precedence.
+
 On failure the harness writes events, live `ReinhardtApp` YAML, owned resource
 YAML, Pod logs, Operator logs, and the generated CRD YAML under the artifact
 directory before cleanup. Login responses, cookies, and authenticated page


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds dashboard dotenv loading for `.env.<profile>` and `.env` before TOML interpolation.
- Switches the final dashboard settings override pass to `EnvSource` so dotenv-loaded `REINHARDT_*` values are visible while real process env still wins.
- Documents local `.env.local` behavior and updates settings template comments.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

Dashboard local development could have dotenv files present without those values reaching settings startup. This made values such as local `PORT` and `REINHARDT_*` overrides depend on an external shell sourcing step instead of the dashboard settings pipeline.

Fixes #663

Related to: #662

## How Was This Tested?

- `cargo test -p reinhardt-cloud-dashboard dotenv_profile_file_feeds_toml_interpolation --all-features`
- `cargo test -p reinhardt-cloud-dashboard process_env_overrides_dotenv_profile_file --all-features`
- `cargo test -p reinhardt-cloud-dashboard get_redis_url_prefers_dotenv_env_over_profile_toml --all-features`
- `cargo make fmt-check`
- `cd dashboard && cargo clippy --all-features -- -D warnings`
- `git diff --check`

## Performance Impact

Not performance-related. Dotenv files are optional and loaded during settings startup.

## Breaking Changes

No breaking changes.

**Migration Guide:**

No migration is required. Existing exported environment variables still take precedence over dotenv files.

## Screenshots

Not UI-related.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #663
- Related to #662

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [ ] `kubernetes` - Kubernetes resources, controllers, operators
- [ ] `deployment` - Application deployment logic
- [ ] `networking` - Ingress, services, network policies
- [ ] `storage` - Persistent volumes, storage classes
- [ ] `auth` - Authentication, authorization, RBAC
- [ ] `api` - REST API, serializers, handlers
- [ ] `cli` - Command-line interface
- [x] `config` - Configuration management
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

`DotEnvSource` does not overwrite existing process environment values. Loading `.env.<profile>` before `.env` preserves the intended precedence: real process env, then profile dotenv, then base dotenv.

🤖 Generated with [Codex](https://openai.com/codex)
