### PR TITLE
feat(dashboard): link github accounts from account page

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ For the end-to-end deployment flow — CLI branches, dashboard relay, agent beha
 - **Autoscaling** — HPA-based scaling on CPU, memory, or requests-per-second with configurable thresholds
 - **Workload Isolation** — gVisor, Kata Containers, network policies (Cilium), seccomp profiles, Pod Security Standards
 - **Multi-Tenant Namespacing** — `TenantRef` on the CRD maps each app to an Organization/Team and enforces a deterministic, isolated namespace with per-tenant `ResourceQuota` and `NetworkPolicy`
-- **Dashboard Authentication** — Local credentials plus GitHub OAuth (account linking, email-verification flow)
+- **Dashboard Authentication** — Local credentials plus GitHub OAuth, account-page linking, logout, and email-verification flow
 - **Preview Environments** — Per-PR ephemeral deployments with TTL, templated ingress hostnames, and override-able replica/database/cache settings
 - **Crossplane-style Plugins** — `PluginSpec` extension points reconciled via the gRPC Plugin service (Composition Functions pattern)
 - **Private Registry & Workload Identity** — `image_pull_secrets` and per-app `ServiceAccount` for IRSA / Workload Identity Federation

--- a/dashboard/src/apps/auth/client/pages.rs
+++ b/dashboard/src/apps/auth/client/pages.rs
@@ -1,8 +1,10 @@
 //! Auth page components for the WASM client.
 
+pub mod account;
 pub mod login;
 pub mod register;
 
+pub use account::account_page;
 pub use login::login_page;
 pub use register::register_page;
 

--- a/dashboard/src/apps/auth/client/pages/account.rs
+++ b/dashboard/src/apps/auth/client/pages/account.rs
@@ -1,0 +1,288 @@
+//! Account page for profile and OAuth account linking.
+
+use reinhardt::pages::component::Page;
+use reinhardt::pages::page;
+use reinhardt::pages::prelude::{Resource, ResourceState, use_resource};
+
+use crate::apps::auth::server_fn::linked_accounts::LinkedOAuthAccountInfo;
+use crate::apps::auth::server_fn::oauth_providers::OAuthProviderInfo;
+use crate::apps::dashboard::client::layout::dashboard_app_shell;
+use crate::shared::UserInfo;
+
+#[cfg(wasm)]
+use crate::apps::auth::server_fn::linked_accounts::list_linked_oauth_accounts;
+#[cfg(wasm)]
+use crate::apps::auth::server_fn::me::me;
+#[cfg(wasm)]
+use crate::apps::auth::server_fn::oauth_providers::list_oauth_providers;
+
+#[cfg(wasm)]
+async fn load_current_user() -> Result<UserInfo, String> {
+	me().await.map_err(|err| err.to_string())
+}
+
+#[cfg(not(wasm))]
+async fn load_current_user() -> Result<UserInfo, String> {
+	Err("current user is loaded by the browser client".to_string())
+}
+
+#[cfg(wasm)]
+async fn load_linked_accounts() -> Result<Vec<LinkedOAuthAccountInfo>, String> {
+	list_linked_oauth_accounts()
+		.await
+		.map_err(|err| err.to_string())
+}
+
+#[cfg(not(wasm))]
+async fn load_linked_accounts() -> Result<Vec<LinkedOAuthAccountInfo>, String> {
+	Ok(Vec::new())
+}
+
+#[cfg(wasm)]
+async fn load_oauth_providers() -> Result<Vec<OAuthProviderInfo>, String> {
+	list_oauth_providers().await.map_err(|err| err.to_string())
+}
+
+#[cfg(not(wasm))]
+async fn load_oauth_providers() -> Result<Vec<OAuthProviderInfo>, String> {
+	Ok(Vec::new())
+}
+
+fn github_link_url(providers: &[OAuthProviderInfo]) -> Option<String> {
+	providers
+		.iter()
+		.find(|provider| provider.id == "github")
+		.map(|provider| provider.start_url.clone())
+}
+
+fn github_account(linked: &[LinkedOAuthAccountInfo]) -> Option<&LinkedOAuthAccountInfo> {
+	linked.iter().find(|account| account.provider == "github")
+}
+
+pub(crate) fn render_account_content(
+	user: UserInfo,
+	providers: Vec<OAuthProviderInfo>,
+	linked: Vec<LinkedOAuthAccountInfo>,
+) -> Page {
+	let github = github_account(&linked).cloned();
+	let github_linked = github.is_some();
+	let github_label = github
+		.and_then(|account| account.provider_username)
+		.unwrap_or_else(|| "Linked".to_string());
+	let github_link_url = github_link_url(&providers);
+	page!(|user: UserInfo, github_linked: bool, github_label: String, github_link_url: Option<String>| {
+		div {
+			class: "rc-shell",
+			div {
+				class: "rc-topline",
+				div {
+					p {
+						class: "rc-kicker",
+						"Account"
+					}
+					h1 {
+						class: "rc-title mt-1",
+						"Account"
+					}
+				}
+			}
+			div {
+				class: "grid gap-4 lg:grid-cols-2",
+				section {
+					class: "rc-panel-pad",
+					h2 {
+						class: "text-base font-semibold text-ink-950",
+						"Profile"
+					}
+					dl {
+						class: "mt-4 grid gap-3 text-sm",
+						div {
+							dt {
+								class: "font-medium text-ink-600",
+								"Username"
+							}
+							dd {
+								class: "mt-1 text-ink-950",
+								{
+									user.username.clone()
+								}
+							}
+						}
+						div {
+							dt {
+								class: "font-medium text-ink-600",
+								"Email"
+							}
+							dd {
+								class: "mt-1 text-ink-950",
+								{
+									user.email.clone()
+								}
+							}
+						}
+					}
+				}
+				section {
+					class: "rc-panel-pad",
+					div {
+						class: "flex items-start justify-between gap-4",
+						div {
+							h2 {
+								class: "text-base font-semibold text-ink-950",
+								"GitHub"
+							}
+							p {
+								class: "rc-muted mt-1",
+								"Authentication provider"
+							}
+						}
+						{
+							if github_linked {
+								page!(|label: String| {
+									span {
+										class: "inline-flex shrink-0 rounded-full bg-control-500/10 px-2.5 py-1 text-xs font-semibold text-control-700",
+										{ label }
+									}
+								})(github_label.clone())
+							} else { Page::Empty }
+						}
+					}
+					div {
+						class: "mt-5",
+						{
+							if github_linked {
+								page!(|| {
+									p {
+										class: "text-sm font-medium text-ink-700",
+										"GitHub account linked"
+									}
+								})()
+							} else if let Some(url) = github_link_url.clone() {
+								page!(|url: String| {
+									a {
+										href: url,
+										rel: "external",
+										class: "btn-primary inline-flex px-4 py-2 text-sm",
+										"Link GitHub"
+									}
+								})(url)
+							} else {
+								page!(|| {
+									p {
+										class: "text-sm font-medium text-ink-600",
+										"GitHub OAuth is not configured"
+									}
+								})()
+							}
+						}
+					}
+				}
+			}
+		}
+	})(user, github_linked, github_label, github_link_url)
+}
+
+fn account_error(message: &str) -> Page {
+	let login_href = "/login".to_string();
+	page!(|message: String, login_href: String| {
+		div {
+			class: "rc-shell",
+			div {
+				class: "rc-panel-pad",
+				h1 {
+					class: "text-xl font-semibold text-ink-950",
+					"Account"
+				}
+				p {
+					class: "rc-muted mt-2",
+					{ message }
+				}
+				a {
+					href: login_href,
+					class: "btn-primary mt-5 inline-flex px-4 py-2 text-sm",
+					"Sign in"
+				}
+			}
+		}
+	})(message.to_string(), login_href)
+}
+
+/// Render the account page.
+pub fn account_page() -> Page {
+	let user = use_resource(|| async move { self::load_current_user().await }, ());
+	let providers = use_resource(|| async move { self::load_oauth_providers().await }, ());
+	let linked = use_resource(|| async move { self::load_linked_accounts().await }, ());
+
+	let content =
+		page!(|user: Resource<UserInfo, String>,
+		       providers: Resource<Vec<OAuthProviderInfo>, String>,
+		       linked: Resource<Vec<LinkedOAuthAccountInfo>, String>| {
+			{
+				match (user.get(), providers.get(), linked.get()) {
+					(
+						ResourceState::Success(user),
+						ResourceState::Success(providers),
+						ResourceState::Success(linked),
+					) => self::render_account_content(user, providers, linked),
+					(ResourceState::Error(err), _, _) => self::account_error(&err),
+					(_, ResourceState::Error(err), _) => self::account_error(&err),
+					(_, _, ResourceState::Error(err)) => self::account_error(&err),
+					_ => Page::Empty,
+				}
+			}
+		})(user, providers, linked);
+
+	dashboard_app_shell("account", content)
+}
+
+#[cfg(test)]
+mod tests {
+	use rstest::rstest;
+
+	use super::*;
+
+	#[rstest]
+	fn account_content_renders_link_action_when_github_is_unlinked() {
+		// Arrange
+		let user = UserInfo {
+			id: "user-1".to_string(),
+			username: "alice".to_string(),
+			email: "alice@example.com".to_string(),
+		};
+		let providers = vec![OAuthProviderInfo {
+			id: "github".to_string(),
+			label: "GitHub".to_string(),
+			start_url: "/api/auth/oauth/github/start/".to_string(),
+		}];
+
+		// Act
+		let html = render_account_content(user, providers, Vec::new()).render_to_string();
+
+		// Assert
+		assert!(html.contains("Link GitHub"));
+		assert!(html.contains(r#"href="/api/auth/oauth/github/start/""#));
+	}
+
+	#[rstest]
+	fn account_content_renders_linked_state_without_link_action() {
+		// Arrange
+		let user = UserInfo {
+			id: "user-1".to_string(),
+			username: "alice".to_string(),
+			email: "alice@example.com".to_string(),
+		};
+		let linked = vec![LinkedOAuthAccountInfo {
+			provider: "github".to_string(),
+			label: "GitHub".to_string(),
+			provider_username: Some("octocat".to_string()),
+		}];
+
+		// Act
+		let html = render_account_content(user, Vec::new(), linked).render_to_string();
+
+		// Assert
+		assert!(html.contains("GitHub account linked"));
+		assert!(html.contains("octocat"));
+		assert!(!html.contains("Link GitHub"));
+	}
+}

--- a/dashboard/src/apps/auth/server_fn.rs
+++ b/dashboard/src/apps/auth/server_fn.rs
@@ -5,6 +5,7 @@
 //! handles conditional compilation: on the server the original async function
 //! runs, while on WASM a POST stub is generated automatically.
 
+pub mod linked_accounts;
 pub mod login;
 pub mod logout;
 pub mod me;

--- a/dashboard/src/apps/auth/server_fn/linked_accounts.rs
+++ b/dashboard/src/apps/auth/server_fn/linked_accounts.rs
@@ -1,0 +1,49 @@
+//! Linked OAuth account server function.
+
+use reinhardt::pages::server_fn::{ServerFnError, server_fn};
+use serde::{Deserialize, Serialize};
+
+/// Linked OAuth account metadata safe to expose to the browser.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct LinkedOAuthAccountInfo {
+	pub provider: String,
+	pub label: String,
+	pub provider_username: Option<String>,
+}
+
+/// Return OAuth accounts linked to the current user.
+#[server_fn]
+pub async fn list_linked_oauth_accounts(
+	#[inject] reinhardt::CurrentUser(user): reinhardt::CurrentUser<crate::apps::auth::models::User>,
+) -> Result<Vec<LinkedOAuthAccountInfo>, ServerFnError> {
+	#[cfg(native)]
+	{
+		use reinhardt::db::orm::Model;
+
+		use crate::apps::auth::models::SocialAccount;
+		use crate::apps::auth::server_fn::oauth_providers::label_for_provider;
+
+		let rows = SocialAccount::objects()
+			.filter(SocialAccount::field_user_id().eq(user.id.to_string()))
+			.all()
+			.await
+			.map_err(|err| {
+				tracing::error!("Failed to load linked OAuth accounts: {err}");
+				ServerFnError::application("Internal server error")
+			})?;
+
+		Ok(rows
+			.into_iter()
+			.map(|account| LinkedOAuthAccountInfo {
+				label: label_for_provider(&account.provider).to_string(),
+				provider: account.provider,
+				provider_username: account.provider_username,
+			})
+			.collect())
+	}
+	#[cfg(wasm)]
+	{
+		let _ = user;
+		unreachable!("server_fn body is replaced on wasm")
+	}
+}

--- a/dashboard/src/apps/auth/server_fn/logout.rs
+++ b/dashboard/src/apps/auth/server_fn/logout.rs
@@ -18,23 +18,14 @@ pub async fn logout(
 	{
 		use tracing::warn;
 
-		// Extract session ID from the Cookie header
+		use crate::apps::auth::services::session::session_id_from_cookie_header;
+
 		let session_id = http_request
 			.inner()
 			.headers
 			.get("Cookie")
 			.and_then(|v| v.to_str().ok())
-			.and_then(|cookies| {
-				cookies.split(';').find_map(|pair| {
-					let pair = pair.trim();
-					let (name, value) = pair.split_once('=')?;
-					if name.trim() == "sessionid" {
-						Some(value.trim().to_string())
-					} else {
-						None
-					}
-				})
-			});
+			.and_then(session_id_from_cookie_header);
 
 		// Destroy the session in Redis if a session cookie was present
 		if let Some(ref sid) = session_id

--- a/dashboard/src/apps/auth/server_urls.rs
+++ b/dashboard/src/apps/auth/server_urls.rs
@@ -9,6 +9,7 @@ use reinhardt::core::serde::json;
 use reinhardt::db::orm::Model;
 use reinhardt::di::Depends;
 use reinhardt::http::ViewResult;
+use reinhardt::pages::server_fn::ServerFnRequest;
 use reinhardt::{BaseUser, Path, Query, Response, StatusCode, get};
 use serde::Deserialize;
 use tracing::{error, info};
@@ -17,7 +18,9 @@ use crate::apps::auth::models::User;
 use crate::apps::auth::services::oauth::backend::OAuthBackendBox;
 use crate::apps::auth::services::oauth::linking::link_or_create_user;
 use crate::apps::auth::services::oauth::storage::OrmSocialAccountStorage;
-use crate::apps::auth::services::session::{SessionService, session_cookie_header};
+use crate::apps::auth::services::session::{
+	SessionService, session_cookie_header, session_id_from_cookie_header,
+};
 use crate::apps::auth::services::token::{TokenError, TokenPurpose, verify_token};
 use crate::config::settings::ProjectSettings;
 
@@ -54,6 +57,33 @@ fn map_session_error(err: impl std::fmt::Display) -> AppError {
 	AppError::Internal("Internal server error".to_string())
 }
 
+async fn current_user_from_cookie(
+	request: &ServerFnRequest,
+	session_service: &SessionService,
+) -> Result<Option<User>, AppError> {
+	let Some(session_id) = request
+		.inner()
+		.headers
+		.get("Cookie")
+		.and_then(|v| v.to_str().ok())
+		.and_then(session_id_from_cookie_header)
+	else {
+		return Ok(None);
+	};
+	let Some((user_id, _username)) = session_service.validate_session(&session_id).await else {
+		return Ok(None);
+	};
+	let user = User::objects()
+		.filter(User::field_id().eq(user_id.clone()))
+		.first()
+		.await
+		.map_err(|err| {
+			error!("Failed to look up session user {user_id} during OAuth callback: {err}");
+			AppError::Internal("Internal server error".to_string())
+		})?;
+	Ok(user)
+}
+
 /// Start an OAuth authorization flow for a configured provider.
 ///
 /// `GET /api/auth/oauth/{provider_id}/start/`
@@ -77,6 +107,7 @@ pub async fn oauth_start(
 pub async fn oauth_callback(
 	Path(provider_id): Path<String>,
 	Query(query): Query<OAuthCallbackQuery>,
+	#[inject] http_request: ServerFnRequest,
 	#[inject] backend: Depends<OAuthBackendBox>,
 	#[inject] session_service: Depends<SessionService>,
 ) -> ViewResult<Response> {
@@ -89,7 +120,8 @@ pub async fn oauth_callback(
 		AppError::Validation("OAuth provider did not return user claims".to_string())
 	})?;
 	let storage = OrmSocialAccountStorage::new();
-	let user = link_or_create_user(&storage, &provider_id, &claims, None)
+	let current_user = current_user_from_cookie(&http_request, &session_service).await?;
+	let user = link_or_create_user(&storage, &provider_id, &claims, current_user)
 		.await
 		.map_err(|err| AppError::Validation(err.to_string()))?;
 	let session_id = session_service

--- a/dashboard/src/apps/auth/services/session.rs
+++ b/dashboard/src/apps/auth/services/session.rs
@@ -109,6 +109,19 @@ impl SessionService {
 	}
 }
 
+/// Extract the dashboard session id from a raw `Cookie` header value.
+pub fn session_id_from_cookie_header(cookie_header: &str) -> Option<String> {
+	cookie_header.split(';').find_map(|pair| {
+		let pair = pair.trim();
+		let (name, value) = pair.split_once('=')?;
+		if name.trim() == "sessionid" {
+			Some(value.trim().to_string())
+		} else {
+			None
+		}
+	})
+}
+
 /// Build the `Set-Cookie` header value for a persisted session id.
 pub fn session_cookie_header(session_id: &str, debug: bool) -> String {
 	let secure_flag = if debug { "" } else { "; Secure" };
@@ -164,5 +177,20 @@ mod tests {
 		// require a live Redis instance; integration tests cover
 		// the round-trip path against a real Redis container.
 		let _ = svc;
+	}
+
+	#[rstest]
+	#[case("sessionid=abc123", Some("abc123"))]
+	#[case("theme=dark; sessionid=abc123; csrftoken=token", Some("abc123"))]
+	#[case("theme=dark", None)]
+	fn test_session_id_from_cookie_header(
+		#[case] cookie_header: &str,
+		#[case] expected: Option<&str>,
+	) {
+		// Arrange / Act
+		let session_id = session_id_from_cookie_header(cookie_header);
+
+		// Assert
+		assert_eq!(session_id.as_deref(), expected);
 	}
 }

--- a/dashboard/src/apps/auth/tests.rs
+++ b/dashboard/src/apps/auth/tests.rs
@@ -1,6 +1,7 @@
 //! Tests for auth app.
 
 pub mod unit {
+	pub mod test_account_page;
 	pub mod test_auth_property;
 	pub mod test_email_verification;
 	pub mod test_jwt;

--- a/dashboard/src/apps/auth/tests/unit/test_account_page.rs
+++ b/dashboard/src/apps/auth/tests/unit/test_account_page.rs
@@ -1,0 +1,55 @@
+//! Tests for the account page rendering contract.
+
+#[cfg(test)]
+mod tests {
+	use rstest::rstest;
+
+	use crate::apps::auth::client::pages::account::render_account_content;
+	use crate::apps::auth::server_fn::linked_accounts::LinkedOAuthAccountInfo;
+	use crate::apps::auth::server_fn::oauth_providers::OAuthProviderInfo;
+	use crate::shared::UserInfo;
+
+	fn sample_user() -> UserInfo {
+		UserInfo {
+			id: "user-1".to_string(),
+			username: "alice".to_string(),
+			email: "alice@example.com".to_string(),
+		}
+	}
+
+	#[rstest]
+	fn unlinked_github_provider_renders_link_action() {
+		// Arrange
+		let providers = vec![OAuthProviderInfo {
+			id: "github".to_string(),
+			label: "GitHub".to_string(),
+			start_url: "/api/auth/oauth/github/start/".to_string(),
+		}];
+
+		// Act
+		let html = render_account_content(sample_user(), providers, Vec::new()).render_to_string();
+
+		// Assert
+		assert!(html.contains("Link GitHub"));
+		assert!(html.contains(r#"href="/api/auth/oauth/github/start/""#));
+		assert!(html.contains(r#"rel="external""#));
+	}
+
+	#[rstest]
+	fn linked_github_provider_renders_status_without_link_action() {
+		// Arrange
+		let linked = vec![LinkedOAuthAccountInfo {
+			provider: "github".to_string(),
+			label: "GitHub".to_string(),
+			provider_username: Some("octocat".to_string()),
+		}];
+
+		// Act
+		let html = render_account_content(sample_user(), Vec::new(), linked).render_to_string();
+
+		// Assert
+		assert!(html.contains("GitHub account linked"));
+		assert!(html.contains("octocat"));
+		assert!(!html.contains("Link GitHub"));
+	}
+}

--- a/dashboard/src/apps/auth/tests/unit/test_oauth_providers_view.rs
+++ b/dashboard/src/apps/auth/tests/unit/test_oauth_providers_view.rs
@@ -11,6 +11,7 @@ mod tests {
 	use rstest::rstest;
 	use serde_json::Value;
 
+	use crate::apps::auth::server_fn::linked_accounts::LinkedOAuthAccountInfo;
 	use crate::apps::auth::server_fn::oauth_providers::{
 		OAuthProviderInfo, label_for_provider, oauth_start_url,
 	};
@@ -94,6 +95,34 @@ mod tests {
 
 		// Assert
 		assert_eq!(json, Value::Array(vec![]));
+	}
+
+	#[rstest]
+	fn test_linked_account_entry_serializes_only_public_provider_fields() {
+		// Arrange
+		let entry = LinkedOAuthAccountInfo {
+			provider: "github".to_string(),
+			label: "GitHub".to_string(),
+			provider_username: Some("octocat".to_string()),
+		};
+
+		// Act
+		let json = serde_json::to_value(&entry).expect("serialize linked account");
+
+		// Assert
+		let obj = json.as_object().expect("entry is object");
+		assert_eq!(
+			obj.len(),
+			3,
+			"LinkedOAuthAccountInfo must serialize to exactly 3 fields, got {}: {json:?}",
+			obj.len()
+		);
+		assert_eq!(obj.get("provider").and_then(Value::as_str), Some("github"));
+		assert_eq!(obj.get("label").and_then(Value::as_str), Some("GitHub"));
+		assert_eq!(
+			obj.get("provider_username").and_then(Value::as_str),
+			Some("octocat")
+		);
 	}
 
 	#[rstest]

--- a/dashboard/src/apps/auth/urls.rs
+++ b/dashboard/src/apps/auth/urls.rs
@@ -6,7 +6,7 @@ pub mod ws_urls;
 
 use reinhardt::urls::prelude::UnifiedRouter;
 
-use crate::apps::auth::client::pages::{login_page, register_page};
+use crate::apps::auth::client::pages::{account_page, login_page, register_page};
 #[cfg(native)]
 use crate::apps::auth::server_urls;
 
@@ -21,15 +21,13 @@ pub fn url_patterns() -> UnifiedRouter {
 			s
 		})
 		.client(|c| {
-			c.route("login_page", "/login", login_page).route(
-				"register_page",
-				"/register",
-				register_page,
-			)
+			c.route("account_page", "/account", account_page)
+				.route("login_page", "/login", login_page)
+				.route("register_page", "/register", register_page)
 		})
 }
 
-#[cfg(test)]
+#[cfg(all(test, native))]
 mod tests {
 	use reinhardt::urls::prelude::UnifiedRouter;
 	use rstest::rstest;
@@ -52,5 +50,19 @@ mod tests {
 			callback,
 			Some("/api/auth/oauth/github/callback/".to_string())
 		);
+	}
+
+	#[rstest]
+	fn account_page_route_is_registered() {
+		// Arrange
+		let router = UnifiedRouter::new()
+			.mount_unified("/", super::url_patterns())
+			.into_client();
+
+		// Act
+		let account = router.reverse("account_page", &[]);
+
+		// Assert
+		assert_eq!(account, Ok("/account".to_string()));
 	}
 }

--- a/dashboard/src/apps/clusters/client/pages/list.rs
+++ b/dashboard/src/apps/clusters/client/pages/list.rs
@@ -203,12 +203,12 @@ pub fn clusters_list_page() -> Page {
 							class: "rc-title",
 							"Clusters"
 						}
-					p {
-						class: "rc-muted mt-1",
-						"Registered Kubernetes clusters and agent health."
+						p {
+							class: "rc-muted mt-1",
+							"Registered Kubernetes clusters and agent health."
+						}
 					}
 				}
-			}
 				div {
 					class: "grid gap-6 lg:grid-cols-[1fr_320px]",
 					div {

--- a/dashboard/src/apps/dashboard/client/layout.rs
+++ b/dashboard/src/apps/dashboard/client/layout.rs
@@ -13,11 +13,11 @@ fn nav_item_class(is_active: bool) -> &'static str {
 
 /// Render the shared dashboard application chrome around a section page.
 pub fn dashboard_app_shell(active_item: &'static str, content: Page) -> Page {
-	let login_href = "/login".to_string();
+	let account_href = "/account".to_string();
 	let home_href = "/".to_string();
 	let clusters_href = "/clusters".to_string();
 	let deployments_href = "/deployments".to_string();
-	page!(|active_item: &'static str, content: Page, login_href: String, home_href: String, clusters_href: String, deployments_href: String| {
+	page!(|active_item: &'static str, content: Page, account_href: String, home_href: String, clusters_href: String, deployments_href: String| {
 		div {
 			class: "rc-app flex flex-col",
 			header {
@@ -39,9 +39,14 @@ pub fn dashboard_app_shell(active_item: &'static str, content: Page) -> Page {
 						"Dashboard"
 					}
 					a {
-						href: login_href,
+						href: account_href.clone(),
 						class: "rc-link",
-						"Login"
+						"Account"
+					}
+					button {
+						type: "button",
+						class: "rc-link js-dashboard-logout",
+						"Logout"
 					}
 				}
 			}
@@ -72,6 +77,13 @@ pub fn dashboard_app_shell(active_item: &'static str, content: Page) -> Page {
 								"Deployments"
 							}
 						}
+						li {
+							a {
+								href: account_href,
+								class: self::nav_item_class(active_item == "account"),
+								"Account"
+							}
+						}
 					}
 				}
 				main {
@@ -83,7 +95,7 @@ pub fn dashboard_app_shell(active_item: &'static str, content: Page) -> Page {
 	})(
 		active_item,
 		content,
-		login_href,
+		account_href,
 		home_href,
 		clusters_href,
 		deployments_href,
@@ -175,5 +187,23 @@ mod tests {
 
 		// Assert
 		assert_eq!(class, expected_class);
+	}
+
+	#[rstest]
+	fn dashboard_shell_renders_account_and_logout_controls() {
+		use reinhardt::pages::component::Page;
+
+		// Arrange
+		let content = Page::Empty;
+
+		// Act
+		let html = super::dashboard_app_shell("account", content).render_to_string();
+
+		// Assert
+		assert!(html.contains(r#"href="/account""#));
+		assert!(html.contains("Account"));
+		assert!(html.contains("js-dashboard-logout"));
+		assert!(html.contains("Logout"));
+		assert!(!html.contains(">Login<"));
 	}
 }

--- a/dashboard/src/apps/deployments/client/pages/list.rs
+++ b/dashboard/src/apps/deployments/client/pages/list.rs
@@ -251,12 +251,12 @@ pub fn deployments_list_page() -> Page {
 							class: "rc-title",
 							"Deployments"
 						}
-					p {
-						class: "rc-muted mt-1",
-						"Applications deployed through Reinhardt Cloud."
+						p {
+							class: "rc-muted mt-1",
+							"Applications deployed through Reinhardt Cloud."
+						}
 					}
 				}
-			}
 				div {
 					class: "grid gap-6 lg:grid-cols-[1fr_320px]",
 					div {

--- a/dashboard/src/client.rs
+++ b/dashboard/src/client.rs
@@ -44,6 +44,11 @@ mod wasm_entry {
 		}
 	}
 
+	fn ensure_dashboard_chrome_for_path(ctx: &PathCtx<'_>) {
+		components::logout::ensure_logout_buttons_connected();
+		ensure_notifications_for_path(ctx);
+	}
+
 	/// WASM entry point — invoked automatically when the module loads.
 	#[wasm_bindgen(start)]
 	pub(super) fn main() -> Result<(), JsValue> {
@@ -64,10 +69,11 @@ mod wasm_entry {
 			.router_client(router::init_router)
 			.on_path("/", |ctx: &PathCtx<'_>| {
 				ctx.ensure_portal("toast-container", components::toast::toast_container);
-				ensure_notifications_for_path(ctx);
+				ensure_dashboard_chrome_for_path(ctx);
 			})
-			.on_path("/clusters", ensure_notifications_for_path)
-			.on_path("/deployments", ensure_notifications_for_path)
+			.on_path("/account", ensure_dashboard_chrome_for_path)
+			.on_path("/clusters", ensure_dashboard_chrome_for_path)
+			.on_path("/deployments", ensure_dashboard_chrome_for_path)
 			.launch()?;
 
 		Ok(())

--- a/dashboard/src/client/router.rs
+++ b/dashboard/src/client/router.rs
@@ -30,7 +30,7 @@
 
 use reinhardt::urls::prelude::{ClientRouter, UnifiedRouter};
 
-use crate::apps::auth::client::pages::{login_page, register_page};
+use crate::apps::auth::client::pages::{account_page, login_page, register_page};
 use crate::apps::clusters::client::pages::clusters_list_page;
 use crate::apps::dashboard::client::layout::dashboard_shell;
 use crate::apps::deployments::client::pages::deployments_list_page;
@@ -46,6 +46,7 @@ pub fn init_router() -> ClientRouter {
 	UnifiedRouter::new()
 		.client(|c| {
 			c.route("dashboard:home", "/", dashboard_shell)
+				.route("auth:account_page", "/account", account_page)
 				.route("auth:login_page", "/login", login_page)
 				.route("auth:register_page", "/register", register_page)
 				.route("clusters:list", "/clusters", clusters_list_page)

--- a/dashboard/src/config/urls.rs
+++ b/dashboard/src/config/urls.rs
@@ -299,6 +299,7 @@ async fn make_router(#[inject] infra: Depends<RouterInfrastructure>) -> Dashboar
 			.mount_unified("/", crate::apps::organizations::urls::url_patterns())
 			.server(|s| {
 				s.server_fn(server_fn::login::login::marker)
+					.server_fn(server_fn::linked_accounts::list_linked_oauth_accounts::marker)
 					.server_fn(server_fn::register::register::marker)
 					.server_fn(server_fn::logout::logout::marker)
 					.server_fn(server_fn::me::me::marker)

--- a/dashboard/src/shared/client/components.rs
+++ b/dashboard/src/shared/client/components.rs
@@ -1,4 +1,5 @@
 //! Cross-app client-side UI components for the dashboard SPA.
 
+pub mod logout;
 pub mod status_badge;
 pub mod toast;

--- a/dashboard/src/shared/client/components/logout.rs
+++ b/dashboard/src/shared/client/components/logout.rs
@@ -1,0 +1,63 @@
+//! Logout button browser wiring.
+
+#[cfg(any(wasm, test))]
+const LOGOUT_SELECTOR: &str = ".js-dashboard-logout";
+#[cfg(wasm)]
+const BOUND_ATTR: &str = "data-dashboard-logout-bound";
+
+/// Attach logout behavior to dashboard shell buttons on the current page.
+#[cfg(wasm)]
+pub fn ensure_logout_buttons_connected() {
+	use wasm_bindgen::JsCast;
+	use wasm_bindgen::closure::Closure;
+	use wasm_bindgen_futures::spawn_local;
+
+	use crate::apps::auth::server_fn::logout::logout;
+
+	let Some(document) = web_sys::window().and_then(|w| w.document()) else {
+		return;
+	};
+	let Ok(nodes) = document.query_selector_all(LOGOUT_SELECTOR) else {
+		return;
+	};
+
+	for i in 0..nodes.length() {
+		let Some(node) = nodes.item(i) else {
+			continue;
+		};
+		let Ok(element) = node.dyn_into::<web_sys::Element>() else {
+			continue;
+		};
+		if element.has_attribute(BOUND_ATTR) {
+			continue;
+		}
+		let _ = element.set_attribute(BOUND_ATTR, "true");
+		let closure =
+			Closure::<dyn FnMut(web_sys::Event)>::wrap(Box::new(move |event: web_sys::Event| {
+				event.prevent_default();
+				spawn_local(async {
+					let _ = logout().await;
+					if let Some(window) = web_sys::window() {
+						let _ = window.location().set_href("/login");
+					}
+				});
+			}));
+		let _ = element.add_event_listener_with_callback("click", closure.as_ref().unchecked_ref());
+		closure.forget();
+	}
+}
+
+/// Native rendering does not need browser event wiring.
+#[cfg(not(wasm))]
+pub fn ensure_logout_buttons_connected() {}
+
+#[cfg(test)]
+mod tests {
+	use rstest::rstest;
+
+	#[rstest]
+	fn logout_selector_targets_logout_button_class() {
+		// Arrange / Act / Assert
+		assert_eq!(super::LOGOUT_SELECTOR, ".js-dashboard-logout");
+	}
+}

--- a/dashboard/tests/wasm/test_spa_route_paths.rs
+++ b/dashboard/tests/wasm/test_spa_route_paths.rs
@@ -27,6 +27,12 @@ fn spa_routes_reverse_to_expected_paths() {
 	// Act + Assert — each named SPA route reverses to its declared path.
 	assert_eq!(
 		router
+			.reverse("auth:account_page", &[])
+			.expect("auth:account_page must be reversible"),
+		"/account"
+	);
+	assert_eq!(
+		router
 			.reverse("auth:login_page", &[])
 			.expect("auth:login_page must be reversible"),
 		"/login"

--- a/docs/tools/dashboard.md
+++ b/docs/tools/dashboard.md
@@ -64,17 +64,18 @@ Then open `http://localhost:8000` in a browser.
 
 ### First login
 
-The Dashboard uses the same credential-based authentication as the CLI. See [CLI login](cli.md#reinhardt-cloud-login) for how credentials are issued. Once you have a valid username and password, visit the Dashboard login page at `/login` and enter them there.
+The Dashboard supports credential-based authentication and configured GitHub OAuth. Visit `/login` for local username/password sign-in. After signing in, use `/account` to view the current profile, link a GitHub account, or log out from the dashboard shell.
 
 ### Layout tour
 
-The WASM client router (`dashboard/src/client/router.rs`) registers three top-level client routes, and the HTTP server mounts three application namespaces plus an admin panel:
+The WASM client router (`dashboard/src/client/router.rs`) registers the top-level client routes, and the HTTP server mounts application namespaces plus an admin panel:
 
 1. **Dashboard shell** (`/`) — the root application shell; landing view after login
-2. **Auth** (`/auth/`) — login and registration pages; JWT issuance
-3. **Clusters** (`/clusters/`) — registered Kubernetes cluster list and management
-4. **Deployments** (`/deployments/`) — deployment records paired with operator `ReinhardtApp` CRDs
-5. **Admin panel** (`/api/admin/`) — operator-level administration UI (reinhardt-admin)
+2. **Account** (`/account`) — profile summary and GitHub account linking
+3. **Auth** (`/auth/`) — login, registration, OAuth callback, and session endpoints
+4. **Clusters** (`/clusters/`) — registered Kubernetes cluster list and management
+5. **Deployments** (`/deployments/`) — deployment records paired with operator `ReinhardtApp` CRDs
+6. **Admin panel** (`/api/admin/`) — operator-level administration UI (reinhardt-admin)
 
 ---
 
@@ -205,9 +206,9 @@ This is set unconditionally by `dashboard/src/bin/manage.rs` before delegating t
 
 Override at deploy time by mounting a `local.toml` as a `ConfigMap` volume, or by supplying a `production.toml` file alongside `base.toml` in the settings directory. The reinhardt-web loader merges files in lexicographic order of their names.
 
-### OIDC / SSO
+### GitHub OAuth
 
-OIDC/SSO is not configured out of the box. There are no `oidc`, `openid`, `saml`, or `oauth2` references in `dashboard/src/` (grep confirmed). The Dashboard currently uses credential-based login via the `LocalAuthService` registered in `dashboard/src/config/urls.rs`. Integration with an external identity provider is planned but not implemented.
+GitHub OAuth is enabled when all required provider settings are present in the runtime environment. The login and registration pages show only configured providers. Existing users can link GitHub from `/account`; the callback attaches the provider identity to the active session user when a valid `sessionid` cookie is present. OAuth access tokens are not persisted by the dashboard.
 
 ### Operations
 
@@ -313,9 +314,10 @@ If the discrepancy persists beyond a few minutes, verify the agent's heartbeat i
 | Path | Handler | Notes |
 |------|---------|-------|
 | `/` | Dashboard shell (WASM SPA entrypoint) | Client-side router takes over after initial load |
+| `/account` | Account page | Shows profile, GitHub linking state, and logout control |
 | `/login` | Login page | WASM client route; auth POST goes to `/auth/` API |
 | `/register` | Registration page | WASM client route |
-| `/auth/` | Auth app URL patterns | JWT issuance, login, registration API endpoints |
+| `/auth/` | Auth app URL patterns | Login, registration, OAuth, and session API endpoints |
 | `/clusters/` | Clusters app URL patterns | Cluster CRUD API |
 | `/deployments/` | Deployments app URL patterns | Deployment record API |
 | `/api/admin/` | reinhardt-admin panel | Requires admin account |


### PR DESCRIPTION
## Summary

This PR addresses:

- Add an authenticated `/account` page that shows the current profile and GitHub linking state.
- Link GitHub OAuth callbacks to the current session user when a valid dashboard session exists.
- Add dashboard Account and Logout controls, with WASM logout wiring that clears the session and returns to `/login`.
- Document dashboard GitHub linking and logout behavior.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

Authenticated dashboard users need a way to attach GitHub as a sign-in provider without creating a separate account. The callback can safely distinguish sign-in from linking by checking the existing session cookie before calling the OAuth link-or-create flow.

Fixes #684

Related to: #683

## How Was This Tested?

- `cargo test -p reinhardt-cloud-dashboard auth::tests::unit --all-features`
- `cargo test -p reinhardt-cloud-dashboard dashboard_shell_renders_account_and_logout_controls --all-features`
- `cargo test -p reinhardt-cloud-dashboard test_oauth_start_url_uses_registered_route_reverse --all-features`
- `cargo test -p reinhardt-cloud-dashboard test_session_id_from_cookie_header --all-features`
- `cargo make fmt-check`
- `cargo make clippy-check`
- `cd dashboard && cargo make wasm-compile-dev`
- `cd dashboard && cargo make wasm-spa-test`

## Performance Impact

Not performance-related.

## Breaking Changes

None.

## Screenshots

### Before

N/A

### After

N/A

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #684
- Stacked on #683 because the account/logout controls build on the dashboard shell added there.

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [ ] `kubernetes` - Kubernetes resources, controllers, operators
- [ ] `deployment` - Application deployment logic
- [ ] `networking` - Ingress, services, network policies
- [ ] `storage` - Persistent volumes, storage classes
- [x] `auth` - Authentication, authorization, RBAC
- [ ] `api` - REST API, serializers, handlers
- [ ] `cli` - Command-line interface
- [ ] `config` - Configuration management
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

This PR intentionally does not persist OAuth access tokens. The account page exposes only provider metadata that is safe for browser display.

Generated with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Account page where users can view their profile and link GitHub OAuth accounts
  * Added GitHub OAuth account linking functionality for enhanced authentication
  * Added logout button to dashboard navigation
  * Updated dashboard navigation to display Account link instead of Login link

* **Documentation**
  * Updated documentation to reflect new Account page and GitHub OAuth linking capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->