### PR TITLE
feat: add reinhardt-cloud facade crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5500,6 +5500,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "reinhardt-cloud"
+version = "0.1.0"
+dependencies = [
+ "reinhardt-cloud-core",
+ "reinhardt-cloud-grpc",
+ "reinhardt-cloud-k8s",
+ "reinhardt-cloud-proto",
+ "reinhardt-cloud-telemetry",
+ "reinhardt-cloud-types",
+]
+
+[[package]]
 name = "reinhardt-cloud-agent"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
 	# Library crates
+	"crates/reinhardt-cloud",
 	"crates/reinhardt-cloud-types",
 	"crates/reinhardt-cloud-core",
 	"crates/reinhardt-cloud-k8s",
@@ -85,6 +86,7 @@ schemars = "1"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 
 # Internal workspace crates
+reinhardt-cloud = { path = "crates/reinhardt-cloud" }
 reinhardt-cloud-types = { path = "crates/reinhardt-cloud-types" }
 reinhardt-cloud-core = { path = "crates/reinhardt-cloud-core" }
 reinhardt-cloud-k8s = { path = "crates/reinhardt-cloud-k8s" }

--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ CUSTOM_VAR = "custom_value"
 
 | Crate | Type | Description |
 |---|---|---|
+| `reinhardt-cloud` | Library | Facade crate that re-exports public library components |
 | `reinhardt-cloud-types` | Library | CRD types, config schema, validation, introspect types |
 | `reinhardt-cloud-core` | Library | Business logic, plugin system, auth, pagination |
 | `reinhardt-cloud-k8s` | Library | Kubernetes client helpers and resource builders |

--- a/crates/reinhardt-cloud/Cargo.toml
+++ b/crates/reinhardt-cloud/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "reinhardt-cloud"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+
+[dependencies]
+reinhardt-cloud-core = { workspace = true }
+reinhardt-cloud-grpc = { workspace = true }
+reinhardt-cloud-k8s = { workspace = true }
+reinhardt-cloud-proto = { workspace = true }
+reinhardt-cloud-telemetry = { workspace = true }
+reinhardt-cloud-types = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/reinhardt-cloud/README.md
+++ b/crates/reinhardt-cloud/README.md
@@ -1,0 +1,11 @@
+# reinhardt-cloud
+
+Facade crate for Reinhardt Cloud library components.
+
+Use this crate when an application or integration needs one dependency that exposes the public library crates under stable namespaces:
+
+```rust
+use reinhardt_cloud::{core, grpc, k8s, proto, telemetry, types};
+```
+
+The CLI, operator, and agent remain binary crates.

--- a/crates/reinhardt-cloud/src/lib.rs
+++ b/crates/reinhardt-cloud/src/lib.rs
@@ -1,0 +1,18 @@
+//! Facade crate for Reinhardt Cloud library components.
+//!
+//! This crate provides a single dependency that re-exports the public
+//! library crates in this workspace under stable module-style names.
+//! Binary crates such as the CLI, operator, and cluster agent are not
+//! re-exported because they do not expose library APIs.
+
+pub use reinhardt_cloud_core as core;
+pub use reinhardt_cloud_grpc as grpc;
+pub use reinhardt_cloud_k8s as k8s;
+pub use reinhardt_cloud_proto as proto;
+pub use reinhardt_cloud_telemetry as telemetry;
+pub use reinhardt_cloud_types as types;
+
+/// Convenient access to the facade's component namespaces.
+pub mod prelude {
+	pub use crate::{core, grpc, k8s, proto, telemetry, types};
+}


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds a `reinhardt-cloud` facade library crate that re-exports the public library components under stable namespaces.
- Documents the facade crate in the workspace crate table and crate README.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

- Consumers currently need to depend on each internal library crate separately or use the dashboard application crate as an incidental re-export point.
- A dedicated facade keeps the reusable API surface separate from the dashboard app while preserving direct access to each component namespace.

Fixes #

Related to: #

## How Was This Tested?

- `cargo check -p reinhardt-cloud`
- `cargo make fmt-check`

## Performance Impact

- Not performance-related.

## Breaking Changes

- None.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

<!-- ⚠️ CI CONTROL CHECKBOX - DO NOT EDIT MANUALLY ⚠️
The following checkbox controls CI runner selection.
Checking this option triggers self-hosted runner usage,
which incurs infrastructure costs. Only the repository owner should enable this.
If this checkbox is missing or unchecked, CI defaults to GitHub-hosted runners.
Do NOT modify the checkbox text — CI parses it by exact pattern match. -->
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- None.

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [x] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [ ] `kubernetes` - Kubernetes resources, controllers, operators
- [ ] `deployment` - Application deployment logic
- [ ] `networking` - Ingress, services, network policies
- [ ] `storage` - Persistent volumes, storage classes
- [ ] `auth` - Authentication, authorization, RBAC
- [ ] `api` - REST API, serializers, handlers
- [ ] `cli` - Command-line interface
- [ ] `config` - Configuration management
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [x] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

- GitWhy context: `ctx_405609a6`

🤖 Generated with [Codex](https://openai.com/codex)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the `reinhardt-cloud` crate providing unified access to library components through stable module names (core, grpc, k8s, proto, telemetry, types).
  * Added a prelude module enabling convenient bulk imports of all components.

* **Documentation**
  * Added documentation describing the facade crate architecture and available modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->