### PR TITLE
fix(auth): require OAuth token encryption key

### DIFF
--- a/dashboard/src/apps/auth/services/oauth/config.rs
+++ b/dashboard/src/apps/auth/services/oauth/config.rs
@@ -3,9 +3,9 @@
 //! Per `CM-2`, OAuth client credentials are environment-driven so that
 //! deployments never bake provider secrets into TOML or container images.
 //! A provider is considered enabled iff its `CLIENT_ID` and `CLIENT_SECRET`
-//! are both set; partial configuration disables the provider entirely so
-//! that the login UI does not present a button that cannot complete the
-//! flow.
+//! are both set and the dashboard can encrypt persisted OAuth tokens; partial
+//! runtime configuration disables the provider entirely so that the login UI
+//! does not present a button that cannot complete the flow.
 //!
 //! [`OAuthSettings`] is exposed via `#[injectable_factory]` so handlers
 //! and the OAuth backend factory resolve a single shared snapshot of the
@@ -16,6 +16,8 @@
 use std::env;
 
 use reinhardt::di::injectable_factory;
+
+use crate::apps::auth::services::oauth::token_crypto::token_encryption_key_is_configured;
 /// Credentials for a single OAuth provider, populated from env vars.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProviderCredentials {
@@ -38,12 +40,13 @@ impl OAuthSettings {
 	/// Reads provider credentials from the process environment.
 	///
 	/// For each provider, all three env vars (`CLIENT_ID`, `CLIENT_SECRET`,
-	/// `REDIRECT_URI`) must be present and non-empty for the provider to be
-	/// enabled. If any of them is missing, the provider entry is `None` and
-	/// provider discovery omits that provider.
+	/// `REDIRECT_URI`) and a valid OAuth token encryption key must be present
+	/// for the provider to be enabled. If any of them is missing, the provider
+	/// entry is `None` and provider discovery omits that provider.
 	pub fn from_env() -> Self {
+		let can_store_tokens = token_encryption_key_is_configured();
 		Self {
-			github: read_provider("GITHUB"),
+			github: can_store_tokens.then(|| read_provider("GITHUB")).flatten(),
 		}
 	}
 

--- a/dashboard/src/apps/auth/services/oauth/token_crypto.rs
+++ b/dashboard/src/apps/auth/services/oauth/token_crypto.rs
@@ -39,6 +39,11 @@ pub fn decrypt_access_token(encrypted: &str) -> Result<String, OAuthTokenCryptoE
 	decrypt_access_token_with_key(encrypted, &key)
 }
 
+/// Return whether the process has a valid OAuth token encryption key.
+pub(crate) fn token_encryption_key_is_configured() -> bool {
+	key_from_env().is_ok()
+}
+
 pub(crate) fn encrypt_access_token_with_key(
 	access_token: &str,
 	key_bytes: &[u8; KEY_LEN],

--- a/dashboard/src/apps/auth/tests/unit/test_oauth_settings.rs
+++ b/dashboard/src/apps/auth/tests/unit/test_oauth_settings.rs
@@ -2,9 +2,9 @@
 //!
 //! Verifies that a provider is enabled iff all three of its credential env
 //! vars (`CLIENT_ID`, `CLIENT_SECRET`, `REDIRECT_URI`) are present and
-//! non-empty. Partial configuration disables the provider rather than
-//! half-enabling it, so the login UI never offers a button that cannot
-//! complete the flow.
+//! non-empty, and the token encryption key is valid. Partial configuration
+//! disables the provider rather than half-enabling it, so the login UI never
+//! offers a button that cannot complete the flow.
 
 #[cfg(test)]
 mod tests {
@@ -16,6 +16,8 @@ mod tests {
 	const KEY_ID: &str = "REINHARDT_CLOUD_OAUTH_GITHUB_CLIENT_ID";
 	const KEY_SECRET: &str = "REINHARDT_CLOUD_OAUTH_GITHUB_CLIENT_SECRET";
 	const KEY_REDIRECT: &str = "REINHARDT_CLOUD_OAUTH_GITHUB_REDIRECT_URI";
+	const KEY_TOKEN_ENCRYPTION: &str = "REINHARDT_CLOUD_OAUTH_TOKEN_ENCRYPTION_KEY";
+	const VALID_TOKEN_ENCRYPTION_KEY: &str = "AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=";
 
 	/// RAII guard that restores OAuth env vars on drop. Mirrors the pattern
 	/// used by the e2e mailer tests so behavior under `serial` is identical.
@@ -62,6 +64,7 @@ mod tests {
 			(KEY_ID, Some("github-client-id")),
 			(KEY_SECRET, Some("github-client-secret")),
 			(KEY_REDIRECT, Some("https://example.test/cb")),
+			(KEY_TOKEN_ENCRYPTION, Some(VALID_TOKEN_ENCRYPTION_KEY)),
 		]);
 
 		// Act
@@ -85,6 +88,7 @@ mod tests {
 			(KEY_ID, Some("id-only")),
 			(KEY_SECRET, None),
 			(KEY_REDIRECT, Some("https://example.test/cb")),
+			(KEY_TOKEN_ENCRYPTION, Some(VALID_TOKEN_ENCRYPTION_KEY)),
 		]);
 
 		// Act
@@ -103,6 +107,7 @@ mod tests {
 			(KEY_ID, None),
 			(KEY_SECRET, Some("secret-only")),
 			(KEY_REDIRECT, Some("https://example.test/cb")),
+			(KEY_TOKEN_ENCRYPTION, Some(VALID_TOKEN_ENCRYPTION_KEY)),
 		]);
 
 		// Act
@@ -120,6 +125,7 @@ mod tests {
 			(KEY_ID, None),
 			(KEY_SECRET, None),
 			(KEY_REDIRECT, None),
+			(KEY_TOKEN_ENCRYPTION, None),
 		]);
 
 		// Act
@@ -141,6 +147,7 @@ mod tests {
 			(KEY_ID, Some("")),
 			(KEY_SECRET, Some("secret")),
 			(KEY_REDIRECT, Some("https://example.test/cb")),
+			(KEY_TOKEN_ENCRYPTION, Some(VALID_TOKEN_ENCRYPTION_KEY)),
 		]);
 
 		// Act
@@ -148,5 +155,43 @@ mod tests {
 
 		// Assert
 		assert!(settings.github.is_none());
+	}
+
+	#[rstest]
+	#[serial(env_oauth)]
+	fn test_github_disabled_when_token_encryption_key_missing() {
+		// Arrange
+		let _g = EnvGuard::set(vec![
+			(KEY_ID, Some("github-client-id")),
+			(KEY_SECRET, Some("github-client-secret")),
+			(KEY_REDIRECT, Some("https://example.test/cb")),
+			(KEY_TOKEN_ENCRYPTION, None),
+		]);
+
+		// Act
+		let settings = OAuthSettings::from_env();
+
+		// Assert
+		assert!(settings.github.is_none());
+		assert!(settings.enabled_provider_ids().is_empty());
+	}
+
+	#[rstest]
+	#[serial(env_oauth)]
+	fn test_github_disabled_when_token_encryption_key_invalid() {
+		// Arrange
+		let _g = EnvGuard::set(vec![
+			(KEY_ID, Some("github-client-id")),
+			(KEY_SECRET, Some("github-client-secret")),
+			(KEY_REDIRECT, Some("https://example.test/cb")),
+			(KEY_TOKEN_ENCRYPTION, Some("not-base64-32-bytes")),
+		]);
+
+		// Act
+		let settings = OAuthSettings::from_env();
+
+		// Assert
+		assert!(settings.github.is_none());
+		assert!(settings.enabled_provider_ids().is_empty());
 	}
 }

--- a/docs/tools/dashboard.md
+++ b/docs/tools/dashboard.md
@@ -208,9 +208,15 @@ Override at deploy time by mounting a `local.toml` as a `ConfigMap` volume, or b
 
 ### GitHub OAuth
 
-GitHub OAuth is enabled when all required provider settings are present in the runtime environment. The login and registration pages show only configured providers. Existing users can link GitHub from `/account`; the callback attaches the provider identity to the active session user when a valid `sessionid` cookie is present.
+GitHub OAuth is enabled when all required provider settings and the OAuth token encryption key are present in the runtime environment. The login and registration pages show only configured providers. Existing users can link GitHub from `/account`; the callback attaches the provider identity to the active session user when a valid `sessionid` cookie is present.
 
 The dashboard persists GitHub OAuth access tokens only after encrypting them with `REINHARDT_CLOUD_OAUTH_TOKEN_ENCRYPTION_KEY`. Set this variable to a base64-encoded 32-byte key before enabling GitHub OAuth. The stored token is used to verify GitHub App setup callbacks against `/user/installations`; OAuth storage APIs still return tokenless account records to normal authentication callers.
+
+Generate a local development key with:
+
+```bash
+openssl rand -base64 32
+```
 
 Set `REINHARDT_CLOUD_GITHUB_APP_INSTALL_URL` to the GitHub App installation URL shown in GitHub App settings. The GitHub repository page uses it for the empty-state install action after the current user has linked a GitHub OAuth account.
 


### PR DESCRIPTION
## Summary

This PR addresses:

- disables GitHub OAuth when the dashboard cannot encrypt persisted OAuth tokens
- documents the required local development token-encryption key
- covers missing and invalid token-encryption-key configurations in OAuth settings tests

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

GitHub OAuth currently becomes visible when provider credentials are present, even if `REINHARDT_CLOUD_OAUTH_TOKEN_ENCRYPTION_KEY` is missing or invalid. The callback then reaches token persistence and fails with HTTP 500 after the user completes the provider flow. That is the wrong failure boundary: incomplete runtime configuration should suppress the provider before the UI offers a broken login/link action.

Related to: #684, #687

## How Was This Tested?

- `cargo make fmt-check`
- `cargo test -p reinhardt-cloud-dashboard apps::auth::tests::unit::test_oauth_settings --all-features`
- `git diff --check`

## Performance Impact

-

## Breaking Changes

-

**Migration Guide:**

Set `REINHARDT_CLOUD_OAUTH_TOKEN_ENCRYPTION_KEY` to a base64-encoded 32-byte key in any environment that enables GitHub OAuth.

## Screenshots

### Before

-

### After

-

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Related to #684
- Related to #687

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [ ] `kubernetes` - Kubernetes resources, controllers, operators
- [ ] `deployment` - Application deployment logic
- [ ] `networking` - Ingress, services, network policies
- [ ] `storage` - Persistent volumes, storage classes
- [x] `auth` - Authentication, authorization, RBAC
- [ ] `api` - REST API, serializers, handlers
- [ ] `cli` - Command-line interface
- [x] `config` - Configuration management
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The reported local callback failures were consistent with OAuth token persistence failing after successful provider callback handling.

🤖 Generated with [Codex](https://openai.com/codex)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * GitHub OAuth provider now requires both credential environment variables and a valid token encryption key to be enabled.

* **Documentation**
  * Added instructions for generating a local development encryption key for OAuth configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->