### PR TITLE
feat(github): add app installation onboarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5589,8 +5589,10 @@ dependencies = [
 name = "reinhardt-cloud-dashboard"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm",
  "anyhow",
  "async-trait",
+ "base64 0.22.1",
  "cfg_aliases",
  "chrono",
  "console_error_panic_hook",

--- a/dashboard/Cargo.toml
+++ b/dashboard/Cargo.toml
@@ -47,6 +47,8 @@ tokio = { workspace = true }
 hmac = "0.12"
 sha2 = "0.10"
 hex = "0.4"
+aes-gcm = "0.10"
+base64 = "0.22"
 subtle = "2"
 url = "2"
 percent-encoding = "2"

--- a/dashboard/migrations/auth/0006_add_social_account_token_metadata.rs
+++ b/dashboard/migrations/auth/0006_add_social_account_token_metadata.rs
@@ -1,0 +1,58 @@
+use reinhardt::db::migrations::FieldType;
+use reinhardt::db::migrations::prelude::*;
+
+pub fn migration() -> Migration {
+	Migration {
+		app_label: "auth".to_string(),
+		name: "0006_add_social_account_token_metadata".to_string(),
+		operations: vec![
+			Operation::AddColumn {
+				table: "auth_social_accounts".to_string(),
+				column: ColumnDefinition {
+					name: "encrypted_access_token".to_string(),
+					type_definition: FieldType::VarChar(4096u32),
+					not_null: false,
+					unique: false,
+					primary_key: false,
+					auto_increment: false,
+					default: None,
+				},
+				mysql_options: None,
+			},
+			Operation::AddColumn {
+				table: "auth_social_accounts".to_string(),
+				column: ColumnDefinition {
+					name: "token_expires_at".to_string(),
+					type_definition: FieldType::TimestampTz,
+					not_null: false,
+					unique: false,
+					primary_key: false,
+					auto_increment: false,
+					default: None,
+				},
+				mysql_options: None,
+			},
+			Operation::AddColumn {
+				table: "auth_social_accounts".to_string(),
+				column: ColumnDefinition {
+					name: "scopes".to_string(),
+					type_definition: FieldType::VarChar(2048u32),
+					not_null: false,
+					unique: false,
+					primary_key: false,
+					auto_increment: false,
+					default: None,
+				},
+				mysql_options: None,
+			},
+		],
+		dependencies: vec![("auth".to_string(), "0005_add_social_accounts".to_string())],
+		atomic: true,
+		replaces: vec![],
+		initial: Some(false),
+		state_only: false,
+		database_only: false,
+		swappable_dependencies: vec![],
+		optional_dependencies: vec![],
+	}
+}

--- a/dashboard/src/apps/auth/models/social_account.rs
+++ b/dashboard/src/apps/auth/models/social_account.rs
@@ -5,10 +5,8 @@
 //! providers. The pair `(provider, provider_user_id)` is globally unique so
 //! that the same external identity cannot be claimed by two local users.
 //!
-//! No long-term token is persisted: the OAuth access token is exchanged in
-//! memory during callback, used to fetch user info, then dropped. Refresh
-//! tokens are out of scope until a future "deploy from your repository"
-//! feature explicitly opts in.
+//! OAuth tokens are stored only as encrypted metadata when a downstream
+//! integration needs user-scoped provider API authorization.
 
 use chrono::{DateTime, Utc};
 use reinhardt::db::associations::ForeignKeyField;
@@ -47,6 +45,18 @@ pub struct SocialAccount {
 	/// because some providers may not surface it.
 	#[field(max_length = 255, null = true)]
 	pub provider_username: Option<String>,
+
+	/// Encrypted OAuth access token for provider API calls.
+	#[field(max_length = 4096, null = true)]
+	pub encrypted_access_token: Option<String>,
+
+	/// Access-token expiration timestamp, when the provider returns one.
+	#[field(null = true)]
+	pub token_expires_at: Option<DateTime<Utc>>,
+
+	/// Space-separated OAuth scopes granted by the provider.
+	#[field(max_length = 2048, null = true)]
+	pub scopes: Option<String>,
 
 	/// Creation timestamp.
 	#[field(auto_now_add = true)]

--- a/dashboard/src/apps/auth/server_urls.rs
+++ b/dashboard/src/apps/auth/server_urls.rs
@@ -124,6 +124,14 @@ pub async fn oauth_callback(
 	let user = link_or_create_user(&storage, &provider_id, &claims, current_user)
 		.await
 		.map_err(|err| AppError::Validation(err.to_string()))?;
+	let oauth_token = result.token_response.to_oauth_token();
+	storage
+		.store_token_for_user(user.id, &provider_id, &claims.sub, &oauth_token)
+		.await
+		.map_err(|err| {
+			error!("Failed to persist OAuth token metadata for provider {provider_id}: {err}");
+			AppError::Internal("Internal server error".to_string())
+		})?;
 	let session_id = session_service
 		.create_session(&user)
 		.await

--- a/dashboard/src/apps/auth/services/oauth.rs
+++ b/dashboard/src/apps/auth/services/oauth.rs
@@ -19,3 +19,5 @@ pub mod config;
 pub mod linking;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod storage;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod token_crypto;

--- a/dashboard/src/apps/auth/services/oauth/storage.rs
+++ b/dashboard/src/apps/auth/services/oauth/storage.rs
@@ -5,13 +5,13 @@
 //! local ORM model `crate::apps::auth::models::SocialAccount` (which only
 //! persists the link itself).
 //!
-//! Token persistence is deliberately omitted: the access_token is exchanged
-//! during callback only to fetch user info, then dropped. Out of scope for
-//! this PR are encrypted at-rest storage of OAuth tokens and refresh-flow
-//! support; see #428 for the policy and follow-up issues for tracking.
+//! OAuth access tokens are persisted only through explicit helper methods
+//! that encrypt the token before writing the ORM row. The trait-facing
+//! account-linking API still returns tokenless accounts so generic social
+//! auth callers cannot accidentally observe stored credentials.
 //!
 //! When the storage trait returns a `SocialAccount` to the framework, the
-//! token / scope / email / display_name / picture fields are filled with
+//! access token / email / display_name / picture fields are filled with
 //! safe defaults (empty strings / `Vec::new()` / `None`) so that callers
 //! that round-trip through `update()` cannot accidentally observe a token
 //! value loaded from the database.
@@ -27,12 +27,16 @@
 
 use async_trait::async_trait;
 use chrono::{TimeZone, Utc};
+use reinhardt::auth::social::core::OAuthToken;
 use reinhardt::auth::social::core::SocialAuthError;
 use reinhardt::auth::social::storage::{SocialAccount, SocialAccountStorage};
 use reinhardt::db::orm::{IntoPrimaryKey, Model};
 use uuid::Uuid;
 
 use crate::apps::auth::models::{SocialAccount as OrmSocialAccount, User};
+use crate::apps::auth::services::oauth::token_crypto::{
+	decrypt_access_token, encrypt_access_token,
+};
 /// Maps an ORM record to the framework `SocialAccount` shape with empty
 /// token-bearing fields. The storage layer never returns persisted tokens.
 fn orm_to_framework(orm: OrmSocialAccount) -> SocialAccount {
@@ -71,6 +75,62 @@ impl OrmSocialAccountStorage {
 	/// DI container, exactly like the rest of the dashboard's ORM usage.
 	pub const fn new() -> Self {
 		Self
+	}
+
+	/// Persist encrypted token metadata for a linked provider account.
+	pub async fn store_token_for_user(
+		&self,
+		user_id: Uuid,
+		provider: &str,
+		provider_user_id: &str,
+		token: &OAuthToken,
+	) -> Result<(), SocialAuthError> {
+		let mut row = OrmSocialAccount::objects()
+			.filter(OrmSocialAccount::field_user_id().eq(user_id.to_string()))
+			.filter(OrmSocialAccount::field_provider().eq(provider.to_string()))
+			.filter(OrmSocialAccount::field_provider_user_id().eq(provider_user_id.to_string()))
+			.first()
+			.await
+			.map_err(|e| map_orm_err("store_token_for_user.lookup", e))?
+			.ok_or_else(|| {
+				SocialAuthError::Storage(format!(
+					"Social account not found for provider {provider}: {provider_user_id}"
+				))
+			})?;
+		row.encrypted_access_token = Some(
+			encrypt_access_token(&token.access_token)
+				.map_err(|e| SocialAuthError::Storage(e.to_string()))?,
+		);
+		row.token_expires_at = Some(token.expires_at);
+		row.scopes = Some(token.scopes.join(" "));
+		OrmSocialAccount::objects()
+			.update(&row)
+			.await
+			.map_err(|e| map_orm_err("store_token_for_user.update", e))?;
+		Ok(())
+	}
+
+	/// Load and decrypt a stored provider access token for a dashboard user.
+	pub async fn access_token_for_user(
+		&self,
+		user_id: Uuid,
+		provider: &str,
+	) -> Result<Option<String>, SocialAuthError> {
+		let row = OrmSocialAccount::objects()
+			.filter(OrmSocialAccount::field_user_id().eq(user_id.to_string()))
+			.filter(OrmSocialAccount::field_provider().eq(provider.to_string()))
+			.first()
+			.await
+			.map_err(|e| map_orm_err("access_token_for_user.lookup", e))?;
+		let Some(row) = row else {
+			return Ok(None);
+		};
+		let Some(encrypted) = row.encrypted_access_token else {
+			return Ok(None);
+		};
+		decrypt_access_token(&encrypted)
+			.map(Some)
+			.map_err(|e| SocialAuthError::Storage(e.to_string()))
 	}
 }
 
@@ -116,6 +176,9 @@ impl SocialAccountStorage for OrmSocialAccountStorage {
 			.provider(account.provider.clone())
 			.provider_user_id(account.provider_user_id.clone())
 			.provider_username(account.display_name.clone())
+			.encrypted_access_token(None)
+			.token_expires_at(None)
+			.scopes(None)
 			.created_at(account.created_at)
 			.updated_at(account.updated_at)
 			.finish();
@@ -146,15 +209,11 @@ impl SocialAccountStorage for OrmSocialAccountStorage {
 		// though we ignored token-bearing fields.
 		let updated_at = chrono::Utc::now();
 
-		let orm = OrmSocialAccount::build()
-			.id(account.id)
-			.user(&account)
-			.provider(account.provider.clone())
-			.provider_user_id(account.provider_user_id.clone())
-			.provider_username(account.display_name.clone())
-			.created_at(account.created_at)
-			.updated_at(updated_at)
-			.finish();
+		let mut orm = exists.expect("existing social account checked above");
+		orm.provider = account.provider.clone();
+		orm.provider_user_id = account.provider_user_id.clone();
+		orm.provider_username = account.display_name.clone();
+		orm.updated_at = updated_at;
 		let saved = OrmSocialAccount::objects()
 			.update(&orm)
 			.await

--- a/dashboard/src/apps/auth/services/oauth/token_crypto.rs
+++ b/dashboard/src/apps/auth/services/oauth/token_crypto.rs
@@ -1,0 +1,123 @@
+//! Encryption helpers for persisted OAuth access tokens.
+
+use aes_gcm::aead::{Aead, AeadCore, KeyInit, OsRng};
+use aes_gcm::{Aes256Gcm, Key, Nonce};
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
+use thiserror::Error;
+
+const TOKEN_ENCRYPTION_KEY_ENV: &str = "REINHARDT_CLOUD_OAUTH_TOKEN_ENCRYPTION_KEY";
+const KEY_LEN: usize = 32;
+const NONCE_LEN: usize = 12;
+
+/// Errors returned by OAuth token encryption/decryption.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum OAuthTokenCryptoError {
+	#[error("{TOKEN_ENCRYPTION_KEY_ENV} is required")]
+	MissingKey,
+	#[error("{TOKEN_ENCRYPTION_KEY_ENV} must be base64-encoded 32 bytes")]
+	InvalidKey,
+	#[error("encrypted OAuth token payload is invalid")]
+	InvalidPayload,
+	#[error("failed to encrypt OAuth token")]
+	Encrypt,
+	#[error("failed to decrypt OAuth token")]
+	Decrypt,
+	#[error("OAuth token is not valid UTF-8")]
+	Utf8,
+}
+
+/// Encrypt an OAuth access token with the configured process key.
+pub fn encrypt_access_token(access_token: &str) -> Result<String, OAuthTokenCryptoError> {
+	let key = key_from_env()?;
+	encrypt_access_token_with_key(access_token, &key)
+}
+
+/// Decrypt an OAuth access token with the configured process key.
+pub fn decrypt_access_token(encrypted: &str) -> Result<String, OAuthTokenCryptoError> {
+	let key = key_from_env()?;
+	decrypt_access_token_with_key(encrypted, &key)
+}
+
+pub(crate) fn encrypt_access_token_with_key(
+	access_token: &str,
+	key_bytes: &[u8; KEY_LEN],
+) -> Result<String, OAuthTokenCryptoError> {
+	let cipher = cipher_from_key(key_bytes);
+	let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
+	let ciphertext = cipher
+		.encrypt(&nonce, access_token.as_bytes())
+		.map_err(|_| OAuthTokenCryptoError::Encrypt)?;
+	let mut payload = Vec::with_capacity(NONCE_LEN + ciphertext.len());
+	payload.extend_from_slice(&nonce);
+	payload.extend_from_slice(&ciphertext);
+	Ok(STANDARD.encode(payload))
+}
+
+pub(crate) fn decrypt_access_token_with_key(
+	encrypted: &str,
+	key_bytes: &[u8; KEY_LEN],
+) -> Result<String, OAuthTokenCryptoError> {
+	let payload = STANDARD
+		.decode(encrypted)
+		.map_err(|_| OAuthTokenCryptoError::InvalidPayload)?;
+	if payload.len() <= NONCE_LEN {
+		return Err(OAuthTokenCryptoError::InvalidPayload);
+	}
+	let (nonce, ciphertext) = payload.split_at(NONCE_LEN);
+	let cipher = cipher_from_key(key_bytes);
+	let plaintext = cipher
+		.decrypt(Nonce::from_slice(nonce), ciphertext)
+		.map_err(|_| OAuthTokenCryptoError::Decrypt)?;
+	String::from_utf8(plaintext).map_err(|_| OAuthTokenCryptoError::Utf8)
+}
+
+fn key_from_env() -> Result<[u8; KEY_LEN], OAuthTokenCryptoError> {
+	let raw =
+		std::env::var(TOKEN_ENCRYPTION_KEY_ENV).map_err(|_| OAuthTokenCryptoError::MissingKey)?;
+	let decoded = STANDARD
+		.decode(raw)
+		.map_err(|_| OAuthTokenCryptoError::InvalidKey)?;
+	decoded
+		.try_into()
+		.map_err(|_| OAuthTokenCryptoError::InvalidKey)
+}
+
+fn cipher_from_key(key_bytes: &[u8; KEY_LEN]) -> Aes256Gcm {
+	Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key_bytes))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use rstest::rstest;
+
+	#[rstest]
+	fn test_access_token_encryption_roundtrip() {
+		// Arrange
+		let key = [7u8; KEY_LEN];
+
+		// Act
+		let encrypted =
+			encrypt_access_token_with_key("ghu_secret", &key).expect("encrypt should succeed");
+		let decrypted =
+			decrypt_access_token_with_key(&encrypted, &key).expect("decrypt should succeed");
+
+		// Assert
+		assert_eq!(decrypted, "ghu_secret");
+		assert_ne!(encrypted, "ghu_secret");
+	}
+
+	#[rstest]
+	fn test_access_token_decryption_rejects_wrong_key() {
+		// Arrange
+		let encrypted = encrypt_access_token_with_key("ghu_secret", &[1u8; KEY_LEN])
+			.expect("encrypt should succeed");
+
+		// Act
+		let result = decrypt_access_token_with_key(&encrypted, &[2u8; KEY_LEN]);
+
+		// Assert
+		assert_eq!(result, Err(OAuthTokenCryptoError::Decrypt));
+	}
+}

--- a/dashboard/src/apps/auth/tests/integration/test_oauth_storage.rs
+++ b/dashboard/src/apps/auth/tests/integration/test_oauth_storage.rs
@@ -7,8 +7,11 @@
 
 #[cfg(test)]
 mod tests {
+	use base64::Engine;
+	use base64::engine::general_purpose::STANDARD;
 	use chrono::{Duration, Utc};
 	use reinhardt::BaseUser;
+	use reinhardt::auth::social::core::OAuthToken;
 	use reinhardt::auth::social::storage::{SocialAccount, SocialAccountStorage};
 	use reinhardt::db::orm::Model;
 	use reinhardt::prelude::DatabaseConnection;
@@ -23,6 +26,40 @@ mod tests {
 	use crate::apps::auth::models::User;
 	use crate::apps::auth::services::oauth::storage::OrmSocialAccountStorage;
 	use reinhardt::UrlReverser;
+
+	const TOKEN_ENCRYPTION_KEY_ENV: &str = "REINHARDT_CLOUD_OAUTH_TOKEN_ENCRYPTION_KEY";
+
+	struct EnvGuard {
+		saved: Vec<(&'static str, Option<String>)>,
+	}
+
+	impl EnvGuard {
+		fn set(vars: Vec<(&'static str, String)>) -> Self {
+			let mut saved = Vec::new();
+			for (key, value) in vars {
+				saved.push((key, std::env::var(key).ok()));
+				// SAFETY: these database tests are serialized before mutating process env.
+				unsafe {
+					std::env::set_var(key, value);
+				}
+			}
+			Self { saved }
+		}
+	}
+
+	impl Drop for EnvGuard {
+		fn drop(&mut self) {
+			for (key, value) in &self.saved {
+				// SAFETY: serialized test teardown restores process env.
+				unsafe {
+					match value {
+						Some(value) => std::env::set_var(key, value),
+						None => std::env::remove_var(key),
+					}
+				}
+			}
+		}
+	}
 
 	#[fixture]
 	async fn db() -> (
@@ -83,6 +120,10 @@ mod tests {
 		}
 	}
 
+	fn test_encryption_key() -> String {
+		STANDARD.encode([42u8; 32])
+	}
+
 	#[rstest]
 	#[tokio::test(flavor = "multi_thread")]
 	#[serial(database)]
@@ -127,6 +168,59 @@ mod tests {
 		let found = found.expect("row should exist");
 		assert_eq!(found.id, created.id);
 		assert!(found.access_token.is_empty());
+	}
+
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_store_token_for_user_encrypts_and_loads_explicitly(
+		#[future] db: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			APIClient,
+			Arc<UrlReverser>,
+		),
+	) {
+		// Arrange
+		let (_container, _conn, _client, _urls) = db.await;
+		let _env = EnvGuard::set(vec![(TOKEN_ENCRYPTION_KEY_ENV, test_encryption_key())]);
+		let user_id = create_test_user("oauth_token_store", "tokenstore@example.com").await;
+		let storage = OrmSocialAccountStorage::new();
+		let account = sample_account(user_id, "github", "gh_token");
+		storage
+			.create(account)
+			.await
+			.expect("account create should succeed");
+		let token = OAuthToken {
+			access_token: "ghu_live_token".to_string(),
+			token_type: "Bearer".to_string(),
+			expires_at: Utc::now() + Duration::hours(1),
+			refresh_token: None,
+			scopes: vec!["read:user".to_string(), "read:org".to_string()],
+			id_token: None,
+		};
+
+		// Act
+		storage
+			.store_token_for_user(user_id, "github", "gh_token", &token)
+			.await
+			.expect("token metadata should persist");
+		let explicit = storage
+			.access_token_for_user(user_id, "github")
+			.await
+			.expect("explicit token load should succeed");
+		let linked = storage
+			.find_by_provider_and_uid("github", "gh_token")
+			.await
+			.expect("linked account should load")
+			.expect("linked account should exist");
+
+		// Assert
+		assert_eq!(explicit.as_deref(), Some("ghu_live_token"));
+		assert!(
+			linked.access_token.is_empty(),
+			"framework storage lookup must remain tokenless"
+		);
 	}
 
 	#[rstest]

--- a/dashboard/src/apps/auth/tests/unit/test_social_account_model.rs
+++ b/dashboard/src/apps/auth/tests/unit/test_social_account_model.rs
@@ -3,10 +3,21 @@
 #[cfg(test)]
 mod tests {
 	use chrono::Utc;
+	use reinhardt::db::migrations::operations::Operation;
 	use rstest::rstest;
 	use uuid::Uuid;
 
 	use crate::apps::auth::models::SocialAccount;
+
+	// Included migration files keep `pub fn migration()` because production
+	// discovery loads that symbol from standalone migration modules.
+	#[allow(unreachable_pub)]
+	mod token_metadata_migration {
+		include!(concat!(
+			env!("CARGO_MANIFEST_DIR"),
+			"/migrations/auth/0006_add_social_account_token_metadata.rs"
+		));
+	}
 
 	fn sample_account() -> SocialAccount {
 		let now = Utc::now();
@@ -15,6 +26,9 @@ mod tests {
 			.provider("github".to_string())
 			.provider_user_id("12345".to_string())
 			.provider_username(Some("octocat".to_string()))
+			.encrypted_access_token(None)
+			.token_expires_at(None)
+			.scopes(None)
 			.finish();
 		account.id = Uuid::new_v4();
 		account.created_at = now;
@@ -33,6 +47,9 @@ mod tests {
 		assert!(account.provider.is_empty());
 		assert!(account.provider_user_id.is_empty());
 		assert!(account.provider_username.is_none());
+		assert!(account.encrypted_access_token.is_none());
+		assert!(account.token_expires_at.is_none());
+		assert!(account.scopes.is_none());
 	}
 
 	#[rstest]
@@ -51,6 +68,12 @@ mod tests {
 		assert_eq!(deserialized.provider, account.provider);
 		assert_eq!(deserialized.provider_user_id, account.provider_user_id);
 		assert_eq!(deserialized.provider_username, account.provider_username);
+		assert_eq!(
+			deserialized.encrypted_access_token,
+			account.encrypted_access_token
+		);
+		assert_eq!(deserialized.token_expires_at, account.token_expires_at);
+		assert_eq!(deserialized.scopes, account.scopes);
 	}
 
 	#[rstest]
@@ -83,5 +106,44 @@ mod tests {
 
 		// Assert
 		assert_eq!(deserialized.provider, provider);
+	}
+
+	#[rstest]
+	fn test_social_account_token_metadata_migration_adds_nullable_columns() {
+		// Arrange
+		let migration = token_metadata_migration::migration();
+
+		// Act & Assert
+		assert_add_column(
+			&migration.operations,
+			"encrypted_access_token",
+			"VarChar(4096)",
+		);
+		assert_add_column(&migration.operations, "token_expires_at", "TimestampTz");
+		assert_add_column(&migration.operations, "scopes", "VarChar(2048)");
+		assert_eq!(
+			migration.dependencies,
+			vec![("auth".to_string(), "0005_add_social_accounts".to_string())]
+		);
+	}
+
+	fn assert_add_column(operations: &[Operation], name: &str, field_type: &str) {
+		let column = operations
+			.iter()
+			.find_map(|operation| match operation {
+				Operation::AddColumn { table, column, .. }
+					if table == "auth_social_accounts" && column.name == name =>
+				{
+					Some(column)
+				}
+				_ => None,
+			})
+			.unwrap_or_else(|| panic!("{name} column must be added"));
+		assert_eq!(format!("{:?}", column.type_definition), field_type);
+		assert!(!column.not_null, "{name}.not_null");
+		assert!(!column.unique, "{name}.unique");
+		assert!(!column.primary_key, "{name}.primary_key");
+		assert!(!column.auto_increment, "{name}.auto_increment");
+		assert!(column.default.is_none(), "{name}.default");
 	}
 }

--- a/dashboard/src/apps/github/client/pages/list.rs
+++ b/dashboard/src/apps/github/client/pages/list.rs
@@ -9,10 +9,12 @@ use crate::apps::clusters::server_fn::ClusterInfo;
 #[cfg(wasm)]
 use crate::apps::clusters::server_fn::list_clusters_for_current_org;
 use crate::apps::dashboard::client::layout::dashboard_app_shell;
-#[cfg(wasm)]
-use crate::apps::github::server_fn::list_github_repositories_for_current_org;
 use crate::apps::github::server_fn::{
-	GitHubRepositoryInfo, import_github_repository_for_current_org,
+	GitHubOnboardingInfo, GitHubRepositoryInfo, import_github_repository_for_current_org,
+};
+#[cfg(wasm)]
+use crate::apps::github::server_fn::{
+	get_github_onboarding_for_current_org, list_github_repositories_for_current_org,
 };
 
 fn format_server_error(raw: &str) -> String {
@@ -60,6 +62,21 @@ async fn load_repositories() -> Result<Vec<GitHubRepositoryInfo>, String> {
 }
 
 #[cfg(wasm)]
+async fn load_onboarding() -> Result<GitHubOnboardingInfo, String> {
+	get_github_onboarding_for_current_org()
+		.await
+		.map_err(|e| e.to_string())
+}
+
+#[cfg(not(wasm))]
+async fn load_onboarding() -> Result<GitHubOnboardingInfo, String> {
+	Ok(GitHubOnboardingInfo {
+		github_account_linked: true,
+		install_url: None,
+	})
+}
+
+#[cfg(wasm)]
 async fn load_clusters() -> Result<Vec<ClusterInfo>, String> {
 	list_clusters_for_current_org()
 		.await
@@ -74,6 +91,7 @@ async fn load_clusters() -> Result<Vec<ClusterInfo>, String> {
 /// Render the GitHub repository import page.
 pub fn github_repositories_page() -> Page {
 	let repositories = use_resource(|| async move { self::load_repositories().await }, ());
+	let onboarding = use_resource(|| async move { self::load_onboarding().await }, ());
 	let clusters = use_resource(|| async move { self::load_clusters().await }, ());
 
 	let import_form = form! {
@@ -123,7 +141,7 @@ pub fn github_repositories_page() -> Page {
 	let import_error = import_form.error().clone();
 	let import_view = import_form.into_page();
 
-	let content = page!(|repositories: reinhardt::pages::prelude::Resource<Vec<GitHubRepositoryInfo>, String>, clusters: reinhardt::pages::prelude::Resource<Vec<ClusterInfo>, String>, import_view: Page, import_error: Signal<Option<String>>, import_submitting: Signal<bool>, import_repository_id: Signal<String>, import_cluster_id: Signal<String>, import_app_name: Signal<String>| {
+	let content = page!(|repositories: reinhardt::pages::prelude::Resource<Vec<GitHubRepositoryInfo>, String>, onboarding: reinhardt::pages::prelude::Resource<GitHubOnboardingInfo, String>, clusters: reinhardt::pages::prelude::Resource<Vec<ClusterInfo>, String>, import_view: Page, import_error: Signal<Option<String>>, import_submitting: Signal<bool>, import_repository_id: Signal<String>, import_cluster_id: Signal<String>, import_app_name: Signal<String>| {
 		div {
 			class: "rc-shell",
 			div {
@@ -205,15 +223,47 @@ pub fn github_repositories_page() -> Page {
 													}
 												}
 											})(err),
-											ResourceState::Success(items)if items.is_empty() => page!(|| {
+											ResourceState::Success(items)if items.is_empty() => page!(|onboarding: reinhardt::pages::prelude::Resource<GitHubOnboardingInfo, String>| {
 												tr {
 													td {
-														class: "px-3 py-3 text-cloud-500",
+														class: "px-3 py-4 text-cloud-500",
 														colspan: 5,
-														"No GitHub App repositories are available."
+														{
+															match onboarding.get() {
+																ResourceState::Success(info)if !info.github_account_linked => page!(|| {
+																	div {
+																		class: "flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between",
+																		span { "Link your GitHub account before installing the GitHub App." }
+																		a {
+																			class: "btn-secondary text-xs",
+																			href: "/api/auth/oauth/github/start/",
+																			"Link GitHub account"
+																		}
+																	}
+																})(),
+																ResourceState::Success(info) => {
+																	if let Some(url) = info.install_url {
+																		page!(|url: String| {
+																			div {
+																				class: "flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between",
+																				span { "No GitHub App repositories are available." }
+																				a {
+																					class: "btn-secondary text-xs",
+																					href: url,
+																					"Connect GitHub repositories"
+																				}
+																			}
+																		})(url)
+																	} else {
+																		page!(|| { "No GitHub App repositories are available." })()
+																	}
+																}
+																_ => page!(|| { "No GitHub App repositories are available." })(),
+															}
+														}
 													}
 												}
-											})(),
+											})(onboarding.clone()),
 											ResourceState::Success(items) => page!(|items: Vec<GitHubRepositoryInfo>, import_repository_id: Signal<String>, import_app_name: Signal<String>| { {
 												items.clone().into_iter().map(|repo| {
 													page!(|repo: GitHubRepositoryInfo, import_repository_id: Signal<String>, import_app_name: Signal<String>| {
@@ -369,6 +419,7 @@ pub fn github_repositories_page() -> Page {
 		}
 	})(
 		repositories,
+		onboarding,
 		clusters,
 		import_view,
 		import_error,

--- a/dashboard/src/apps/github/server_fn.rs
+++ b/dashboard/src/apps/github/server_fn.rs
@@ -42,6 +42,12 @@ pub struct GitHubProjectInfo {
 	pub status: String,
 }
 
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct GitHubOnboardingInfo {
+	pub github_account_linked: bool,
+	pub install_url: Option<String>,
+}
+
 #[cfg(native)]
 async fn current_org_id(user: &crate::apps::auth::models::User) -> Result<i64, ServerFnError> {
 	crate::apps::organizations::helpers::current_organization_id_for_user(user.id)
@@ -50,19 +56,26 @@ async fn current_org_id(user: &crate::apps::auth::models::User) -> Result<i64, S
 }
 
 #[cfg(native)]
-async fn ensure_github_account_linked(
+async fn github_account_linked(
 	user: &crate::apps::auth::models::User,
-) -> Result<(), ServerFnError> {
+) -> Result<bool, ServerFnError> {
 	use reinhardt::Model;
 
-	let linked = crate::apps::auth::models::SocialAccount::objects()
+	crate::apps::auth::models::SocialAccount::objects()
 		.filter(crate::apps::auth::models::SocialAccount::field_user_id().eq(user.id.to_string()))
 		.filter(crate::apps::auth::models::SocialAccount::field_provider().eq("github"))
 		.exists()
 		.await
 		.map_err(|e| {
 			ServerFnError::application(format!("Failed to check linked GitHub account: {e}"))
-		})?;
+		})
+}
+
+#[cfg(native)]
+async fn ensure_github_account_linked(
+	user: &crate::apps::auth::models::User,
+) -> Result<(), ServerFnError> {
+	let linked = github_account_linked(user).await?;
 	if linked {
 		Ok(())
 	} else {
@@ -219,6 +232,25 @@ async fn sync_repositories_for_installation(
 		}
 	}
 	Ok(())
+}
+
+#[server_fn]
+pub async fn get_github_onboarding_for_current_org(
+	#[inject] CurrentUser(user): CurrentUser<crate::apps::auth::models::User>,
+) -> Result<GitHubOnboardingInfo, ServerFnError> {
+	#[cfg(native)]
+	{
+		Ok(GitHubOnboardingInfo {
+			github_account_linked: github_account_linked(&user).await?,
+			install_url:
+				crate::apps::github::services::config::GitHubAppSettings::install_url_from_env(),
+		})
+	}
+	#[cfg(wasm)]
+	{
+		let _ = user;
+		unreachable!("server_fn body is replaced on wasm")
+	}
 }
 
 #[server_fn]

--- a/dashboard/src/apps/github/server_urls.rs
+++ b/dashboard/src/apps/github/server_urls.rs
@@ -7,13 +7,14 @@ use reinhardt::di::Depends;
 use reinhardt::http::ViewResult;
 use reinhardt::pages::server_fn::ServerFnRequest;
 use reinhardt::reinhardt_params::Body;
-use reinhardt::{Response, StatusCode, post};
-use serde::Serialize;
+use reinhardt::{CurrentUser, Query, Response, StatusCode, get, post};
+use serde::{Deserialize, Serialize};
 use tracing::{error, info, warn};
 
 use crate::apps::clusters::models::Cluster;
 use crate::apps::deployments::models::Deployment;
 use crate::apps::github::models::{GitHubInstallation, GitHubProject, GitHubRepository};
+use crate::apps::github::services::client::{GitHubAppClient, GitHubUserInstallation};
 use crate::apps::github::services::config::GitHubAppSettings;
 use crate::apps::github::services::import::apply_webhook_action_to_manifest;
 use crate::apps::github::services::pipeline::github_credentials_secret_name;
@@ -25,6 +26,55 @@ use crate::utils::vcs::signature::verify_github_signature;
 struct GitHubWebhookResponse {
 	status: &'static str,
 	action: &'static str,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GitHubSetupQuery {
+	installation_id: i64,
+}
+
+/// Complete GitHub App setup after GitHub redirects to the configured setup URL.
+#[get("/setup/", name = "github-setup")]
+pub async fn github_setup(
+	Query(query): Query<GitHubSetupQuery>,
+	#[inject] CurrentUser(user): CurrentUser<crate::apps::auth::models::User>,
+	#[inject] settings: Depends<GitHubAppSettings>,
+) -> ViewResult<Response> {
+	let storage = crate::apps::auth::services::oauth::storage::OrmSocialAccountStorage::new();
+	let Some(user_access_token) = storage
+		.access_token_for_user(user.id, "github")
+		.await
+		.map_err(|e| {
+			error!("Failed to load GitHub OAuth token for setup callback: {e}");
+			AppError::Internal("Internal server error".to_string())
+		})?
+	else {
+		return Err(AppError::Authorization(
+			"GitHub account must be linked before installing the GitHub App".to_string(),
+		));
+	};
+
+	let client =
+		crate::apps::github::services::client::ReqwestGitHubAppClient::new((*settings).clone());
+	let installation = client
+		.list_user_installations(&user_access_token)
+		.await
+		.map_err(|e| {
+			error!("Failed to list GitHub installations visible to setup user: {e}");
+			AppError::Internal("Failed to verify GitHub App installation".to_string())
+		})?
+		.into_iter()
+		.find(|installation| installation.id == query.installation_id)
+		.ok_or_else(|| {
+			AppError::Authorization(
+				"GitHub App installation is not accessible to this user".to_string(),
+			)
+		})?;
+	let organization_id =
+		crate::apps::organizations::helpers::current_organization_id_for_user(user.id).await?;
+	upsert_verified_installation(organization_id, installation).await?;
+
+	Ok(Response::temporary_redirect("/github"))
 }
 
 #[post("/webhooks/github/", name = "github-webhook")]
@@ -43,6 +93,16 @@ pub async fn github_webhook(
 			GitHubWebhookResponse {
 				status: "error",
 				action: "invalid_signature",
+			},
+		);
+	}
+	if event_type == "installation" {
+		reconcile_installation_webhook(&payload).await?;
+		return json_response(
+			StatusCode::ACCEPTED,
+			GitHubWebhookResponse {
+				status: "accepted",
+				action: "installation",
 			},
 		);
 	}
@@ -197,6 +257,125 @@ pub async fn github_webhook(
 			action: action_name,
 		},
 	)
+}
+
+async fn upsert_verified_installation(
+	organization_id: i64,
+	installation: GitHubUserInstallation,
+) -> Result<(), AppError> {
+	let existing = GitHubInstallation::objects()
+		.filter(GitHubInstallation::field_installation_id().eq(installation.id))
+		.first()
+		.await
+		.map_err(|e| {
+			error!(
+				"Failed to look up GitHub installation {} during setup: {e}",
+				installation.id
+			);
+			AppError::Internal("Failed to persist GitHub installation".to_string())
+		})?;
+	if let Some(mut existing) = existing {
+		if *existing.organization_id() != organization_id {
+			return Err(AppError::Conflict(
+				"GitHub App installation is already linked to another organization".to_string(),
+			));
+		}
+		existing.account_id = installation.account_id;
+		existing.account_login = installation.account_login;
+		existing.account_type = installation.account_type;
+		existing.status = "active".to_string();
+		GitHubInstallation::objects()
+			.update(&existing)
+			.await
+			.map_err(|e| {
+				error!(
+					"Failed to update GitHub installation {} during setup: {e}",
+					installation.id
+				);
+				AppError::Internal("Failed to persist GitHub installation".to_string())
+			})?;
+		return Ok(());
+	}
+
+	let row = GitHubInstallation::build()
+		.organization(organization_id)
+		.installation_id(installation.id)
+		.account_id(installation.account_id)
+		.account_login(installation.account_login)
+		.account_type(installation.account_type)
+		.status("active".to_string())
+		.finish();
+	GitHubInstallation::objects()
+		.create(&row)
+		.await
+		.map_err(|e| {
+			error!(
+				"Failed to create GitHub installation {} during setup: {e}",
+				installation.id
+			);
+			AppError::Internal("Failed to persist GitHub installation".to_string())
+		})?;
+	Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubInstallationWebhookPayload {
+	action: String,
+	installation: GitHubInstallationWebhookInstallation,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubInstallationWebhookInstallation {
+	id: i64,
+	account: GitHubInstallationWebhookAccount,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubInstallationWebhookAccount {
+	id: i64,
+	login: String,
+	#[serde(rename = "type")]
+	account_type: String,
+}
+
+async fn reconcile_installation_webhook(payload: &[u8]) -> Result<(), AppError> {
+	let event: GitHubInstallationWebhookPayload = serde_json::from_slice(payload)
+		.map_err(|e| AppError::Validation(format!("Invalid installation webhook payload: {e}")))?;
+	let status = match event.action.as_str() {
+		"created" | "unsuspend" | "new_permissions_accepted" => "active",
+		"deleted" => "inactive",
+		"suspend" => "suspended",
+		_ => return Ok(()),
+	};
+	let Some(mut installation) = GitHubInstallation::objects()
+		.filter(GitHubInstallation::field_installation_id().eq(event.installation.id))
+		.first()
+		.await
+		.map_err(|e| {
+			error!(
+				"Failed to load GitHub installation {} for webhook reconciliation: {e}",
+				event.installation.id
+			);
+			AppError::Internal("Failed to reconcile GitHub installation".to_string())
+		})?
+	else {
+		return Ok(());
+	};
+	installation.account_id = event.installation.account.id;
+	installation.account_login = event.installation.account.login;
+	installation.account_type = event.installation.account.account_type;
+	installation.status = status.to_string();
+	GitHubInstallation::objects()
+		.update(&installation)
+		.await
+		.map_err(|e| {
+			error!(
+				"Failed to update GitHub installation {} from webhook: {e}",
+				event.installation.id
+			);
+			AppError::Internal("Failed to reconcile GitHub installation".to_string())
+		})?;
+	Ok(())
 }
 
 async fn refresh_git_credentials_secret_for_webhook(

--- a/dashboard/src/apps/github/services/client.rs
+++ b/dashboard/src/apps/github/services/client.rs
@@ -34,6 +34,15 @@ pub struct GitHubInstallationAccessToken {
 	pub expires_at: String,
 }
 
+/// GitHub App installation visible to a user access token.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GitHubUserInstallation {
+	pub id: i64,
+	pub account_id: i64,
+	pub account_login: String,
+	pub account_type: String,
+}
+
 impl std::fmt::Debug for GitHubInstallationAccessToken {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("GitHubInstallationAccessToken")
@@ -66,6 +75,11 @@ pub trait GitHubAppClient: Send + Sync {
 		&self,
 		installation_id: i64,
 	) -> Result<Vec<GitHubInstallationRepository>, GitHubAppClientError>;
+
+	async fn list_user_installations(
+		&self,
+		user_access_token: &str,
+	) -> Result<Vec<GitHubUserInstallation>, GitHubAppClientError>;
 }
 
 /// Reqwest-backed GitHub App API client.
@@ -147,6 +161,46 @@ impl ReqwestGitHubAppClient {
 
 		Ok(repositories)
 	}
+
+	pub(crate) async fn list_user_installations_with_token(
+		&self,
+		user_access_token: &str,
+	) -> Result<Vec<GitHubUserInstallation>, GitHubAppClientError> {
+		let mut page = 1u32;
+		let mut installations = Vec::new();
+
+		loop {
+			let url = user_installations_url(&self.settings.api_base_url)?;
+			let response = self
+				.http_client
+				.get(url)
+				.bearer_auth(user_access_token)
+				.github_json_headers()
+				.query(&[
+					("per_page", REPOSITORIES_PER_PAGE.to_string()),
+					("page", page.to_string()),
+				])
+				.send()
+				.await
+				.map_err(|err| GitHubAppClientError::Http(err.to_string()))?;
+			let page_response = parse_response::<GitHubUserInstallationsResponse>(response).await?;
+			let total_count = page_response.total_count;
+			let page_len = page_response.installations.len();
+			installations.extend(
+				page_response
+					.installations
+					.into_iter()
+					.map(GitHubUserInstallation::from),
+			);
+
+			if installations.len() >= total_count || page_len < usize::from(REPOSITORIES_PER_PAGE) {
+				break;
+			}
+			page += 1;
+		}
+
+		Ok(installations)
+	}
 }
 
 #[async_trait]
@@ -159,6 +213,14 @@ impl GitHubAppClient for ReqwestGitHubAppClient {
 			.create_installation_access_token(installation_id)
 			.await?;
 		self.list_repositories_with_token(&access_token.token).await
+	}
+
+	async fn list_user_installations(
+		&self,
+		user_access_token: &str,
+	) -> Result<Vec<GitHubUserInstallation>, GitHubAppClientError> {
+		self.list_user_installations_with_token(user_access_token)
+			.await
 	}
 }
 
@@ -230,6 +292,10 @@ pub(crate) fn installation_repositories_url(
 	api_url(api_base_url, &["installation", "repositories"])
 }
 
+pub(crate) fn user_installations_url(api_base_url: &str) -> Result<Url, GitHubAppClientError> {
+	api_url(api_base_url, &["user", "installations"])
+}
+
 fn api_url(api_base_url: &str, path_segments: &[&str]) -> Result<Url, GitHubAppClientError> {
 	let mut url = Url::parse(api_base_url)
 		.map_err(|err| GitHubAppClientError::Config(format!("invalid api_base_url: {err}")))?;
@@ -288,6 +354,37 @@ impl From<GitHubRepositoryResponse> for GitHubInstallationRepository {
 			name: response.name,
 			private: response.private,
 			default_branch: response.default_branch,
+		}
+	}
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubUserInstallationsResponse {
+	total_count: usize,
+	installations: Vec<GitHubUserInstallationResponse>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubUserInstallationResponse {
+	id: i64,
+	account: GitHubUserInstallationAccountResponse,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubUserInstallationAccountResponse {
+	id: i64,
+	login: String,
+	#[serde(rename = "type")]
+	account_type: String,
+}
+
+impl From<GitHubUserInstallationResponse> for GitHubUserInstallation {
+	fn from(response: GitHubUserInstallationResponse) -> Self {
+		Self {
+			id: response.id,
+			account_id: response.account.id,
+			account_login: response.account.login,
+			account_type: response.account.account_type,
 		}
 	}
 }

--- a/dashboard/src/apps/github/services/config.rs
+++ b/dashboard/src/apps/github/services/config.rs
@@ -12,6 +12,7 @@ const APP_ID_ENV: &str = "REINHARDT_CLOUD_GITHUB_APP_ID";
 const PRIVATE_KEY_PEM_ENV: &str = "REINHARDT_CLOUD_GITHUB_APP_PRIVATE_KEY_PEM";
 const WEBHOOK_SECRET_ENV: &str = "REINHARDT_CLOUD_GITHUB_WEBHOOK_SECRET";
 const API_BASE_URL_ENV: &str = "REINHARDT_CLOUD_GITHUB_API_BASE_URL";
+const INSTALL_URL_ENV: &str = "REINHARDT_CLOUD_GITHUB_APP_INSTALL_URL";
 const DEFAULT_API_BASE_URL: &str = "https://api.github.com";
 
 /// Runtime settings required to operate as a GitHub App.
@@ -21,6 +22,7 @@ pub struct GitHubAppSettings {
 	pub private_key_pem: String,
 	pub webhook_secret: String,
 	pub api_base_url: String,
+	pub install_url: Option<String>,
 }
 
 /// Error returned when GitHub App settings cannot be loaded.
@@ -39,13 +41,20 @@ impl GitHubAppSettings {
 		let webhook_secret = required_env(WEBHOOK_SECRET_ENV)?;
 		let api_base_url =
 			optional_env(API_BASE_URL_ENV).unwrap_or_else(|| DEFAULT_API_BASE_URL.to_string());
+		let install_url = optional_env(INSTALL_URL_ENV);
 
 		Ok(Self {
 			app_id,
 			private_key_pem,
 			webhook_secret,
 			api_base_url,
+			install_url,
 		})
+	}
+
+	/// Reads the configured GitHub App installation URL, if present.
+	pub fn install_url_from_env() -> Option<String> {
+		optional_env(INSTALL_URL_ENV)
 	}
 }
 
@@ -56,6 +65,7 @@ impl fmt::Debug for GitHubAppSettings {
 			.field("private_key_pem", &"[redacted]")
 			.field("webhook_secret", &"[redacted]")
 			.field("api_base_url", &self.api_base_url)
+			.field("install_url", &self.install_url)
 			.finish()
 	}
 }

--- a/dashboard/src/apps/github/tests/unit.rs
+++ b/dashboard/src/apps/github/tests/unit.rs
@@ -70,6 +70,7 @@ pub mod client_tests {
 
 	use crate::apps::github::services::client::{
 		ReqwestGitHubAppClient, installation_access_tokens_url, installation_repositories_url,
+		user_installations_url,
 	};
 	use crate::apps::github::services::config::GitHubAppSettings;
 
@@ -79,6 +80,7 @@ pub mod client_tests {
 			private_key_pem: "unused-private-key".to_string(),
 			webhook_secret: "unused-webhook-secret".to_string(),
 			api_base_url,
+			install_url: None,
 		}
 	}
 
@@ -112,6 +114,8 @@ pub mod client_tests {
 			installation_access_tokens_url(api_base_url, 987_654).expect("url should build");
 		let repositories_url =
 			installation_repositories_url(api_base_url).expect("url should build");
+		let user_installations_url =
+			user_installations_url(api_base_url).expect("url should build");
 
 		// Assert
 		assert_eq!(
@@ -122,6 +126,53 @@ pub mod client_tests {
 			repositories_url.as_str(),
 			"https://github.example.test/api/v3/installation/repositories"
 		);
+		assert_eq!(
+			user_installations_url.as_str(),
+			"https://github.example.test/api/v3/user/installations"
+		);
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_github_app_client_lists_user_installations_with_headers() {
+		// Arrange
+		let server = MockServer::start().await;
+		Mock::given(method("GET"))
+			.and(path("/user/installations"))
+			.and(header("Authorization", "Bearer user-token"))
+			.and(header("Accept", "application/vnd.github+json"))
+			.and(header("X-GitHub-Api-Version", "2022-11-28"))
+			.and(query_param("per_page", "100"))
+			.and(query_param("page", "1"))
+			.respond_with(ResponseTemplate::new(200).set_body_json(json!({
+				"total_count": 1,
+				"installations": [{
+					"id": 987654,
+					"account": {
+						"id": 42,
+						"login": "kent8192",
+						"type": "Organization"
+					}
+				}]
+			})))
+			.expect(1)
+			.mount(&server)
+			.await;
+		let client =
+			ReqwestGitHubAppClient::with_http_client(test_settings(server.uri()), Client::new());
+
+		// Act
+		let installations = client
+			.list_user_installations_with_token("user-token")
+			.await
+			.expect("installations should load");
+
+		// Assert
+		assert_eq!(installations.len(), 1);
+		assert_eq!(installations[0].id, 987654);
+		assert_eq!(installations[0].account_id, 42);
+		assert_eq!(installations[0].account_login, "kent8192");
+		assert_eq!(installations[0].account_type, "Organization");
 	}
 
 	#[rstest]
@@ -538,6 +589,7 @@ pub mod config_tests {
 	const PRIVATE_KEY_PEM_ENV: &str = "REINHARDT_CLOUD_GITHUB_APP_PRIVATE_KEY_PEM";
 	const WEBHOOK_SECRET_ENV: &str = "REINHARDT_CLOUD_GITHUB_WEBHOOK_SECRET";
 	const API_BASE_URL_ENV: &str = "REINHARDT_CLOUD_GITHUB_API_BASE_URL";
+	const INSTALL_URL_ENV: &str = "REINHARDT_CLOUD_GITHUB_APP_INSTALL_URL";
 
 	struct EnvGuard {
 		saved: Vec<(String, Option<String>)>,
@@ -586,6 +638,10 @@ pub mod config_tests {
 			),
 			(WEBHOOK_SECRET_ENV, Some("webhook-secret")),
 			(API_BASE_URL_ENV, None),
+			(
+				INSTALL_URL_ENV,
+				Some("https://github.com/apps/reinhardt-cloud/installations/new"),
+			),
 		]);
 
 		// Act
@@ -600,6 +656,10 @@ pub mod config_tests {
 		);
 		assert_eq!(settings.webhook_secret, "webhook-secret");
 		assert_eq!(settings.api_base_url, "https://api.github.com");
+		assert_eq!(
+			settings.install_url.as_deref(),
+			Some("https://github.com/apps/reinhardt-cloud/installations/new")
+		);
 	}
 
 	#[rstest]
@@ -653,6 +713,9 @@ pub mod config_tests {
 			private_key_pem: "secret-private-key".to_string(),
 			webhook_secret: "secret-webhook-token".to_string(),
 			api_base_url: "https://api.github.com".to_string(),
+			install_url: Some(
+				"https://github.com/apps/reinhardt-cloud/installations/new".to_string(),
+			),
 		};
 
 		// Act

--- a/dashboard/src/apps/github/urls.rs
+++ b/dashboard/src/apps/github/urls.rs
@@ -8,7 +8,8 @@ use crate::apps::github::server_urls;
 pub fn url_patterns() -> UnifiedRouter {
 	UnifiedRouter::new().server(|s| {
 		#[cfg(native)]
-		let s = s.endpoint(server_urls::github_webhook);
+		let s = s.endpoint(server_urls::github_setup)
+			.endpoint(server_urls::github_webhook);
 		s
 	})
 }
@@ -31,5 +32,20 @@ mod tests {
 
 		// Assert
 		assert_eq!(url, Some("/api/github/webhooks/github/".to_string()));
+	}
+
+	#[rstest]
+	fn github_setup_route_is_registered_under_api_prefix() {
+		// Arrange
+		let router = UnifiedRouter::new()
+			.with_prefix("/api/")
+			.mount_unified("/github/", super::url_patterns())
+			.into_server();
+
+		// Act
+		let url = router.reverse("github-setup", &[]);
+
+		// Assert
+		assert_eq!(url, Some("/api/github/setup/".to_string()));
 	}
 }

--- a/dashboard/src/config/urls.rs
+++ b/dashboard/src/config/urls.rs
@@ -316,6 +316,7 @@ async fn make_router(#[inject] infra: Depends<RouterInfrastructure>) -> Dashboar
 					.server_fn(crate::apps::deployments::server_fn::delete_deployment_for_current_org::marker)
 					.server_fn(crate::apps::deployments::server_fn::update_deployment_status_for_current_org::marker)
 					.server_fn(crate::apps::deployments::server_fn::deployment_logs_for_current_org::marker)
+					.server_fn(crate::apps::github::server_fn::get_github_onboarding_for_current_org::marker)
 					.server_fn(crate::apps::github::server_fn::list_github_installations_for_current_org::marker)
 					.server_fn(crate::apps::github::server_fn::list_github_repositories_for_current_org::marker)
 					.server_fn(crate::apps::github::server_fn::list_github_repositories_for_installation::marker)

--- a/docs/architecture/deployment-flow.md
+++ b/docs/architecture/deployment-flow.md
@@ -109,15 +109,20 @@ before drawing conclusions.**
 > is not a `ReinhardtApp` CRD and therefore does not trigger operator
 > reconciliation.
 >
-> **Current State: GitHub import path** — The dashboard lists repositories
-> visible to the GitHub App installation, obtains an installation access
-> token, clones the selected repository into a temporary checkout, runs
-> `manage introspect --format yaml`, embeds the introspect output in the
-> generated `ReinhardtApp` YAML, and routes two agent commands to the
-> selected cluster: `ApplyGitCredentialsSecret` for private repositories
-> and `ApplyReinhardtApp` for the CRD manifest. The agent applies both
-> resources in-cluster using server-side apply, so the operator owns the
-> derived workload reconciliation. When the manifest carries
+> **Current State: GitHub import path** — The dashboard starts from a linked
+> GitHub OAuth account. Its GitHub App installation URL sends users through
+> GitHub App setup, and `/api/github/setup/` verifies the returned
+> `installation_id` by listing installations visible to the encrypted OAuth
+> user token before binding that installation to the current organization.
+> The repository page then lists repositories visible to the GitHub App
+> installation, obtains an installation access token, clones the selected
+> repository into a temporary checkout, runs `manage introspect --format
+> yaml`, embeds the introspect output in the generated `ReinhardtApp` YAML,
+> and routes two agent commands to the selected cluster:
+> `ApplyGitCredentialsSecret` for private repositories and
+> `ApplyReinhardtApp` for the CRD manifest. The agent applies both resources
+> in-cluster using server-side apply, so the operator owns the derived
+> workload reconciliation. When the manifest carries
 > `reinhardt.dev/build-trigger`, the operator creates the Kaniko build Job
 > and patches `spec.image` to the same image reference used as the Kaniko
 > destination, allowing the next workload reconciliation to deploy the built

--- a/docs/tools/dashboard.md
+++ b/docs/tools/dashboard.md
@@ -208,7 +208,11 @@ Override at deploy time by mounting a `local.toml` as a `ConfigMap` volume, or b
 
 ### GitHub OAuth
 
-GitHub OAuth is enabled when all required provider settings are present in the runtime environment. The login and registration pages show only configured providers. Existing users can link GitHub from `/account`; the callback attaches the provider identity to the active session user when a valid `sessionid` cookie is present. OAuth access tokens are not persisted by the dashboard.
+GitHub OAuth is enabled when all required provider settings are present in the runtime environment. The login and registration pages show only configured providers. Existing users can link GitHub from `/account`; the callback attaches the provider identity to the active session user when a valid `sessionid` cookie is present.
+
+The dashboard persists GitHub OAuth access tokens only after encrypting them with `REINHARDT_CLOUD_OAUTH_TOKEN_ENCRYPTION_KEY`. Set this variable to a base64-encoded 32-byte key before enabling GitHub OAuth. The stored token is used to verify GitHub App setup callbacks against `/user/installations`; OAuth storage APIs still return tokenless account records to normal authentication callers.
+
+Set `REINHARDT_CLOUD_GITHUB_APP_INSTALL_URL` to the GitHub App installation URL shown in GitHub App settings. The GitHub repository page uses it for the empty-state install action after the current user has linked a GitHub OAuth account.
 
 ### Operations
 


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds GitHub App installation onboarding for repository imports.
- Persists GitHub OAuth access tokens encrypted at rest for setup verification.
- Verifies GitHub setup callback `installation_id` against `/user/installations` before binding an installation to the current organization.
- Adds installation webhook lifecycle reconciliation and repository-page empty-state actions.
- Documents the new operator environment variables.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

- Repository imports previously assumed GitHub App installation metadata already existed.
- Users now get a guided path from GitHub account linking to GitHub App installation, and setup callbacks are verified with the linked user's OAuth token instead of trusting callback parameters.

Fixes #687

Related to: #685, #686

## How Was This Tested?

- `cargo make fmt-check`
- `cargo check -p reinhardt-cloud-dashboard`
- `cargo make clippy-check`
- `cargo test -p reinhardt-cloud-dashboard --lib apps::auth::services::oauth::token_crypto`
- `cargo test -p reinhardt-cloud-dashboard --lib apps::github::tests::unit::client_tests`
- `cargo test -p reinhardt-cloud-dashboard --lib apps::github::urls::tests`
- `cargo test -p reinhardt-cloud-dashboard --lib apps::auth::tests::unit::test_social_account_model`
- `cargo test -p reinhardt-cloud-dashboard --lib apps::github::tests::unit::config_tests`
- `REINHARDT_CORE__SECRET_KEY=... REINHARDT_CLOUD_JWT_SECRET=... REINHARDT_DATABASE_PASSWORD=... cargo test -p reinhardt-cloud-dashboard --lib apps::auth::tests::integration::test_oauth_storage`

## Performance Impact

- Not performance-related.

## Breaking Changes

- None.

**Migration Guide:**

- Operators enabling GitHub OAuth for repository imports must set `REINHARDT_CLOUD_OAUTH_TOKEN_ENCRYPTION_KEY` to a base64-encoded 32-byte key.
- Operators should set `REINHARDT_CLOUD_GITHUB_APP_INSTALL_URL` to the GitHub App installation URL.

## Screenshots

### Before

- Not captured.

### After

- Not captured; UI coverage is through route and server-function focused tests.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

<!-- CI runner selection: left unchecked intentionally. -->
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #687
- #685
- #686

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [ ] `kubernetes` - Kubernetes resources, controllers, operators
- [ ] `deployment` - Application deployment logic
- [ ] `networking` - Ingress, services, network policies
- [ ] `storage` - Persistent volumes, storage classes
- [x] `auth` - Authentication, authorization, RBAC
- [x] `api` - REST API, serializers, handlers
- [x] `config` - Configuration management
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

- GitWhy context: `ctx_39d94231`

Generated with Codex
