### PR TITLE
refactor(dashboard): import Resource in page closures

### DIFF
--- a/dashboard/src/apps/clusters/client/pages/list.rs
+++ b/dashboard/src/apps/clusters/client/pages/list.rs
@@ -3,7 +3,9 @@
 use reinhardt::pages::component::Page;
 use reinhardt::pages::form;
 use reinhardt::pages::page;
-use reinhardt::pages::prelude::{ResetOnDeps, ResourceState, Signal, use_form, use_resource};
+use reinhardt::pages::prelude::{
+	ResetOnDeps, Resource, ResourceState, Signal, use_form, use_resource,
+};
 
 #[cfg(wasm)]
 use crate::apps::clusters::server_fn::list_clusters_for_current_org;
@@ -211,7 +213,7 @@ pub fn clusters_list_page() -> Page {
 	let clusters_for_rotate = clusters.clone();
 	let clusters_for_delete = clusters.clone();
 
-	let content = page!(|clusters_for_inventory: reinhardt::pages::prelude::Resource<Vec<ClusterInfo>, String>, clusters_for_edit: reinhardt::pages::prelude::Resource<Vec<ClusterInfo>, String>, clusters_for_rotate: reinhardt::pages::prelude::Resource<Vec<ClusterInfo>, String>, clusters_for_delete: reinhardt::pages::prelude::Resource<Vec<ClusterInfo>, String>, create_view: Page, create_error: Signal<Option<String>>, create_submitting: Signal<bool>, edit_view: Page, edit_error: Signal<Option<String>>, edit_dirty: Signal<bool>, edit_submitting: Signal<bool>, edit_cluster_id: Signal<String>, edit_name: Signal<String>, edit_api_url: Signal<String>, edit_is_active: Signal<bool>, delete_view: Page, delete_error: Signal<Option<String>>, delete_submitting: Signal<bool>, delete_cluster_id: Signal<String>, rotate_view: Page, rotate_error: Signal<Option<String>>, rotate_submitting: Signal<bool>, rotate_cluster_id: Signal<String>, health: Page| {
+	let content = page!(|clusters_for_inventory: Resource<Vec<ClusterInfo>, String>, clusters_for_edit: Resource<Vec<ClusterInfo>, String>, clusters_for_rotate: Resource<Vec<ClusterInfo>, String>, clusters_for_delete: Resource<Vec<ClusterInfo>, String>, create_view: Page, create_error: Signal<Option<String>>, create_submitting: Signal<bool>, edit_view: Page, edit_error: Signal<Option<String>>, edit_dirty: Signal<bool>, edit_submitting: Signal<bool>, edit_cluster_id: Signal<String>, edit_name: Signal<String>, edit_api_url: Signal<String>, edit_is_active: Signal<bool>, delete_view: Page, delete_error: Signal<Option<String>>, delete_submitting: Signal<bool>, delete_cluster_id: Signal<String>, rotate_view: Page, rotate_error: Signal<Option<String>>, rotate_submitting: Signal<bool>, rotate_cluster_id: Signal<String>, health: Page| {
 		div {
 			class: "rc-shell",
 			div {

--- a/dashboard/src/apps/deployments/client/pages/list.rs
+++ b/dashboard/src/apps/deployments/client/pages/list.rs
@@ -3,7 +3,9 @@
 use reinhardt::pages::component::Page;
 use reinhardt::pages::form;
 use reinhardt::pages::page;
-use reinhardt::pages::prelude::{ResetOnDeps, ResourceState, Signal, use_form, use_resource};
+use reinhardt::pages::prelude::{
+	ResetOnDeps, Resource, ResourceState, Signal, use_form, use_resource,
+};
 
 use crate::apps::clusters::server_fn::ClusterInfo;
 #[cfg(wasm)]
@@ -281,7 +283,7 @@ pub fn deployments_list_page() -> Page {
 	let deployments_for_delete = deployments.clone();
 	let clusters_for_create = clusters.clone();
 
-	let content = page!(|deployments_for_inventory: reinhardt::pages::prelude::Resource<Vec<DeploymentInfo>, String>, deployments_for_edit: reinhardt::pages::prelude::Resource<Vec<DeploymentInfo>, String>, deployments_for_status: reinhardt::pages::prelude::Resource<Vec<DeploymentInfo>, String>, deployments_for_delete: reinhardt::pages::prelude::Resource<Vec<DeploymentInfo>, String>, clusters_for_create: reinhardt::pages::prelude::Resource<Vec<ClusterInfo>, String>, create_view: Page, create_error: Signal<Option<String>>, create_submitting: Signal<bool>, create_cluster_id: Signal<String>, edit_view: Page, edit_error: Signal<Option<String>>, edit_dirty: Signal<bool>, edit_submitting: Signal<bool>, edit_deployment_id: Signal<String>, edit_app_name: Signal<String>, edit_image: Signal<String>, edit_status: Signal<String>, status_view: Page, status_error: Signal<Option<String>>, status_submitting: Signal<bool>, status_deployment_id: Signal<String>, delete_view: Page, delete_error: Signal<Option<String>>, delete_submitting: Signal<bool>, delete_deployment_id: Signal<String>, logs: Page| {
+	let content = page!(|deployments_for_inventory: Resource<Vec<DeploymentInfo>, String>, deployments_for_edit: Resource<Vec<DeploymentInfo>, String>, deployments_for_status: Resource<Vec<DeploymentInfo>, String>, deployments_for_delete: Resource<Vec<DeploymentInfo>, String>, clusters_for_create: Resource<Vec<ClusterInfo>, String>, create_view: Page, create_error: Signal<Option<String>>, create_submitting: Signal<bool>, create_cluster_id: Signal<String>, edit_view: Page, edit_error: Signal<Option<String>>, edit_dirty: Signal<bool>, edit_submitting: Signal<bool>, edit_deployment_id: Signal<String>, edit_app_name: Signal<String>, edit_image: Signal<String>, edit_status: Signal<String>, status_view: Page, status_error: Signal<Option<String>>, status_submitting: Signal<bool>, status_deployment_id: Signal<String>, delete_view: Page, delete_error: Signal<Option<String>>, delete_submitting: Signal<bool>, delete_deployment_id: Signal<String>, logs: Page| {
 		div {
 			class: "rc-shell",
 			div {

--- a/dashboard/src/apps/github/client/pages/list.rs
+++ b/dashboard/src/apps/github/client/pages/list.rs
@@ -3,7 +3,7 @@
 use reinhardt::pages::component::Page;
 use reinhardt::pages::form;
 use reinhardt::pages::page;
-use reinhardt::pages::prelude::{ResourceState, Signal, use_form, use_resource};
+use reinhardt::pages::prelude::{Resource, ResourceState, Signal, use_form, use_resource};
 
 use crate::apps::clusters::server_fn::ClusterInfo;
 #[cfg(wasm)]
@@ -172,7 +172,7 @@ pub fn github_repositories_page() -> Page {
 	let clusters_for_import = clusters.clone();
 	let clusters_for_inventory = clusters.clone();
 
-	let content = page!(|repositories_for_inventory: reinhardt::pages::prelude::Resource<Vec<GitHubRepositoryInfo>, String>, repositories_for_import: reinhardt::pages::prelude::Resource<Vec<GitHubRepositoryInfo>, String>, onboarding: reinhardt::pages::prelude::Resource<GitHubOnboardingInfo, String>, clusters_for_import: reinhardt::pages::prelude::Resource<Vec<ClusterInfo>, String>, clusters_for_inventory: reinhardt::pages::prelude::Resource<Vec<ClusterInfo>, String>, import_view: Page, import_error: Signal<Option<String>>, import_submitting: Signal<bool>, import_repository_id: Signal<String>, import_cluster_id: Signal<String>, import_app_name: Signal<String>| {
+	let content = page!(|repositories_for_inventory: Resource<Vec<GitHubRepositoryInfo>, String>, repositories_for_import: Resource<Vec<GitHubRepositoryInfo>, String>, onboarding: Resource<GitHubOnboardingInfo, String>, clusters_for_import: Resource<Vec<ClusterInfo>, String>, clusters_for_inventory: Resource<Vec<ClusterInfo>, String>, import_view: Page, import_error: Signal<Option<String>>, import_submitting: Signal<bool>, import_repository_id: Signal<String>, import_cluster_id: Signal<String>, import_app_name: Signal<String>| {
 		div {
 			class: "rc-shell",
 			div {
@@ -250,7 +250,7 @@ pub fn github_repositories_page() -> Page {
 													}
 												}
 											})(err),
-											ResourceState::Success(items)if items.is_empty() => page!(|onboarding: reinhardt::pages::prelude::Resource<GitHubOnboardingInfo, String>| {
+											ResourceState::Success(items)if items.is_empty() => page!(|onboarding: Resource<GitHubOnboardingInfo, String>| {
 												tr {
 													td {
 														class: "px-3 py-4 text-cloud-500",


### PR DESCRIPTION
## Summary

This PR addresses:

- Imports `Resource` from `reinhardt::pages::prelude` in dashboard client pages.
- Replaces fully qualified `reinhardt::pages::prelude::Resource<...>` annotations inside `page!` closures with `Resource<...>`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

- Long fully qualified `Resource` annotations made `page!` closure signatures harder to scan.
- Importing `Resource` matches the existing shorter style used by other dashboard client pages.

## How Was This Tested?

- `rg "reinhardt::pages::prelude::Resource" dashboard/src/apps -S`
- `cd dashboard && cargo make fmt-check`
- `cd dashboard && cargo check --all-features`
- `git diff --check`

## Performance Impact

- Not performance-related.

## Breaking Changes

- None.

**Migration Guide:**

- Not applicable.

## Screenshots

- Not applicable; this is a code style refactor with no UI rendering change.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

<!-- ⚠️ CI CONTROL CHECKBOX - DO NOT EDIT MANUALLY ⚠️
The following checkbox controls CI runner selection.
Checking this option triggers self-hosted runner usage,
which incurs infrastructure costs. Only the repository owner should enable this.
If this checkbox is missing or unchecked, CI defaults to GitHub-hosted runners.
Do NOT modify the checkbox text — CI parses it by exact pattern match. -->
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- None.

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [x] `refactoring` - Code refactoring
- [x] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [ ] `kubernetes` - Kubernetes resources, controllers, operators
- [ ] `deployment` - Application deployment logic
- [ ] `networking` - Ingress, services, network policies
- [ ] `storage` - Persistent volumes, storage classes
- [ ] `auth` - Authentication, authorization, RBAC
- [ ] `api` - REST API, serializers, handlers
- [ ] `cli` - Command-line interface
- [ ] `config` - Configuration management
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [x] `low` - Minor fix or enhancement

---

**Additional Context:**

- GitWhy context: `ctx_f684ebd2`

🤖 Generated with [Codex](https://openai.com/codex)
