### PR TITLE
feat(dashboard): add entity selectors for operations

### DIFF
--- a/dashboard/Cargo.toml
+++ b/dashboard/Cargo.toml
@@ -85,7 +85,7 @@ rstest = { workspace = true }
 reinhardt = { workspace = true, features = ["pages", "admin", "pages-nav-diag-dom"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
-web-sys = { version = "0.3", features = ["Window", "Document", "Element", "HtmlElement", "Event", "History", "Location", "Storage", "WebSocket", "MessageEvent", "ErrorEvent", "CloseEvent"] }
+web-sys = { version = "0.3", features = ["Window", "Document", "Element", "HtmlElement", "HtmlSelectElement", "Event", "History", "Location", "Storage", "WebSocket", "MessageEvent", "ErrorEvent", "CloseEvent"] }
 js-sys = "0.3"
 gloo-timers = "0.3"
 console_error_panic_hook = "0.1"

--- a/dashboard/src/apps/clusters/client/pages/list.rs
+++ b/dashboard/src/apps/clusters/client/pages/list.rs
@@ -13,6 +13,7 @@ use crate::apps::clusters::server_fn::{
 };
 use crate::apps::dashboard::client::layout::dashboard_app_shell;
 use crate::apps::deployments::client::components::cluster_health::cluster_health_container;
+use crate::shared::client::components::entity_select::{EntitySelectOption, entity_select};
 use crate::shared::client::routes::route_href;
 
 fn format_server_error(raw: &str) -> String {
@@ -57,6 +58,24 @@ async fn load_clusters() -> Result<Vec<ClusterInfo>, String> {
 #[cfg(not(wasm))]
 async fn load_clusters() -> Result<Vec<ClusterInfo>, String> {
 	Ok(Vec::new())
+}
+
+fn cluster_select_options(items: &[ClusterInfo]) -> Vec<EntitySelectOption> {
+	items
+		.iter()
+		.map(|cluster| {
+			let state = if cluster.is_active {
+				"active"
+			} else {
+				"inactive"
+			};
+			EntitySelectOption::new(
+				cluster.id.to_string(),
+				cluster.name.clone(),
+				Some(format!("{state} / {}", cluster.api_url)),
+			)
+		})
+		.collect()
 }
 
 /// Render the clusters page.
@@ -135,6 +154,10 @@ pub fn clusters_list_page() -> Page {
 		.reset_on_deps(ResetOnDeps::ResetAll)
 		.build();
 	let edit_state = edit_runtime.form_state();
+	let edit_cluster_id = edit_runtime.watch_field::<String>(edit_form.cluster_id_field());
+	let edit_name = edit_runtime.watch_field::<String>(edit_form.name_field());
+	let edit_api_url = edit_runtime.watch_field::<String>(edit_form.api_url_field());
+	let edit_is_active = edit_runtime.watch_field::<bool>(edit_form.is_active_field());
 	let edit_error = edit_form.error().clone();
 	let edit_view = edit_form.into_page();
 
@@ -145,11 +168,8 @@ pub fn clusters_list_page() -> Page {
 		success_url: |_form| route_href("clusters:list", "/clusters"),
 		class: "rc-form-stack",
 		fields: {
-			cluster_id: CharField {
-				required,
-				label: "Cluster ID",
-				placeholder: "1",
-				class: "rc-input",
+			cluster_id: HiddenField {
+				initial: String::new(),
 			}
 			submit: SubmitButton {
 				label: "Delete cluster",
@@ -159,6 +179,7 @@ pub fn clusters_list_page() -> Page {
 	};
 	let delete_runtime = use_form(&delete_form).build();
 	let delete_state = delete_runtime.form_state();
+	let delete_cluster_id = delete_runtime.watch_field::<String>(delete_form.cluster_id_field());
 	let delete_error = delete_form.error().clone();
 	let delete_view = delete_form.into_page();
 
@@ -169,11 +190,8 @@ pub fn clusters_list_page() -> Page {
 		success_url: |_form| route_href("clusters:list", "/clusters"),
 		class: "rc-form-stack",
 		fields: {
-			cluster_id: CharField {
-				required,
-				label: "Cluster ID",
-				placeholder: "1",
-				class: "rc-input",
+			cluster_id: HiddenField {
+				initial: String::new(),
 			}
 			submit: SubmitButton {
 				label: "Rotate token",
@@ -183,12 +201,17 @@ pub fn clusters_list_page() -> Page {
 	};
 	let rotate_runtime = use_form(&rotate_form).build();
 	let rotate_state = rotate_runtime.form_state();
+	let rotate_cluster_id = rotate_runtime.watch_field::<String>(rotate_form.cluster_id_field());
 	let rotate_error = rotate_form.error().clone();
 	let rotate_view = rotate_form.into_page();
 
 	let health = cluster_health_container();
+	let clusters_for_inventory = clusters.clone();
+	let clusters_for_edit = clusters.clone();
+	let clusters_for_rotate = clusters.clone();
+	let clusters_for_delete = clusters.clone();
 
-	let content = page!(|clusters: reinhardt::pages::prelude::Resource<Vec<ClusterInfo>, String>, create_view: Page, create_error: Signal<Option<String>>, create_submitting: Signal<bool>, edit_view: Page, edit_error: Signal<Option<String>>, edit_dirty: Signal<bool>, edit_submitting: Signal<bool>, delete_view: Page, delete_error: Signal<Option<String>>, delete_submitting: Signal<bool>, rotate_view: Page, rotate_error: Signal<Option<String>>, rotate_submitting: Signal<bool>, health: Page| {
+	let content = page!(|clusters_for_inventory: reinhardt::pages::prelude::Resource<Vec<ClusterInfo>, String>, clusters_for_edit: reinhardt::pages::prelude::Resource<Vec<ClusterInfo>, String>, clusters_for_rotate: reinhardt::pages::prelude::Resource<Vec<ClusterInfo>, String>, clusters_for_delete: reinhardt::pages::prelude::Resource<Vec<ClusterInfo>, String>, create_view: Page, create_error: Signal<Option<String>>, create_submitting: Signal<bool>, edit_view: Page, edit_error: Signal<Option<String>>, edit_dirty: Signal<bool>, edit_submitting: Signal<bool>, edit_cluster_id: Signal<String>, edit_name: Signal<String>, edit_api_url: Signal<String>, edit_is_active: Signal<bool>, delete_view: Page, delete_error: Signal<Option<String>>, delete_submitting: Signal<bool>, delete_cluster_id: Signal<String>, rotate_view: Page, rotate_error: Signal<Option<String>>, rotate_submitting: Signal<bool>, rotate_cluster_id: Signal<String>, health: Page| {
 		div {
 			class: "rc-shell",
 			div {
@@ -221,7 +244,7 @@ pub fn clusters_list_page() -> Page {
 								"Cluster Inventory"
 							}
 							{
-								match clusters.get() {
+								match clusters_for_inventory.get() {
 									ResourceState::Loading => page!(|| {
 										div {
 											class: "rc-empty",
@@ -362,6 +385,37 @@ pub fn clusters_list_page() -> Page {
 							{
 								self::alert(edit_error.clone())
 							}
+							{
+								match clusters_for_edit.get() {
+									ResourceState::Success(items) => {
+										let clusters_for_change = items.clone();
+										let name_signal = edit_name.clone();
+										let api_url_signal = edit_api_url.clone();
+										let is_active_signal = edit_is_active.clone();
+										self::entity_select("Cluster", "Select cluster", self::cluster_select_options(&items), edit_cluster_id.clone(), move |value| {
+											if let Some(cluster) = clusters_for_change.iter().find(|cluster| cluster.id.to_string() == value) {
+												name_signal.set(cluster.name.clone());
+												api_url_signal.set(cluster.api_url.clone());
+												is_active_signal.set(cluster.is_active);
+											}
+										}, )
+									}
+									ResourceState::Loading => page!(|| {
+										p {
+											class: "mb-3 text-xs text-ink-600",
+											"Loading clusters..."
+										}
+									})(),
+									ResourceState::Error(message) => page!(|message: String| {
+										p {
+											class: "mb-3 text-xs font-medium text-red-700",
+											{
+												self::format_server_error(&message)
+											}
+										}
+									})(message),
+								}
+							}
 							{ edit_view }
 							{
 								if edit_dirty.get() {
@@ -389,6 +443,25 @@ pub fn clusters_list_page() -> Page {
 							{
 								self::alert(rotate_error.clone())
 							}
+							{
+								match clusters_for_rotate.get() {
+									ResourceState::Success(items) => self::entity_select("Cluster", "Select cluster", self::cluster_select_options(&items), rotate_cluster_id.clone(), |_value| {}, ),
+									ResourceState::Loading => page!(|| {
+										p {
+											class: "mb-3 text-xs text-ink-600",
+											"Loading clusters..."
+										}
+									})(),
+									ResourceState::Error(message) => page!(|message: String| {
+										p {
+											class: "mb-3 text-xs font-medium text-red-700",
+											{
+												self::format_server_error(&message)
+											}
+										}
+									})(message),
+								}
+							}
 							{ rotate_view }
 							{
 								if rotate_submitting.get() {
@@ -405,6 +478,25 @@ pub fn clusters_list_page() -> Page {
 							}
 							{
 								self::alert(delete_error.clone())
+							}
+							{
+								match clusters_for_delete.get() {
+									ResourceState::Success(items) => self::entity_select("Cluster", "Select cluster", self::cluster_select_options(&items), delete_cluster_id.clone(), |_value| {}, ),
+									ResourceState::Loading => page!(|| {
+										p {
+											class: "mb-3 text-xs text-ink-600",
+											"Loading clusters..."
+										}
+									})(),
+									ResourceState::Error(message) => page!(|message: String| {
+										p {
+											class: "mb-3 text-xs font-medium text-red-700",
+											{
+												self::format_server_error(&message)
+											}
+										}
+									})(message),
+								}
 							}
 							{ delete_view }
 							{
@@ -423,7 +515,10 @@ pub fn clusters_list_page() -> Page {
 			}
 		}
 	})(
-		clusters,
+		clusters_for_inventory,
+		clusters_for_edit,
+		clusters_for_rotate,
+		clusters_for_delete,
 		create_view,
 		create_error,
 		create_state.is_submitting,
@@ -431,12 +526,18 @@ pub fn clusters_list_page() -> Page {
 		edit_error,
 		edit_state.is_dirty,
 		edit_state.is_submitting,
+		edit_cluster_id,
+		edit_name,
+		edit_api_url,
+		edit_is_active,
 		delete_view,
 		delete_error,
 		delete_state.is_submitting,
+		delete_cluster_id,
 		rotate_view,
 		rotate_error,
 		rotate_state.is_submitting,
+		rotate_cluster_id,
 		health,
 	);
 	dashboard_app_shell("clusters", content)

--- a/dashboard/src/apps/deployments/client/pages/list.rs
+++ b/dashboard/src/apps/deployments/client/pages/list.rs
@@ -5,6 +5,9 @@ use reinhardt::pages::form;
 use reinhardt::pages::page;
 use reinhardt::pages::prelude::{ResetOnDeps, ResourceState, Signal, use_form, use_resource};
 
+use crate::apps::clusters::server_fn::ClusterInfo;
+#[cfg(wasm)]
+use crate::apps::clusters::server_fn::list_clusters_for_current_org;
 use crate::apps::dashboard::client::layout::dashboard_app_shell;
 use crate::apps::deployments::client::components::log_viewer::log_viewer_container;
 #[cfg(wasm)]
@@ -13,6 +16,7 @@ use crate::apps::deployments::server_fn::{
 	DeploymentInfo, create_deployment_for_current_org, delete_deployment_for_current_org,
 	update_deployment_for_current_org, update_deployment_status_for_current_org,
 };
+use crate::shared::client::components::entity_select::{EntitySelectOption, entity_select};
 use crate::shared::client::components::status_badge;
 use crate::shared::client::routes::route_href;
 use crate::shared::ws_messages::DeploymentState;
@@ -83,9 +87,48 @@ async fn load_deployments() -> Result<Vec<DeploymentInfo>, String> {
 	Ok(Vec::new())
 }
 
+#[cfg(wasm)]
+async fn load_clusters() -> Result<Vec<ClusterInfo>, String> {
+	list_clusters_for_current_org()
+		.await
+		.map_err(|e| e.to_string())
+}
+
+#[cfg(not(wasm))]
+async fn load_clusters() -> Result<Vec<ClusterInfo>, String> {
+	Ok(Vec::new())
+}
+
+fn cluster_select_options(items: &[ClusterInfo]) -> Vec<EntitySelectOption> {
+	items
+		.iter()
+		.map(|cluster| {
+			EntitySelectOption::new(
+				cluster.id.to_string(),
+				cluster.name.clone(),
+				Some(cluster.api_url.clone()),
+			)
+		})
+		.collect()
+}
+
+fn deployment_select_options(items: &[DeploymentInfo]) -> Vec<EntitySelectOption> {
+	items
+		.iter()
+		.map(|deployment| {
+			EntitySelectOption::new(
+				deployment.id.to_string(),
+				deployment.app_name.clone(),
+				Some(format!("{} / {}", deployment.status, deployment.image)),
+			)
+		})
+		.collect()
+}
+
 /// Render the deployments page.
 pub fn deployments_list_page() -> Page {
 	let deployments = use_resource(|| async move { self::load_deployments().await }, ());
+	let clusters = use_resource(|| async move { self::load_clusters().await }, ());
 
 	let create_form = form! {
 		name: CreateDeploymentForm,
@@ -101,11 +144,8 @@ pub fn deployments_list_page() -> Page {
 				placeholder: "web",
 				class: "rc-input",
 			}
-			cluster_id: CharField {
-				required,
-				label: "Cluster ID",
-				placeholder: "1",
-				class: "rc-input",
+			cluster_id: HiddenField {
+				initial: String::new(),
 			}
 			image: CharField {
 				required,
@@ -128,6 +168,7 @@ pub fn deployments_list_page() -> Page {
 	};
 	let create_runtime = use_form(&create_form).build();
 	let create_state = create_runtime.form_state();
+	let create_cluster_id = create_runtime.watch_field::<String>(create_form.cluster_id_field());
 	let create_error = create_form.error().clone();
 	let create_view = create_form.into_page();
 
@@ -138,11 +179,8 @@ pub fn deployments_list_page() -> Page {
 		success_url: |_form| route_href("deployments:list", "/deployments"),
 		class: "rc-form-stack",
 		fields: {
-			deployment_id: CharField {
-				required,
-				label: "Deployment ID",
-				placeholder: "1",
-				class: "rc-input",
+			deployment_id: HiddenField {
+				initial: String::new(),
 			}
 			app_name: CharField {
 				required,
@@ -176,6 +214,10 @@ pub fn deployments_list_page() -> Page {
 		.reset_on_deps(ResetOnDeps::ResetAll)
 		.build();
 	let edit_state = edit_runtime.form_state();
+	let edit_deployment_id = edit_runtime.watch_field::<String>(edit_form.deployment_id_field());
+	let edit_app_name = edit_runtime.watch_field::<String>(edit_form.app_name_field());
+	let edit_image = edit_runtime.watch_field::<String>(edit_form.image_field());
+	let edit_status = edit_runtime.watch_field::<String>(edit_form.status_field());
 	let edit_error = edit_form.error().clone();
 	let edit_view = edit_form.into_page();
 
@@ -186,11 +228,8 @@ pub fn deployments_list_page() -> Page {
 		success_url: |_form| route_href("deployments:list", "/deployments"),
 		class: "rc-form-stack",
 		fields: {
-			deployment_id: CharField {
-				required,
-				label: "Deployment ID",
-				placeholder: "1",
-				class: "rc-input",
+			deployment_id: HiddenField {
+				initial: String::new(),
 			}
 			status: CharField {
 				required,
@@ -207,6 +246,8 @@ pub fn deployments_list_page() -> Page {
 	};
 	let status_runtime = use_form(&status_form).build();
 	let status_state = status_runtime.form_state();
+	let status_deployment_id =
+		status_runtime.watch_field::<String>(status_form.deployment_id_field());
 	let status_error = status_form.error().clone();
 	let status_view = status_form.into_page();
 
@@ -217,11 +258,8 @@ pub fn deployments_list_page() -> Page {
 		success_url: |_form| route_href("deployments:list", "/deployments"),
 		class: "rc-form-stack",
 		fields: {
-			deployment_id: CharField {
-				required,
-				label: "Deployment ID",
-				placeholder: "1",
-				class: "rc-input",
+			deployment_id: HiddenField {
+				initial: String::new(),
 			}
 			submit: SubmitButton {
 				label: "Delete deployment",
@@ -231,12 +269,19 @@ pub fn deployments_list_page() -> Page {
 	};
 	let delete_runtime = use_form(&delete_form).build();
 	let delete_state = delete_runtime.form_state();
+	let delete_deployment_id =
+		delete_runtime.watch_field::<String>(delete_form.deployment_id_field());
 	let delete_error = delete_form.error().clone();
 	let delete_view = delete_form.into_page();
 
 	let logs = log_viewer_container();
+	let deployments_for_inventory = deployments.clone();
+	let deployments_for_edit = deployments.clone();
+	let deployments_for_status = deployments.clone();
+	let deployments_for_delete = deployments.clone();
+	let clusters_for_create = clusters.clone();
 
-	let content = page!(|deployments: reinhardt::pages::prelude::Resource<Vec<DeploymentInfo>, String>, create_view: Page, create_error: Signal<Option<String>>, create_submitting: Signal<bool>, edit_view: Page, edit_error: Signal<Option<String>>, edit_dirty: Signal<bool>, edit_submitting: Signal<bool>, status_view: Page, status_error: Signal<Option<String>>, status_submitting: Signal<bool>, delete_view: Page, delete_error: Signal<Option<String>>, delete_submitting: Signal<bool>, logs: Page| {
+	let content = page!(|deployments_for_inventory: reinhardt::pages::prelude::Resource<Vec<DeploymentInfo>, String>, deployments_for_edit: reinhardt::pages::prelude::Resource<Vec<DeploymentInfo>, String>, deployments_for_status: reinhardt::pages::prelude::Resource<Vec<DeploymentInfo>, String>, deployments_for_delete: reinhardt::pages::prelude::Resource<Vec<DeploymentInfo>, String>, clusters_for_create: reinhardt::pages::prelude::Resource<Vec<ClusterInfo>, String>, create_view: Page, create_error: Signal<Option<String>>, create_submitting: Signal<bool>, create_cluster_id: Signal<String>, edit_view: Page, edit_error: Signal<Option<String>>, edit_dirty: Signal<bool>, edit_submitting: Signal<bool>, edit_deployment_id: Signal<String>, edit_app_name: Signal<String>, edit_image: Signal<String>, edit_status: Signal<String>, status_view: Page, status_error: Signal<Option<String>>, status_submitting: Signal<bool>, status_deployment_id: Signal<String>, delete_view: Page, delete_error: Signal<Option<String>>, delete_submitting: Signal<bool>, delete_deployment_id: Signal<String>, logs: Page| {
 		div {
 			class: "rc-shell",
 			div {
@@ -269,7 +314,7 @@ pub fn deployments_list_page() -> Page {
 								"Deployment Inventory"
 							}
 							{
-								match deployments.get() {
+								match deployments_for_inventory.get() {
 									ResourceState::Loading => page!(|| {
 										div {
 											class: "rc-empty",
@@ -385,6 +430,25 @@ pub fn deployments_list_page() -> Page {
 							{
 								self::alert(create_error.clone())
 							}
+							{
+								match clusters_for_create.get() {
+									ResourceState::Success(items) => self::entity_select("Cluster", "Select target cluster", self::cluster_select_options(&items), create_cluster_id.clone(), |_value| {}, ),
+									ResourceState::Loading => page!(|| {
+										p {
+											class: "mb-3 text-xs text-ink-600",
+											"Loading clusters..."
+										}
+									})(),
+									ResourceState::Error(message) => page!(|message: String| {
+										p {
+											class: "mb-3 text-xs font-medium text-red-700",
+											{
+												self::format_server_error(&message)
+											}
+										}
+									})(message),
+								}
+							}
 							{ create_view }
 							{
 								if create_submitting.get() {
@@ -417,6 +481,37 @@ pub fn deployments_list_page() -> Page {
 							{
 								self::alert(edit_error.clone())
 							}
+							{
+								match deployments_for_edit.get() {
+									ResourceState::Success(items) => {
+										let deployments_for_change = items.clone();
+										let app_name_signal = edit_app_name.clone();
+										let image_signal = edit_image.clone();
+										let status_signal = edit_status.clone();
+										self::entity_select("Deployment", "Select deployment", self::deployment_select_options(&items), edit_deployment_id.clone(), move |value| {
+											if let Some(deployment) = deployments_for_change.iter().find(|deployment| deployment.id.to_string() == value) {
+												app_name_signal.set(deployment.app_name.clone());
+												image_signal.set(deployment.image.clone());
+												status_signal.set(deployment.status.clone());
+											}
+										}, )
+									}
+									ResourceState::Loading => page!(|| {
+										p {
+											class: "mb-3 text-xs text-ink-600",
+											"Loading deployments..."
+										}
+									})(),
+									ResourceState::Error(message) => page!(|message: String| {
+										p {
+											class: "mb-3 text-xs font-medium text-red-700",
+											{
+												self::format_server_error(&message)
+											}
+										}
+									})(message),
+								}
+							}
 							{ edit_view }
 							{
 								if edit_dirty.get() {
@@ -444,6 +539,25 @@ pub fn deployments_list_page() -> Page {
 							{
 								self::alert(status_error.clone())
 							}
+							{
+								match deployments_for_status.get() {
+									ResourceState::Success(items) => self::entity_select("Deployment", "Select deployment", self::deployment_select_options(&items), status_deployment_id.clone(), |_value| {}, ),
+									ResourceState::Loading => page!(|| {
+										p {
+											class: "mb-3 text-xs text-ink-600",
+											"Loading deployments..."
+										}
+									})(),
+									ResourceState::Error(message) => page!(|message: String| {
+										p {
+											class: "mb-3 text-xs font-medium text-red-700",
+											{
+												self::format_server_error(&message)
+											}
+										}
+									})(message),
+								}
+							}
 							{ status_view }
 							{
 								if status_submitting.get() {
@@ -460,6 +574,25 @@ pub fn deployments_list_page() -> Page {
 							}
 							{
 								self::alert(delete_error.clone())
+							}
+							{
+								match deployments_for_delete.get() {
+									ResourceState::Success(items) => self::entity_select("Deployment", "Select deployment", self::deployment_select_options(&items), delete_deployment_id.clone(), |_value| {}, ),
+									ResourceState::Loading => page!(|| {
+										p {
+											class: "mb-3 text-xs text-ink-600",
+											"Loading deployments..."
+										}
+									})(),
+									ResourceState::Error(message) => page!(|message: String| {
+										p {
+											class: "mb-3 text-xs font-medium text-red-700",
+											{
+												self::format_server_error(&message)
+											}
+										}
+									})(message),
+								}
 							}
 							{ delete_view }
 							{
@@ -478,20 +611,31 @@ pub fn deployments_list_page() -> Page {
 			}
 		}
 	})(
-		deployments,
+		deployments_for_inventory,
+		deployments_for_edit,
+		deployments_for_status,
+		deployments_for_delete,
+		clusters_for_create,
 		create_view,
 		create_error,
 		create_state.is_submitting,
+		create_cluster_id,
 		edit_view,
 		edit_error,
 		edit_state.is_dirty,
 		edit_state.is_submitting,
+		edit_deployment_id,
+		edit_app_name,
+		edit_image,
+		edit_status,
 		status_view,
 		status_error,
 		status_state.is_submitting,
+		status_deployment_id,
 		delete_view,
 		delete_error,
 		delete_state.is_submitting,
+		delete_deployment_id,
 		logs,
 	);
 	dashboard_app_shell("deployments", content)

--- a/dashboard/src/apps/github/client/pages/list.rs
+++ b/dashboard/src/apps/github/client/pages/list.rs
@@ -1,6 +1,6 @@
 //! GitHub repository import page.
 
-use reinhardt::pages::component::{IntoPage, Page, PageElement};
+use reinhardt::pages::component::Page;
 use reinhardt::pages::form;
 use reinhardt::pages::page;
 use reinhardt::pages::prelude::{ResourceState, Signal, use_form, use_resource};
@@ -16,6 +16,7 @@ use crate::apps::github::server_fn::{
 use crate::apps::github::server_fn::{
 	get_github_onboarding_for_current_org, list_github_repositories_for_current_org,
 };
+use crate::shared::client::components::entity_select::{EntitySelectOption, entity_select};
 use crate::shared::client::routes::route_href;
 
 fn format_server_error(raw: &str) -> String {
@@ -89,6 +90,37 @@ async fn load_clusters() -> Result<Vec<ClusterInfo>, String> {
 	Ok(Vec::new())
 }
 
+fn repository_select_options(items: &[GitHubRepositoryInfo]) -> Vec<EntitySelectOption> {
+	items
+		.iter()
+		.map(|repository| {
+			let visibility = if repository.private {
+				"private"
+			} else {
+				"public"
+			};
+			EntitySelectOption::new(
+				repository.id.to_string(),
+				repository.full_name.clone(),
+				Some(format!("{visibility} / {}", repository.default_branch)),
+			)
+		})
+		.collect()
+}
+
+fn cluster_select_options(items: &[ClusterInfo]) -> Vec<EntitySelectOption> {
+	items
+		.iter()
+		.map(|cluster| {
+			EntitySelectOption::new(
+				cluster.id.to_string(),
+				cluster.name.clone(),
+				Some(cluster.api_url.clone()),
+			)
+		})
+		.collect()
+}
+
 /// Render the GitHub repository import page.
 pub fn github_repositories_page() -> Page {
 	let repositories = use_resource(|| async move { self::load_repositories().await }, ());
@@ -102,17 +134,11 @@ pub fn github_repositories_page() -> Page {
 		success_url: |_form| route_href("github:repositories", "/github"),
 		class: "rc-form-grid",
 		fields: {
-			repository_id: CharField {
-				required,
-				label: "Repository ID",
-				placeholder: "1",
-				class: "rc-input",
+			repository_id: HiddenField {
+				initial: String::new(),
 			}
-			cluster_id: CharField {
-				required,
-				label: "Cluster ID",
-				placeholder: "1",
-				class: "rc-input",
+			cluster_id: HiddenField {
+				initial: String::new(),
 			}
 			app_name: CharField {
 				max_length: 63,
@@ -141,8 +167,12 @@ pub fn github_repositories_page() -> Page {
 	let import_app_name = import_runtime.watch_field::<String>(import_form.app_name_field());
 	let import_error = import_form.error().clone();
 	let import_view = import_form.into_page();
+	let repositories_for_inventory = repositories.clone();
+	let repositories_for_import = repositories.clone();
+	let clusters_for_import = clusters.clone();
+	let clusters_for_inventory = clusters.clone();
 
-	let content = page!(|repositories: reinhardt::pages::prelude::Resource<Vec<GitHubRepositoryInfo>, String>, onboarding: reinhardt::pages::prelude::Resource<GitHubOnboardingInfo, String>, clusters: reinhardt::pages::prelude::Resource<Vec<ClusterInfo>, String>, import_view: Page, import_error: Signal<Option<String>>, import_submitting: Signal<bool>, import_repository_id: Signal<String>, import_cluster_id: Signal<String>, import_app_name: Signal<String>| {
+	let content = page!(|repositories_for_inventory: reinhardt::pages::prelude::Resource<Vec<GitHubRepositoryInfo>, String>, repositories_for_import: reinhardt::pages::prelude::Resource<Vec<GitHubRepositoryInfo>, String>, onboarding: reinhardt::pages::prelude::Resource<GitHubOnboardingInfo, String>, clusters_for_import: reinhardt::pages::prelude::Resource<Vec<ClusterInfo>, String>, clusters_for_inventory: reinhardt::pages::prelude::Resource<Vec<ClusterInfo>, String>, import_view: Page, import_error: Signal<Option<String>>, import_submitting: Signal<bool>, import_repository_id: Signal<String>, import_cluster_id: Signal<String>, import_app_name: Signal<String>| {
 		div {
 			class: "rc-shell",
 			div {
@@ -194,21 +224,17 @@ pub fn github_repositories_page() -> Page {
 											class: "px-3 py-2 text-left font-semibold text-cloud-600",
 											"State"
 										}
-										th {
-											class: "px-3 py-2 text-left font-semibold text-cloud-600",
-											""
-										}
 									}
 								}
 								tbody {
 									class: "divide-y divide-cloud-100",
 									{
-										match repositories.get() {
+										match repositories_for_inventory.get() {
 											ResourceState::Loading => page!(|| {
 												tr {
 													td {
 														class: "px-3 py-3 text-cloud-500",
-														colspan: 5,
+														colspan: 4,
 														"Loading repositories..."
 													}
 												}
@@ -217,7 +243,7 @@ pub fn github_repositories_page() -> Page {
 												tr {
 													td {
 														class: "px-3 py-3 text-red-700",
-														colspan: 5,
+														colspan: 4,
 														{
 															self::format_server_error(&err)
 														}
@@ -228,7 +254,7 @@ pub fn github_repositories_page() -> Page {
 												tr {
 													td {
 														class: "px-3 py-4 text-cloud-500",
-														colspan: 5,
+														colspan: 4,
 														{
 															match onboarding.get() {
 																ResourceState::Success(info)if !info.github_account_linked => page!(|| {
@@ -265,9 +291,9 @@ pub fn github_repositories_page() -> Page {
 													}
 												}
 											})(onboarding.clone()),
-											ResourceState::Success(items) => page!(|items: Vec<GitHubRepositoryInfo>, import_repository_id: Signal<String>, import_app_name: Signal<String>| { {
+											ResourceState::Success(items) => page!(|items: Vec<GitHubRepositoryInfo>| { {
 												items.clone().into_iter().map(|repo| {
-													page!(|repo: GitHubRepositoryInfo, import_repository_id: Signal<String>, import_app_name: Signal<String>| {
+													page!(|repo: GitHubRepositoryInfo| {
 														tr {
 															td {
 																class: "px-3 py-2 font-mono text-xs text-cloud-500",
@@ -305,23 +331,10 @@ pub fn github_repositories_page() -> Page {
 																	}
 																}
 															}
-															td {
-																class: "px-3 py-2 text-right",
-																{
-																	let repository_id_signal = import_repository_id.clone();
-																	let app_name_signal = import_app_name.clone();
-																	let repo_id = repo.id.to_string();
-																	let app_name = repo.name.clone();
-																	PageElement::new("button").attr("type", "button").attr("class", "btn-secondary text-xs").listener("click", move |_event| {
-																		repository_id_signal.set(repo_id.clone());
-																		app_name_signal.set(app_name.clone());
-																	}).child("Select").into_page()
-																}
-															}
 														}
-													})(repo, import_repository_id.clone(), import_app_name.clone())
+													})(repo)
 												}).collect::<Vec<_>>()
-											} })(items, import_repository_id.clone(), import_app_name.clone()),
+											} })(items),
 										}
 									}
 								}
@@ -338,6 +351,52 @@ pub fn github_repositories_page() -> Page {
 							}
 							{
 								self::alert(import_error.clone())
+							}
+							{
+								match repositories_for_import.get() {
+									ResourceState::Success(items) => {
+										let repositories_for_change = items.clone();
+										let app_name_signal = import_app_name.clone();
+										self::entity_select("Repository", "Select repository", self::repository_select_options(&items), import_repository_id.clone(), move |value| {
+											if let Some(repository) = repositories_for_change.iter().find(|repository| repository.id.to_string() == value) {
+												app_name_signal.set(repository.name.clone());
+											}
+										}, )
+									}
+									ResourceState::Loading => page!(|| {
+										p {
+											class: "mb-3 text-xs text-cloud-500",
+											"Loading repositories..."
+										}
+									})(),
+									ResourceState::Error(err) => page!(|err: String| {
+										p {
+											class: "mb-3 text-xs font-medium text-red-700",
+											{
+												self::format_server_error(&err)
+											}
+										}
+									})(err),
+								}
+							}
+							{
+								match clusters_for_import.get() {
+									ResourceState::Success(items) => self::entity_select("Cluster", "Select target cluster", self::cluster_select_options(&items), import_cluster_id.clone(), |_value| {}, ),
+									ResourceState::Loading => page!(|| {
+										p {
+											class: "mb-3 text-xs text-cloud-500",
+											"Loading clusters..."
+										}
+									})(),
+									ResourceState::Error(err) => page!(|err: String| {
+										p {
+											class: "mb-3 text-xs font-medium text-red-700",
+											{
+												self::format_server_error(&err)
+											}
+										}
+									})(err),
+								}
 							}
 							{
 								import_view.clone()
@@ -358,7 +417,7 @@ pub fn github_repositories_page() -> Page {
 							div {
 								class: "space-y-2 text-sm",
 								{
-									match clusters.get() {
+									match clusters_for_inventory.get() {
 										ResourceState::Loading => page!(|| {
 											p {
 												class: "text-cloud-500",
@@ -379,9 +438,9 @@ pub fn github_repositories_page() -> Page {
 												"No active clusters."
 											}
 										})(),
-										ResourceState::Success(items) => page!(|items: Vec<ClusterInfo>, import_cluster_id: Signal<String>| { {
+										ResourceState::Success(items) => page!(|items: Vec<ClusterInfo>| { {
 											items.clone().into_iter().map(|cluster| {
-												page!(|cluster: ClusterInfo, import_cluster_id: Signal<String>| {
+												page!(|cluster: ClusterInfo| {
 													div {
 														class: "rounded border border-cloud-200 px-3 py-2",
 														div {
@@ -396,20 +455,10 @@ pub fn github_repositories_page() -> Page {
 																format!("id {}", cluster.id)
 															}
 														}
-														div {
-															class: "mt-2",
-															{
-																let cluster_id_signal = import_cluster_id.clone();
-																let cluster_id = cluster.id.to_string();
-																PageElement::new("button").attr("type", "button").attr("class", "btn-secondary text-xs").listener("click", move |_event| {
-																	cluster_id_signal.set(cluster_id.clone());
-																}).child("Select").into_page()
-															}
-														}
 													}
-												})(cluster, import_cluster_id.clone())
+												})(cluster)
 											}).collect::<Vec<_>>()
-										} })(items, import_cluster_id.clone()),
+										} })(items),
 									}
 								}
 							}
@@ -419,9 +468,11 @@ pub fn github_repositories_page() -> Page {
 			}
 		}
 	})(
-		repositories,
+		repositories_for_inventory,
+		repositories_for_import,
 		onboarding,
-		clusters,
+		clusters_for_import,
+		clusters_for_inventory,
 		import_view,
 		import_error,
 		import_state.is_submitting,

--- a/dashboard/src/shared/client/components.rs
+++ b/dashboard/src/shared/client/components.rs
@@ -1,5 +1,6 @@
 //! Cross-app client-side UI components for the dashboard SPA.
 
+pub mod entity_select;
 pub mod logout;
 pub mod status_badge;
 pub mod toast;

--- a/dashboard/src/shared/client/components/entity_select.rs
+++ b/dashboard/src/shared/client/components/entity_select.rs
@@ -1,0 +1,138 @@
+//! Shared entity selection controls for dashboard forms.
+
+use reinhardt::pages::component::{IntoPage, Page, PageElement};
+use reinhardt::pages::page;
+use reinhardt::pages::prelude::Signal;
+
+/// Display option for selecting a persisted dashboard entity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EntitySelectOption {
+	pub value: String,
+	pub label: String,
+	pub detail: Option<String>,
+}
+
+impl EntitySelectOption {
+	/// Build an option with an optional detail line.
+	pub fn new(value: impl Into<String>, label: impl Into<String>, detail: Option<String>) -> Self {
+		Self {
+			value: value.into(),
+			label: label.into(),
+			detail,
+		}
+	}
+
+	fn display_label(&self) -> String {
+		match &self.detail {
+			Some(detail) if !detail.is_empty() => format!("{} - {}", self.label, detail),
+			_ => self.label.clone(),
+		}
+	}
+}
+
+#[cfg(wasm)]
+fn select_change_handler<F>(
+	selected_value: Signal<String>,
+	on_change: F,
+) -> impl Fn(web_sys::Event) + 'static
+where
+	F: Fn(String) + 'static,
+{
+	use wasm_bindgen::JsCast;
+
+	move |event| {
+		let Some(target) = event.target() else {
+			return;
+		};
+		let Ok(select) = target.dyn_into::<web_sys::HtmlSelectElement>() else {
+			return;
+		};
+		let value = select.value();
+		selected_value.set(value.clone());
+		on_change(value);
+	}
+}
+
+#[cfg(native)]
+fn select_change_handler<F>(
+	_selected_value: Signal<String>,
+	_on_change: F,
+) -> impl Fn(reinhardt::pages::component::DummyEvent) + 'static
+where
+	F: Fn(String) + 'static,
+{
+	|_event| {}
+}
+
+/// Render a labeled select that writes the selected entity ID into a form signal.
+pub fn entity_select<F>(
+	label: &str,
+	placeholder: &str,
+	options: Vec<EntitySelectOption>,
+	selected_value: Signal<String>,
+	on_change: F,
+) -> Page
+where
+	F: Fn(String) + 'static,
+{
+	let current_value = selected_value.get();
+	let is_empty = options.is_empty();
+	let placeholder_option = PageElement::new("option")
+		.attr("value", "")
+		.bool_attr("selected", current_value.is_empty())
+		.bool_attr("disabled", !current_value.is_empty())
+		.child(if is_empty {
+			"No options available".to_string()
+		} else {
+			placeholder.to_string()
+		})
+		.into_page();
+	let option_pages = options
+		.into_iter()
+		.map(|option| {
+			PageElement::new("option")
+				.attr("value", option.value.clone())
+				.bool_attr("selected", option.value == current_value)
+				.child(option.display_label())
+				.into_page()
+		})
+		.collect::<Vec<_>>();
+	let select = PageElement::new("select")
+		.attr("class", "rc-input")
+		.bool_attr("disabled", is_empty)
+		.listener("change", select_change_handler(selected_value, on_change))
+		.child(placeholder_option)
+		.children(option_pages)
+		.into_page();
+
+	page!(|label: String, select: Page| {
+		div {
+			label { { label } }
+			{ select }
+		}
+	})(label.to_string(), select)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use rstest::rstest;
+
+	#[rstest]
+	#[case(None, "api", "api")]
+	#[case(Some("active".to_string()), "api", "api - active")]
+	fn test_entity_select_option_display_label(
+		#[case] detail: Option<String>,
+		#[case] label: &str,
+		#[case] expected: &str,
+	) {
+		// Arrange
+		let option = EntitySelectOption::new("1", label, detail);
+
+		// Act
+		let actual = option.display_label();
+
+		// Assert
+		assert_eq!(actual, expected);
+	}
+}

--- a/docs/tools/dashboard.md
+++ b/docs/tools/dashboard.md
@@ -87,6 +87,8 @@ The **Deployments** section (`/deployments/`) presents the PaaS-side records tha
 
 The **Clusters** section (`/clusters/`) shows registered Kubernetes clusters (cluster-management records stored in the Dashboard's own database, not the operator's CRD list).
 
+Dashboard operation forms use inventory-backed selectors for cluster, repository, and deployment targets. Operators choose records by recognizable names and metadata; the form posts the corresponding persisted ID internally.
+
 > **For App Developers**: after running `reinhardt-cloud deploy`, navigate to `/deployments/` and locate your application by name. The record should appear within seconds. Cross-check the `Ready` condition by also running `reinhardt-cloud status --name <app>` from the terminal.
 
 > **For Platform Operators**: use the `/api/admin/` panel to list all deployments across all users. The `DeploymentAdmin` registered in `dashboard/src/config/admin.rs` exposes the full deployment table. Filter by cluster or by creation date to identify stale or failing entries.


### PR DESCRIPTION
## Summary

This PR addresses:

- Replaces raw deployment, cluster, and repository ID entry in Dashboard operation forms with inventory-backed selectors.
- Adds a reusable shared entity select component that writes selected persisted IDs into the existing form signals.
- Updates Dashboard docs to describe selector-based operation forms.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

Dashboard users should not have to copy internal IDs from inventory tables into operation forms. The forms now expose recognizable labels and metadata while preserving the existing server function ID contract internally.

Related to: N/A

## How Was This Tested?

- `cargo check -p reinhardt-cloud-dashboard`
- `cd dashboard && cargo make fmt-check`
- `cd dashboard && cargo make wasm-compile-dev`
- `cargo test -p reinhardt-cloud-dashboard entity_select`
- `cd dashboard && cargo make clippy-check`

## Performance Impact

N/A. This is a small client-side UI ergonomics change.

## Breaking Changes

N/A. Backend APIs, database schema, and server authorization behavior are unchanged.

## Screenshots

### Before

N/A. Existing forms exposed raw ID text inputs.

### After

N/A. Local authenticated browser screenshot was not captured in this run; compile, WASM, unit, and clippy gates passed.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- N/A

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [x] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [ ] `kubernetes` - Kubernetes resources, controllers, operators
- [x] `deployment` - Application deployment logic
- [ ] `networking` - Ingress, services, network policies
- [ ] `storage` - Persistent volumes, storage classes
- [ ] `auth` - Authentication, authorization, RBAC
- [ ] `api` - REST API, serializers, handlers
- [ ] `cli` - Command-line interface
- [x] `config` - Configuration management
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [x] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

- The reusable component keeps `HtmlSelectElement` access behind `cfg(wasm)` so native dashboard builds remain valid.

Generated with Codex.
