### PR TITLE
fix(dashboard): show sidebar on section pages

### DIFF
--- a/dashboard/src/apps/clusters/client/pages/list.rs
+++ b/dashboard/src/apps/clusters/client/pages/list.rs
@@ -11,6 +11,7 @@ use crate::apps::clusters::server_fn::{
 	ClusterInfo, create_cluster_for_current_org, delete_cluster_for_current_org,
 	rotate_cluster_token_for_current_org, update_cluster_for_current_org,
 };
+use crate::apps::dashboard::client::layout::dashboard_app_shell;
 use crate::apps::deployments::client::components::cluster_health::cluster_health_container;
 
 fn format_server_error(raw: &str) -> String {
@@ -186,11 +187,11 @@ pub fn clusters_list_page() -> Page {
 
 	let health = cluster_health_container();
 
-	page!(|clusters: reinhardt::pages::prelude::Resource<Vec<ClusterInfo>, String>, create_view: Page, create_error: Signal<Option<String>>, create_submitting: Signal<bool>, edit_view: Page, edit_error: Signal<Option<String>>, edit_dirty: Signal<bool>, edit_submitting: Signal<bool>, delete_view: Page, delete_error: Signal<Option<String>>, delete_submitting: Signal<bool>, rotate_view: Page, rotate_error: Signal<Option<String>>, rotate_submitting: Signal<bool>, health: Page| {
+	let content = page!(|clusters: reinhardt::pages::prelude::Resource<Vec<ClusterInfo>, String>, create_view: Page, create_error: Signal<Option<String>>, create_submitting: Signal<bool>, edit_view: Page, edit_error: Signal<Option<String>>, edit_dirty: Signal<bool>, edit_submitting: Signal<bool>, delete_view: Page, delete_error: Signal<Option<String>>, delete_submitting: Signal<bool>, rotate_view: Page, rotate_error: Signal<Option<String>>, rotate_submitting: Signal<bool>, health: Page| {
 		div {
-			class: "rc-app",
+			class: "rc-shell",
 			div {
-				class: "rc-shell",
+				class: "space-y-0",
 				div {
 					class: "rc-topline",
 					div {
@@ -202,17 +203,12 @@ pub fn clusters_list_page() -> Page {
 							class: "rc-title",
 							"Clusters"
 						}
-						p {
-							class: "rc-muted mt-1",
-							"Registered Kubernetes clusters and agent health."
-						}
-					}
-					a {
-						href: "/deployments".to_string(),
-						class: "rc-link",
-						"Deployments"
+					p {
+						class: "rc-muted mt-1",
+						"Registered Kubernetes clusters and agent health."
 					}
 				}
+			}
 				div {
 					class: "grid gap-6 lg:grid-cols-[1fr_320px]",
 					div {
@@ -441,5 +437,6 @@ pub fn clusters_list_page() -> Page {
 		rotate_error,
 		rotate_state.is_submitting,
 		health,
-	)
+	);
+	dashboard_app_shell("clusters", content)
 }

--- a/dashboard/src/apps/clusters/client/pages/list.rs
+++ b/dashboard/src/apps/clusters/client/pages/list.rs
@@ -203,12 +203,12 @@ pub fn clusters_list_page() -> Page {
 							class: "rc-title",
 							"Clusters"
 						}
-					p {
-						class: "rc-muted mt-1",
-						"Registered Kubernetes clusters and agent health."
+						p {
+							class: "rc-muted mt-1",
+							"Registered Kubernetes clusters and agent health."
+						}
 					}
 				}
-			}
 				div {
 					class: "grid gap-6 lg:grid-cols-[1fr_320px]",
 					div {

--- a/dashboard/src/apps/dashboard/client/layout.rs
+++ b/dashboard/src/apps/dashboard/client/layout.rs
@@ -3,13 +3,21 @@
 use reinhardt::pages::component::Page;
 use reinhardt::pages::page;
 
-/// Render the main dashboard shell with navigation sidebar and overview cards.
-pub fn dashboard_shell() -> Page {
+fn nav_item_class(is_active: bool) -> &'static str {
+	if is_active {
+		"block rounded-md bg-control-500/10 px-3 py-2 text-sm font-semibold text-control-700"
+	} else {
+		"block rounded-md px-3 py-2 text-sm font-medium text-ink-600 hover:bg-cloud-100 hover:text-ink-950"
+	}
+}
+
+/// Render the shared dashboard application chrome around a section page.
+pub fn dashboard_app_shell(active_item: &'static str, content: Page) -> Page {
 	let login_href = "/login".to_string();
 	let home_href = "/".to_string();
 	let clusters_href = "/clusters".to_string();
 	let deployments_href = "/deployments".to_string();
-	page!(|login_href: String, home_href: String, clusters_href: String, deployments_href: String| {
+	page!(|active_item: &'static str, content: Page, login_href: String, home_href: String, clusters_href: String, deployments_href: String| {
 		div {
 			class: "rc-app flex flex-col",
 			header {
@@ -46,21 +54,21 @@ pub fn dashboard_shell() -> Page {
 						li {
 							a {
 								href: home_href,
-								class: "block rounded-md bg-control-500/10 px-3 py-2 text-sm font-semibold text-control-700",
+								class: self::nav_item_class(active_item == "overview"),
 								"Overview"
 							}
 						}
 						li {
 							a {
 								href: clusters_href,
-								class: "block rounded-md px-3 py-2 text-sm font-medium text-ink-600 hover:bg-cloud-100 hover:text-ink-950",
+								class: self::nav_item_class(active_item == "clusters"),
 								"Clusters"
 							}
 						}
 						li {
 							a {
 								href: deployments_href,
-								class: "block rounded-md px-3 py-2 text-sm font-medium text-ink-600 hover:bg-cloud-100 hover:text-ink-950",
+								class: self::nav_item_class(active_item == "deployments"),
 								"Deployments"
 							}
 						}
@@ -68,61 +76,104 @@ pub fn dashboard_shell() -> Page {
 				}
 				main {
 					class: "flex-1 p-6",
-					div {
-						class: "rc-topline",
-						div {
-							p {
-								class: "rc-kicker",
-								"Control plane"
-							}
-							h1 {
-								class: "rc-title mt-1",
-								"Dashboard"
-							}
-						}
-						p {
-							class: "rc-muted max-w-xl",
-							"Operational entry point for clusters, deployments, and platform health."
-						}
+					{ content }
+				}
+			}
+		}
+	})(
+		active_item,
+		content,
+		login_href,
+		home_href,
+		clusters_href,
+		deployments_href,
+	)
+}
+
+/// Render the main dashboard shell with navigation sidebar and overview cards.
+pub fn dashboard_shell() -> Page {
+	let content = page!(|| {
+		div {
+			class: "rc-shell",
+			div {
+				class: "rc-topline",
+				div {
+					p {
+						class: "rc-kicker",
+						"Control plane"
 					}
-					div {
-						class: "grid grid-cols-1 gap-4 md:grid-cols-3",
-						div {
-							class: "rc-panel-pad",
-							h3 {
-								class: "text-xs font-semibold uppercase tracking-[0.12em] text-ink-600",
-								"Clusters"
-							}
-							p {
-								class: "mt-3 text-3xl font-semibold text-ink-950",
-								"0"
-							}
-						}
-						div {
-							class: "rc-panel-pad",
-							h3 {
-								class: "text-xs font-semibold uppercase tracking-[0.12em] text-ink-600",
-								"Deployments"
-							}
-							p {
-								class: "mt-3 text-3xl font-semibold text-ink-950",
-								"0"
-							}
-						}
-						div {
-							class: "rc-panel-pad",
-							h3 {
-								class: "text-xs font-semibold uppercase tracking-[0.12em] text-ink-600",
-								"System Status"
-							}
-							p {
-								class: "mt-3 inline-flex rounded-full bg-control-500/10 px-2.5 py-1 text-sm font-semibold text-control-700",
-								"Healthy"
-							}
-						}
+					h1 {
+						class: "rc-title mt-1",
+						"Dashboard"
+					}
+				}
+				p {
+					class: "rc-muted max-w-xl",
+					"Operational entry point for clusters, deployments, and platform health."
+				}
+			}
+			div {
+				class: "grid grid-cols-1 gap-4 md:grid-cols-3",
+				div {
+					class: "rc-panel-pad",
+					h3 {
+						class: "text-xs font-semibold uppercase tracking-[0.12em] text-ink-600",
+						"Clusters"
+					}
+					p {
+						class: "mt-3 text-3xl font-semibold text-ink-950",
+						"0"
+					}
+				}
+				div {
+					class: "rc-panel-pad",
+					h3 {
+						class: "text-xs font-semibold uppercase tracking-[0.12em] text-ink-600",
+						"Deployments"
+					}
+					p {
+						class: "mt-3 text-3xl font-semibold text-ink-950",
+						"0"
+					}
+				}
+				div {
+					class: "rc-panel-pad",
+					h3 {
+						class: "text-xs font-semibold uppercase tracking-[0.12em] text-ink-600",
+						"System Status"
+					}
+					p {
+						class: "mt-3 inline-flex rounded-full bg-control-500/10 px-2.5 py-1 text-sm font-semibold text-control-700",
+						"Healthy"
 					}
 				}
 			}
 		}
-	})(login_href, home_href, clusters_href, deployments_href)
+	})();
+	dashboard_app_shell("overview", content)
+}
+
+#[cfg(test)]
+mod tests {
+	use rstest::rstest;
+
+	#[rstest]
+	#[case::active(
+		true,
+		"block rounded-md bg-control-500/10 px-3 py-2 text-sm font-semibold text-control-700"
+	)]
+	#[case::inactive(
+		false,
+		"block rounded-md px-3 py-2 text-sm font-medium text-ink-600 hover:bg-cloud-100 hover:text-ink-950"
+	)]
+	fn nav_item_class_reflects_active_state(#[case] is_active: bool, #[case] expected: &str) {
+		// Arrange
+		let expected_class = expected;
+
+		// Act
+		let class = super::nav_item_class(is_active);
+
+		// Assert
+		assert_eq!(class, expected_class);
+	}
 }

--- a/dashboard/src/apps/deployments/client/pages/list.rs
+++ b/dashboard/src/apps/deployments/client/pages/list.rs
@@ -251,12 +251,12 @@ pub fn deployments_list_page() -> Page {
 							class: "rc-title",
 							"Deployments"
 						}
-					p {
-						class: "rc-muted mt-1",
-						"Applications deployed through Reinhardt Cloud."
+						p {
+							class: "rc-muted mt-1",
+							"Applications deployed through Reinhardt Cloud."
+						}
 					}
 				}
-			}
 				div {
 					class: "grid gap-6 lg:grid-cols-[1fr_320px]",
 					div {

--- a/dashboard/src/apps/deployments/client/pages/list.rs
+++ b/dashboard/src/apps/deployments/client/pages/list.rs
@@ -5,6 +5,7 @@ use reinhardt::pages::form;
 use reinhardt::pages::page;
 use reinhardt::pages::prelude::{ResetOnDeps, ResourceState, Signal, use_form, use_resource};
 
+use crate::apps::dashboard::client::layout::dashboard_app_shell;
 use crate::apps::deployments::client::components::log_viewer::log_viewer_container;
 #[cfg(wasm)]
 use crate::apps::deployments::server_fn::list_deployments_for_current_org;
@@ -234,11 +235,11 @@ pub fn deployments_list_page() -> Page {
 
 	let logs = log_viewer_container();
 
-	page!(|deployments: reinhardt::pages::prelude::Resource<Vec<DeploymentInfo>, String>, create_view: Page, create_error: Signal<Option<String>>, create_submitting: Signal<bool>, edit_view: Page, edit_error: Signal<Option<String>>, edit_dirty: Signal<bool>, edit_submitting: Signal<bool>, status_view: Page, status_error: Signal<Option<String>>, status_submitting: Signal<bool>, delete_view: Page, delete_error: Signal<Option<String>>, delete_submitting: Signal<bool>, logs: Page| {
+	let content = page!(|deployments: reinhardt::pages::prelude::Resource<Vec<DeploymentInfo>, String>, create_view: Page, create_error: Signal<Option<String>>, create_submitting: Signal<bool>, edit_view: Page, edit_error: Signal<Option<String>>, edit_dirty: Signal<bool>, edit_submitting: Signal<bool>, status_view: Page, status_error: Signal<Option<String>>, status_submitting: Signal<bool>, delete_view: Page, delete_error: Signal<Option<String>>, delete_submitting: Signal<bool>, logs: Page| {
 		div {
-			class: "rc-app",
+			class: "rc-shell",
 			div {
-				class: "rc-shell",
+				class: "space-y-0",
 				div {
 					class: "rc-topline",
 					div {
@@ -250,17 +251,12 @@ pub fn deployments_list_page() -> Page {
 							class: "rc-title",
 							"Deployments"
 						}
-						p {
-							class: "rc-muted mt-1",
-							"Applications deployed through Reinhardt Cloud."
-						}
-					}
-					a {
-						href: "/clusters".to_string(),
-						class: "rc-link",
-						"Clusters"
+					p {
+						class: "rc-muted mt-1",
+						"Applications deployed through Reinhardt Cloud."
 					}
 				}
+			}
 				div {
 					class: "grid gap-6 lg:grid-cols-[1fr_320px]",
 					div {
@@ -496,5 +492,6 @@ pub fn deployments_list_page() -> Page {
 		delete_error,
 		delete_state.is_submitting,
 		logs,
-	)
+	);
+	dashboard_app_shell("deployments", content)
 }


### PR DESCRIPTION
## Summary

This PR addresses:

- Shares the Dashboard header/sidebar shell with the Clusters and Deployments pages.
- Marks the active sidebar item for Overview, Clusters, and Deployments.
- Removes the old one-off cross-links from section page headers so sidebar navigation is the single navigation surface.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

Clusters and Deployments rendered their own top-level app shell, so those pages did not include the Dashboard sidebar used on the overview page. The shared shell keeps the navigation consistent across the Dashboard app surface.

Fixes #

Related to: #

## How Was This Tested?

- `cargo fmt --all --check`
- `git diff --check`
- `cd dashboard && cargo check --all-features`
- `cargo test -p reinhardt-cloud-dashboard apps::dashboard::client::layout::tests --all-features`
- `cd dashboard && cargo make wasm-build-dev`
- Browser navigation to `/clusters` and `/deployments` was attempted against the local `manage runserver --with-pages` process, but the page stayed on `Loading Reinhardt Cloud...` because the served `index.html` did not load the available `/reinhardt_cloud_dashboard.js` bundle. Existing closed issue #646 covers that loading-shell class of problem, so this PR keeps scope to sidebar composition.

## Screenshots

### Before

- Not captured: the local browser run is blocked by the existing loading-shell/bootstrap state described above.

### After

- Not captured: the local browser run is blocked by the existing loading-shell/bootstrap state described above.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

<!-- ⚠️ CI CONTROL CHECKBOX - DO NOT EDIT MANUALLY ⚠️
The following checkbox controls CI runner selection.
Checking this option triggers self-hosted runner usage,
which incurs infrastructure costs. Only the repository owner should enable this.
If this checkbox is missing or unchecked, CI defaults to GitHub-hosted runners.
Do NOT modify the checkbox text — CI parses it by exact pattern match. -->
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #646

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `dashboard` - Dashboard UI

### Priority Label (for maintainers)
- [ ] `medium` - Normal priority

---

**Additional Context:**

- GitWhy context: `ctx_c8cbf325`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Created a unified dashboard layout system that applies consistently across all dashboard pages
  * Improved sidebar navigation styling and organization

* **Tests**
  * Added validation tests for layout styling across different navigation states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->