### PR TITLE
test(e2e): add source pipeline smoke coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5783,15 +5783,21 @@ dependencies = [
 name = "reinhardt-cloud-integration-tests"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "chrono",
+ "k8s-openapi",
+ "kube",
  "prost-types 0.13.5",
  "reinhardt-cloud-core",
+ "reinhardt-cloud-dashboard",
  "reinhardt-cloud-grpc",
  "reinhardt-cloud-proto",
  "reinhardt-cloud-types",
  "rstest",
  "serde_json",
+ "serde_yaml",
+ "serial_test",
  "tokio",
  "tokio-stream",
  "tonic 0.13.1",

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -280,6 +280,27 @@ description = "Run the local Dashboard self-deploy E2E harness against the activ
 command = "bash"
 args = ["scripts/dashboard_self_deploy_e2e.sh"]
 
+[tasks.source-pipeline-e2e-build-operator]
+description = "Build the local operator binary used by source pipeline E2E smoke tests"
+command = "cargo"
+args = ["build", "--locked", "-p", "reinhardt-cloud-operator"]
+
+[tasks.source-pipeline-e2e]
+description = "Run deterministic source build, webhook, and preview E2E smoke tests"
+dependencies = ["source-pipeline-e2e-build-operator"]
+env = { REINHARDT_CLOUD_SOURCE_PIPELINE_E2E = "1", REINHARDT_CLOUD_E2E_OPERATOR_BIN = "target/debug/reinhardt-cloud-operator" }
+command = "cargo"
+args = [
+	"nextest",
+	"run",
+	"--locked",
+	"-p",
+	"reinhardt-cloud-integration-tests",
+	"--test",
+	"source_pipeline_e2e",
+	"--no-fail-fast",
+]
+
 # ============================================================================
 # Combined Checks (run before PR)
 # ============================================================================

--- a/docs/development/LOCAL_E2E_TESTING.md
+++ b/docs/development/LOCAL_E2E_TESTING.md
@@ -103,6 +103,51 @@ responses are also preserved there. This harness validates the generated-config
 Dashboard → Agent relay is still limited as described in
 [Known limitations](#known-limitations).
 
+## Automated source pipeline smoke harness
+
+For source builds, webhook automation, and preview environment lifecycle, run
+the deterministic smoke suite:
+
+```bash
+cargo make source-pipeline-e2e
+```
+
+The task builds the local Operator binary, applies the `Project` CRD, creates a
+temporary namespace, starts a local Operator unless an in-cluster Operator is
+already installed, and runs the `source_pipeline_e2e` nextest target. The suite
+uses real Kubernetes reconciliation for the source-build and preview paths, and
+uses the Dashboard GitHub webhook helpers for deterministic webhook payload and
+manifest assertions.
+
+This is intentionally a smoke tier. It verifies that a source `Project`
+creates the expected Kaniko `Job`, that the parent `Project` image and
+annotations are updated, that GitHub push and pull request payloads map to the
+expected pipeline annotations, and that preview create, update, delete, TTL
+cleanup, and owner-reference cleanup are reconciled. It does **not** require a
+real GitHub push, external Git clone, registry authentication, or a successful
+Kaniko image push. Add those as an opt-in full-build tier when CI has a stable
+registry and credentials.
+
+Useful overrides:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `REINHARDT_CLOUD_SOURCE_PIPELINE_E2E` | set to `1` by `cargo make source-pipeline-e2e` | Enables the cluster-backed tests. Without it, those tests report a skip and return success. |
+| `REINHARDT_CLOUD_SOURCE_PIPELINE_E2E_NAMESPACE` | `rc-e2e-<test>-<uuid>` | Reuse or name the test namespace. Existing namespaces are not deleted; only labeled test `Project` resources are removed. |
+| `REINHARDT_CLOUD_SOURCE_PIPELINE_E2E_TIMEOUT_SECONDS` | `90` | Wait timeout for CRD/operator reconciliation assertions. |
+| `REINHARDT_CLOUD_SOURCE_PIPELINE_E2E_ARTIFACT_DIR` | `target/source-pipeline-e2e/<namespace>` | Operator logs and failure diagnostics. |
+| `REINHARDT_CLOUD_SOURCE_PIPELINE_E2E_KEEP_RESOURCES` | `0` | Set to `1` to keep the namespace and artifacts for debugging. |
+| `REINHARDT_CLOUD_E2E_OPERATOR_MODE` | `auto` | `auto`, `existing`, `local`, or `skip`. |
+| `REINHARDT_CLOUD_E2E_OPERATOR_BIN` | `target/debug/reinhardt-cloud-operator` | Override the local Operator binary path. |
+
+Direct nextest invocation is also supported:
+
+```bash
+REINHARDT_CLOUD_SOURCE_PIPELINE_E2E=1 \
+REINHARDT_CLOUD_E2E_OPERATOR_BIN=target/debug/reinhardt-cloud-operator \
+cargo nextest run --locked -p reinhardt-cloud-integration-tests --test source_pipeline_e2e
+```
+
 ## 1. Bring up a local Kubernetes cluster
 
 Pick one of the two options.

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dev-dependencies]
 reinhardt-cloud-core = { workspace = true }
+reinhardt-cloud-dashboard = { path = "../dashboard" }
 reinhardt-cloud-grpc = { workspace = true }
 reinhardt-cloud-types = { workspace = true }
 reinhardt-cloud-proto = { workspace = true }
@@ -16,7 +17,12 @@ tonic-health = "0.13"
 rstest = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
+anyhow = { workspace = true }
+k8s-openapi = { workspace = true }
+kube = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+serial_test = "3.2"
 async-trait = "0.1"
 prost-types = "0.13"
 
@@ -35,6 +41,10 @@ path = "integration/tests/plugin_pipeline_integration.rs"
 [[test]]
 name = "agent_grpc_integration"
 path = "integration/tests/agent_grpc_integration.rs"
+
+[[test]]
+name = "source_pipeline_e2e"
+path = "e2e/source_pipeline.rs"
 
 [lints]
 workspace = true

--- a/tests/e2e/harness.rs
+++ b/tests/e2e/harness.rs
@@ -1,0 +1,538 @@
+use std::fs::{File, create_dir_all};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, bail};
+use k8s_openapi::api::batch::v1::Job;
+use k8s_openapi::api::core::v1::Namespace;
+use kube::api::{Api, ListParams, ObjectMeta, Patch, PatchParams, PostParams};
+use kube::{Client, ResourceExt};
+use reinhardt_cloud_types::crd::Project;
+use uuid::Uuid;
+
+pub(crate) const RUN_ENV: &str = "REINHARDT_CLOUD_SOURCE_PIPELINE_E2E";
+pub(crate) const SUITE_LABEL_KEY: &str = "reinhardt.dev/e2e-suite";
+pub(crate) const SUITE_LABEL_VALUE: &str = "source-pipeline";
+
+const KEEP_ENV: &str = "REINHARDT_CLOUD_SOURCE_PIPELINE_E2E_KEEP_RESOURCES";
+const NAMESPACE_ENV: &str = "REINHARDT_CLOUD_SOURCE_PIPELINE_E2E_NAMESPACE";
+const TIMEOUT_ENV: &str = "REINHARDT_CLOUD_SOURCE_PIPELINE_E2E_TIMEOUT_SECONDS";
+const OPERATOR_MODE_ENV: &str = "REINHARDT_CLOUD_E2E_OPERATOR_MODE";
+const OPERATOR_BIN_ENV: &str = "REINHARDT_CLOUD_E2E_OPERATOR_BIN";
+const ARTIFACT_DIR_ENV: &str = "REINHARDT_CLOUD_SOURCE_PIPELINE_E2E_ARTIFACT_DIR";
+
+pub(crate) struct E2eHarness {
+	client: Client,
+	namespace: String,
+	created_namespace: bool,
+	keep_resources: bool,
+	operator: Option<Child>,
+	artifact_dir: PathBuf,
+	timeout: Duration,
+}
+
+impl E2eHarness {
+	pub(crate) async fn start(test_name: &str) -> Result<Option<Self>> {
+		if std::env::var(RUN_ENV).ok().as_deref() != Some("1") {
+			eprintln!("skipping source pipeline E2E; set {RUN_ENV}=1 to run it");
+			return Ok(None);
+		}
+
+		require_command("kubectl")?;
+		run_kubectl(&["version", "--client"])?;
+		run_kubectl(&["cluster-info"])?;
+		ensure_crd()?;
+
+		let client = Client::try_default()
+			.await
+			.context("failed to create Kubernetes client from the active context")?;
+		let timeout = timeout();
+		let namespace = namespace_name(test_name);
+		let artifact_dir = artifact_dir(&namespace);
+		create_dir_all(&artifact_dir).context("failed to create E2E artifact directory")?;
+		let created_namespace = ensure_namespace(&client, &namespace).await?;
+		let keep_resources = std::env::var(KEEP_ENV).ok().as_deref() == Some("1");
+		let operator = ensure_operator(&artifact_dir)?;
+
+		Ok(Some(Self {
+			client,
+			namespace,
+			created_namespace,
+			keep_resources,
+			operator,
+			artifact_dir,
+			timeout,
+		}))
+	}
+
+	pub(crate) fn namespace(&self) -> &str {
+		&self.namespace
+	}
+
+	pub(crate) fn projects(&self) -> Api<Project> {
+		Api::namespaced(self.client.clone(), &self.namespace)
+	}
+
+	pub(crate) fn jobs(&self) -> Api<Job> {
+		Api::namespaced(self.client.clone(), &self.namespace)
+	}
+
+	pub(crate) async fn create_project(&self, project: &Project) -> Result<Project> {
+		self.projects()
+			.create(&PostParams::default(), project)
+			.await
+			.with_context(|| format!("failed to create Project {}", project.name_any()))
+	}
+
+	pub(crate) async fn patch_project(
+		&self,
+		name: &str,
+		patch: serde_json::Value,
+	) -> Result<Project> {
+		self.projects()
+			.patch(name, &PatchParams::default(), &Patch::Merge(&patch))
+			.await
+			.with_context(|| format!("failed to patch Project {name}"))
+	}
+
+	pub(crate) async fn wait_project<F>(
+		&self,
+		name: &str,
+		description: &str,
+		predicate: F,
+	) -> Result<Project>
+	where
+		F: Fn(&Project) -> bool,
+	{
+		let deadline = Instant::now() + self.timeout;
+		let projects = self.projects();
+		let mut last: Option<Project> = None;
+
+		while Instant::now() < deadline {
+			if let Some(project) = projects
+				.get_opt(name)
+				.await
+				.with_context(|| format!("failed to get Project {name}"))?
+			{
+				if predicate(&project) {
+					return Ok(project);
+				}
+				last = Some(project);
+			}
+			tokio::time::sleep(Duration::from_millis(500)).await;
+		}
+
+		bail!("Project {name} did not satisfy {description}; last state: {last:#?}")
+	}
+
+	pub(crate) async fn wait_project_absent(&self, name: &str) -> Result<()> {
+		let deadline = Instant::now() + self.timeout;
+		let projects = self.projects();
+
+		while Instant::now() < deadline {
+			if projects
+				.get_opt(name)
+				.await
+				.with_context(|| format!("failed to get Project {name}"))?
+				.is_none()
+			{
+				return Ok(());
+			}
+			tokio::time::sleep(Duration::from_millis(500)).await;
+		}
+
+		bail!("Project {name} still existed after {:?}", self.timeout)
+	}
+
+	pub(crate) async fn wait_job_named(&self, name: &str) -> Result<Job> {
+		let deadline = Instant::now() + self.timeout;
+		let jobs = self.jobs();
+
+		while Instant::now() < deadline {
+			if let Some(job) = jobs
+				.get_opt(name)
+				.await
+				.with_context(|| format!("failed to get Job {name}"))?
+			{
+				return Ok(job);
+			}
+			tokio::time::sleep(Duration::from_millis(500)).await;
+		}
+
+		bail!("Job {name} was not created within {:?}", self.timeout)
+	}
+
+	pub(crate) async fn assert_no_job_named_after(
+		&self,
+		name: &str,
+		delay: Duration,
+	) -> Result<()> {
+		tokio::time::sleep(delay).await;
+		let existing = self
+			.jobs()
+			.get_opt(name)
+			.await
+			.with_context(|| format!("failed to check Job {name}"))?;
+		if existing.is_some() {
+			bail!("Job {name} should not have been created");
+		}
+		Ok(())
+	}
+
+	pub(crate) async fn collect_diagnostics(&self, test_name: &str) {
+		let safe_test = sanitize_label(test_name);
+		let _ = kubectl_to_file(
+			&[
+				"get",
+				"project,job,deployment,service,pod",
+				"-n",
+				&self.namespace,
+				"-o",
+				"yaml",
+			],
+			&self
+				.artifact_dir
+				.join(format!("{safe_test}-resources.yaml")),
+		);
+		let _ = kubectl_to_file(
+			&[
+				"get",
+				"events",
+				"-n",
+				&self.namespace,
+				"--sort-by=.lastTimestamp",
+			],
+			&self.artifact_dir.join(format!("{safe_test}-events.txt")),
+		);
+	}
+}
+
+impl Drop for E2eHarness {
+	fn drop(&mut self) {
+		let _ = self.collect_drop_diagnostics();
+
+		if let Some(mut child) = self.operator.take() {
+			stop_process(&mut child);
+		}
+
+		if self.keep_resources {
+			eprintln!(
+				"keeping source pipeline E2E resources in namespace {} and artifacts {}",
+				self.namespace,
+				self.artifact_dir.display()
+			);
+			return;
+		}
+
+		if self.created_namespace {
+			let _ = run_kubectl(&[
+				"delete",
+				"namespace",
+				&self.namespace,
+				"--ignore-not-found",
+				"--wait=false",
+			]);
+		} else {
+			let selector = format!("{SUITE_LABEL_KEY}={SUITE_LABEL_VALUE}");
+			let _ = run_kubectl(&[
+				"delete",
+				"project",
+				"-n",
+				&self.namespace,
+				"-l",
+				&selector,
+				"--ignore-not-found",
+			]);
+		}
+	}
+}
+
+impl E2eHarness {
+	fn collect_drop_diagnostics(&self) -> Result<()> {
+		kubectl_to_file(
+			&[
+				"get",
+				"project,job,deployment,service,pod",
+				"-n",
+				&self.namespace,
+				"-o",
+				"yaml",
+			],
+			&self.artifact_dir.join("drop-resources.yaml"),
+		)?;
+		kubectl_to_file(
+			&[
+				"get",
+				"events",
+				"-n",
+				&self.namespace,
+				"--sort-by=.lastTimestamp",
+			],
+			&self.artifact_dir.join("drop-events.txt"),
+		)?;
+		Ok(())
+	}
+}
+
+pub(crate) fn e2e_labels() -> std::collections::BTreeMap<String, String> {
+	std::collections::BTreeMap::from([(SUITE_LABEL_KEY.to_string(), SUITE_LABEL_VALUE.to_string())])
+}
+
+async fn ensure_namespace(client: &Client, namespace: &str) -> Result<bool> {
+	let namespaces: Api<Namespace> = Api::all(client.clone());
+	if namespaces
+		.get_opt(namespace)
+		.await
+		.with_context(|| format!("failed to check Namespace {namespace}"))?
+		.is_some()
+	{
+		return Ok(false);
+	}
+
+	namespaces
+		.create(
+			&PostParams::default(),
+			&Namespace {
+				metadata: ObjectMeta {
+					name: Some(namespace.to_string()),
+					labels: Some(e2e_labels()),
+					..Default::default()
+				},
+				..Default::default()
+			},
+		)
+		.await
+		.with_context(|| format!("failed to create Namespace {namespace}"))?;
+	Ok(true)
+}
+
+fn ensure_crd() -> Result<()> {
+	let root = workspace_root();
+	let crd_path = root.join("charts/reinhardt-cloud-operator/crds/project-crd.yaml");
+	let crd = crd_path
+		.to_str()
+		.context("Project CRD path is not valid UTF-8")?;
+	run_kubectl(&["apply", "-f", crd])?;
+	run_kubectl(&[
+		"wait",
+		"--for=condition=Established",
+		"crd/projects.paas.reinhardt-cloud.dev",
+		"--timeout=120s",
+	])
+}
+
+fn ensure_operator(artifact_dir: &Path) -> Result<Option<Child>> {
+	let mode = std::env::var(OPERATOR_MODE_ENV).unwrap_or_else(|_| "auto".to_string());
+	match mode.as_str() {
+		"existing" => {
+			if !operator_deployment_exists()? {
+				bail!("no in-cluster reinhardt-cloud operator Deployment was found");
+			}
+			Ok(None)
+		}
+		"skip" => Ok(None),
+		"local" => start_local_operator(artifact_dir).map(Some),
+		"auto" => {
+			if operator_deployment_exists()? {
+				Ok(None)
+			} else {
+				start_local_operator(artifact_dir).map(Some)
+			}
+		}
+		other => {
+			bail!("invalid {OPERATOR_MODE_ENV}={other}; expected auto, existing, local, or skip")
+		}
+	}
+}
+
+fn operator_deployment_exists() -> Result<bool> {
+	let output = Command::new("kubectl")
+		.args([
+			"get",
+			"deployment",
+			"-A",
+			"-l",
+			"app.kubernetes.io/name=reinhardt-cloud-operator",
+			"-o",
+			"name",
+		])
+		.output()
+		.context("failed to query in-cluster operator Deployment")?;
+	if !output.status.success() {
+		return Ok(false);
+	}
+	Ok(!String::from_utf8_lossy(&output.stdout).trim().is_empty())
+}
+
+fn start_local_operator(artifact_dir: &Path) -> Result<Child> {
+	let mut operator_bin = std::env::var(OPERATOR_BIN_ENV)
+		.map(PathBuf::from)
+		.unwrap_or_else(|_| workspace_root().join("target/debug/reinhardt-cloud-operator"));
+	if operator_bin.is_relative() {
+		operator_bin = workspace_root().join(operator_bin);
+	}
+	if !operator_bin.exists() {
+		bail!(
+			"operator binary {} does not exist; build it first or set {OPERATOR_BIN_ENV}",
+			operator_bin.display()
+		);
+	}
+
+	let log_path = artifact_dir.join("operator.log");
+	let log = File::create(&log_path)
+		.with_context(|| format!("failed to create operator log {}", log_path.display()))?;
+	let metrics_addr = random_local_addr()?;
+	let mut child = Command::new(&operator_bin)
+		.current_dir(workspace_root())
+		.env("REINHARDT_CLOUD_METRICS_ADDR", metrics_addr)
+		.env("REINHARDT_CLOUD_METRICS_ENABLED", "0")
+		.stdout(Stdio::from(
+			log.try_clone().context("failed to clone operator log")?,
+		))
+		.stderr(Stdio::from(log))
+		.spawn()
+		.with_context(|| format!("failed to start operator {}", operator_bin.display()))?;
+
+	std::thread::sleep(Duration::from_secs(3));
+	if let Some(status) = child
+		.try_wait()
+		.context("failed to inspect local operator status")?
+	{
+		bail!(
+			"local operator exited with {status}; see {}",
+			log_path.display()
+		);
+	}
+
+	Ok(child)
+}
+
+fn stop_process(child: &mut Child) {
+	let _ = child.kill();
+	let _ = child.wait();
+}
+
+fn run_kubectl(args: &[&str]) -> Result<()> {
+	let output = Command::new("kubectl")
+		.args(args)
+		.output()
+		.with_context(|| format!("failed to run kubectl {}", args.join(" ")))?;
+	if !output.status.success() {
+		bail!(
+			"kubectl {} failed with status {}\nstdout:\n{}\nstderr:\n{}",
+			args.join(" "),
+			output.status,
+			String::from_utf8_lossy(&output.stdout),
+			String::from_utf8_lossy(&output.stderr)
+		);
+	}
+	Ok(())
+}
+
+fn kubectl_to_file(args: &[&str], path: &Path) -> Result<()> {
+	let output = Command::new("kubectl")
+		.args(args)
+		.output()
+		.with_context(|| format!("failed to run kubectl {}", args.join(" ")))?;
+	std::fs::write(path, [&output.stdout[..], &output.stderr[..]].concat())
+		.with_context(|| format!("failed to write {}", path.display()))?;
+	Ok(())
+}
+
+fn require_command(command: &str) -> Result<()> {
+	let status = Command::new(command)
+		.arg("--help")
+		.stdout(Stdio::null())
+		.stderr(Stdio::null())
+		.status()
+		.with_context(|| format!("{command} is required for source pipeline E2E"))?;
+	if !status.success() {
+		bail!("{command} is required for source pipeline E2E");
+	}
+	Ok(())
+}
+
+fn namespace_name(test_name: &str) -> String {
+	if let Ok(namespace) = std::env::var(NAMESPACE_ENV)
+		&& !namespace.trim().is_empty()
+	{
+		return namespace;
+	}
+	let suffix = Uuid::now_v7().to_string();
+	format!("rc-e2e-{}-{}", sanitize_label(test_name), &suffix[..8])
+}
+
+fn artifact_dir(namespace: &str) -> PathBuf {
+	std::env::var(ARTIFACT_DIR_ENV)
+		.map(PathBuf::from)
+		.unwrap_or_else(|_| {
+			workspace_root()
+				.join("target/source-pipeline-e2e")
+				.join(namespace)
+		})
+}
+
+fn timeout() -> Duration {
+	std::env::var(TIMEOUT_ENV)
+		.ok()
+		.and_then(|value| value.parse::<u64>().ok())
+		.map(Duration::from_secs)
+		.unwrap_or_else(|| Duration::from_secs(90))
+}
+
+fn workspace_root() -> PathBuf {
+	PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+		.parent()
+		.expect("tests crate should be inside the workspace root")
+		.to_path_buf()
+}
+
+fn random_local_addr() -> Result<String> {
+	let listener = std::net::TcpListener::bind("127.0.0.1:0")
+		.context("failed to reserve a local operator metrics address")?;
+	let addr = listener
+		.local_addr()
+		.context("failed to read local metrics address")?;
+	Ok(addr.to_string())
+}
+
+fn sanitize_label(value: &str) -> String {
+	let mut label = String::with_capacity(value.len());
+	let mut previous_dash = false;
+	for character in value.chars().flat_map(char::to_lowercase) {
+		let normalized = if character.is_ascii_alphanumeric() {
+			character
+		} else {
+			'-'
+		};
+		let character = normalized;
+		if character == '-' {
+			if label.is_empty() || previous_dash {
+				continue;
+			}
+			previous_dash = true;
+		} else {
+			previous_dash = false;
+		}
+		if label.len() == 48 {
+			break;
+		}
+		label.push(character);
+	}
+	while label.ends_with('-') {
+		label.pop();
+	}
+	if label.is_empty() {
+		"test".to_string()
+	} else {
+		label
+	}
+}
+
+pub(crate) async fn list_jobs(api: &Api<Job>) -> Result<Vec<Job>> {
+	api.list(&ListParams::default())
+		.await
+		.context("failed to list Jobs")
+		.map(|list| list.items)
+}

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -1,4 +1,0 @@
-pub mod credentials;
-pub mod preview;
-pub mod source_build;
-pub mod webhook;

--- a/tests/e2e/preview.rs
+++ b/tests/e2e/preview.rs
@@ -1,8 +1,346 @@
-//! E2E tests for preview environments (#277).
-//!
-//! Test scenarios:
-//! - e2e_preview_lifecycle: PR open → sync → close full lifecycle
-//!   → Preview Project created → updated → deleted
-//! - e2e_preview_ttl_expiry: Preview with expired TTL → Auto-deleted
-//! - e2e_preview_owner_cascade: Delete parent Project
-//!   → Preview cascade-deleted via ownerReferences
+use std::collections::BTreeMap;
+
+use anyhow::Result;
+use chrono::{Duration, Utc};
+use k8s_openapi::api::core::v1::LocalObjectReference;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference;
+use kube::ResourceExt;
+use kube::api::{DeleteParams, ObjectMeta};
+use reinhardt_cloud_types::crd::policy::DeletionPolicy;
+use reinhardt_cloud_types::crd::source::{
+	BuildSpec, GitProvider, PreviewOverrides, PreviewSpec, SourceSpec,
+};
+use reinhardt_cloud_types::crd::{Project, ProjectSpec, ServicesSpec};
+use rstest::rstest;
+use serial_test::serial;
+
+use crate::harness::{E2eHarness, e2e_labels};
+
+const PREVIEW_PARENT: &str = "preview-parent";
+const PREVIEW_NAME: &str = "preview-parent-pr-42";
+const EXPIRED_PREVIEW_NAME: &str = "preview-parent-pr-99";
+
+#[rstest]
+#[tokio::test]
+#[serial(source_pipeline_e2e)]
+async fn preview_lifecycle_ttl_and_owner_cascade_are_reconciled() -> Result<()> {
+	let Some(harness) = E2eHarness::start("preview").await? else {
+		return Ok(());
+	};
+
+	let parent = preview_parent_project(
+		harness.namespace(),
+		Some(preview_annotations(
+			"create",
+			"42",
+			"feature/login",
+			"abcdef1234567890",
+		)),
+	);
+	harness.create_project(&parent).await?;
+
+	let created = harness
+		.wait_project(PREVIEW_NAME, "preview creation", |project| {
+			project.spec.image == "registry.local/reinhardt/preview-parent:pr-42-abcdef12"
+		})
+		.await?;
+	assert_preview_project(
+		&created,
+		"feature-login.pr-42.preview-parent-pr-42.example.test",
+	);
+
+	harness
+		.wait_project(PREVIEW_PARENT, "preview annotations cleared", |project| {
+			!project
+				.metadata
+				.annotations
+				.as_ref()
+				.is_some_and(|annotations| {
+					annotations.contains_key("reinhardt.dev/preview-action")
+						|| annotations.contains_key("reinhardt.dev/pr-number")
+						|| annotations.contains_key("reinhardt.dev/pr-branch")
+				})
+		})
+		.await?;
+
+	harness
+		.patch_project(
+			PREVIEW_PARENT,
+			serde_json::json!({
+				"metadata": {
+					"annotations": preview_annotations(
+						"update",
+						"42",
+						"feature/updated",
+						"fedcba9876543210",
+					)
+				}
+			}),
+		)
+		.await?;
+	let updated = harness
+		.wait_project(PREVIEW_NAME, "preview update", |project| {
+			project.spec.image == "registry.local/reinhardt/preview-parent:pr-42-fedcba98"
+				&& project
+					.spec
+					.services
+					.as_ref()
+					.and_then(|services| services.ingress_host.as_deref())
+					== Some("feature-updated.pr-42.preview-parent-pr-42.example.test")
+		})
+		.await?;
+	assert_preview_project(
+		&updated,
+		"feature-updated.pr-42.preview-parent-pr-42.example.test",
+	);
+
+	harness
+		.patch_project(
+			PREVIEW_PARENT,
+			serde_json::json!({
+				"metadata": {
+					"annotations": {
+						"reinhardt.dev/preview-action": "delete",
+						"reinhardt.dev/pr-number": "42"
+					}
+				}
+			}),
+		)
+		.await?;
+	harness.wait_project_absent(PREVIEW_NAME).await?;
+
+	let live_parent = harness
+		.wait_project(PREVIEW_PARENT, "parent uid available", |project| {
+			project.metadata.uid.is_some()
+		})
+		.await?;
+	let expired_preview = expired_preview_project(harness.namespace(), &live_parent);
+	harness.create_project(&expired_preview).await?;
+	harness
+		.patch_project(
+			PREVIEW_PARENT,
+			serde_json::json!({
+				"metadata": {
+					"annotations": {
+						"reinhardt.dev/e2e-ttl-trigger": Utc::now().to_rfc3339()
+					}
+				}
+			}),
+		)
+		.await?;
+	harness.wait_project_absent(EXPIRED_PREVIEW_NAME).await?;
+
+	harness
+		.patch_project(
+			PREVIEW_PARENT,
+			serde_json::json!({
+				"metadata": {
+					"annotations": preview_annotations(
+						"create",
+						"42",
+						"feature/cascade",
+						"1234567890abcdef",
+					)
+				}
+			}),
+		)
+		.await?;
+	harness
+		.wait_project(
+			PREVIEW_NAME,
+			"preview recreation before parent delete",
+			|project| {
+				project.spec.image == "registry.local/reinhardt/preview-parent:pr-42-12345678"
+			},
+		)
+		.await?;
+	harness
+		.projects()
+		.delete(PREVIEW_PARENT, &DeleteParams::default())
+		.await?;
+	harness.wait_project_absent(PREVIEW_PARENT).await?;
+	harness.wait_project_absent(PREVIEW_NAME).await?;
+
+	harness.collect_diagnostics("preview").await;
+	Ok(())
+}
+
+fn assert_preview_project(project: &Project, expected_host: &str) {
+	assert_eq!(project.name_any(), PREVIEW_NAME);
+	assert_eq!(
+		project
+			.metadata
+			.labels
+			.as_ref()
+			.and_then(|labels| labels.get("reinhardt.dev/preview").map(String::as_str)),
+		Some("true")
+	);
+	assert_eq!(
+		project
+			.metadata
+			.labels
+			.as_ref()
+			.and_then(|labels| labels.get("reinhardt.dev/parent-app").map(String::as_str)),
+		Some(PREVIEW_PARENT)
+	);
+	assert_eq!(
+		project
+			.metadata
+			.labels
+			.as_ref()
+			.and_then(|labels| labels.get("reinhardt.dev/pr-number").map(String::as_str)),
+		Some("42")
+	);
+	assert_eq!(
+		project
+			.metadata
+			.owner_references
+			.as_ref()
+			.and_then(|refs| refs.first())
+			.map(|owner| owner.name.as_str()),
+		Some(PREVIEW_PARENT)
+	);
+	assert_eq!(project.spec.replicas, Some(1));
+	assert_eq!(project.spec.deletion_policy, DeletionPolicy::Delete);
+	assert_eq!(project.spec.source, None);
+	assert_eq!(
+		project.spec.env.get("REINHARDT_ENV").map(String::as_str),
+		Some("preview")
+	);
+	assert_eq!(
+		project
+			.spec
+			.image_pull_secrets
+			.as_ref()
+			.and_then(|refs| refs.first())
+			.map(|reference| reference.name.as_str()),
+		Some("registry-pull-secret")
+	);
+	assert_eq!(
+		project
+			.spec
+			.services
+			.as_ref()
+			.and_then(|services| services.ingress_host.as_deref()),
+		Some(expected_host)
+	);
+}
+
+fn preview_parent_project(
+	namespace: &str,
+	annotations: Option<BTreeMap<String, String>>,
+) -> Project {
+	Project {
+		metadata: ObjectMeta {
+			name: Some(PREVIEW_PARENT.to_string()),
+			namespace: Some(namespace.to_string()),
+			labels: Some(e2e_labels()),
+			annotations,
+			..Default::default()
+		},
+		spec: ProjectSpec {
+			image: "registry.local/reinhardt/preview-parent:placeholder".to_string(),
+			replicas: Some(0),
+			services: Some(ServicesSpec {
+				port: Some(80),
+				target_port: Some(8080),
+				ingress_host: Some("preview-parent.example.test".to_string()),
+			}),
+			env: BTreeMap::from([("REINHARDT_ENV".to_string(), "preview".to_string())]),
+			source: Some(SourceSpec {
+				repository: "https://github.com/kent8192/reinhardt-cloud".to_string(),
+				branch: Some("main".to_string()),
+				provider: Some(GitProvider::GitHub),
+				credentials_secret: None,
+				build: Some(BuildSpec {
+					dockerfile: Some("./Dockerfile".to_string()),
+					context: Some(".".to_string()),
+					registry: Some("registry.local/reinhardt/preview-parent".to_string()),
+					build_args: BTreeMap::new(),
+				}),
+				webhook: None,
+				preview: Some(PreviewSpec {
+					enabled: true,
+					ttl: Some("1h".to_string()),
+					url_template: Some("{branch}.pr-{pr_number}.{app}.example.test".to_string()),
+					overrides: Some(PreviewOverrides {
+						replicas: Some(1),
+						database: Some(false),
+						cache: Some(false),
+					}),
+				}),
+			}),
+			image_pull_secrets: Some(vec![LocalObjectReference {
+				name: "registry-pull-secret".to_string(),
+			}]),
+			..Default::default()
+		},
+		status: None,
+	}
+}
+
+fn expired_preview_project(namespace: &str, parent: &Project) -> Project {
+	let owner = OwnerReference {
+		api_version: "paas.reinhardt-cloud.dev/v1alpha2".to_string(),
+		kind: "Project".to_string(),
+		name: PREVIEW_PARENT.to_string(),
+		uid: parent
+			.metadata
+			.uid
+			.clone()
+			.expect("parent uid should be available"),
+		controller: Some(true),
+		block_owner_deletion: Some(true),
+	};
+	Project {
+		metadata: ObjectMeta {
+			name: Some(EXPIRED_PREVIEW_NAME.to_string()),
+			namespace: Some(namespace.to_string()),
+			labels: Some(BTreeMap::from([
+				("reinhardt.dev/preview".to_string(), "true".to_string()),
+				(
+					"reinhardt.dev/parent-app".to_string(),
+					PREVIEW_PARENT.to_string(),
+				),
+				("reinhardt.dev/pr-number".to_string(), "99".to_string()),
+				(
+					"app.kubernetes.io/managed-by".to_string(),
+					"reinhardt-cloud".to_string(),
+				),
+			])),
+			annotations: Some(BTreeMap::from([(
+				"reinhardt.dev/last-activity".to_string(),
+				(Utc::now() - Duration::hours(2)).to_rfc3339(),
+			)])),
+			owner_references: Some(vec![owner]),
+			..Default::default()
+		},
+		spec: ProjectSpec {
+			image: "registry.local/reinhardt/preview-parent:pr-99-expired".to_string(),
+			replicas: Some(0),
+			deletion_policy: DeletionPolicy::Delete,
+			..Default::default()
+		},
+		status: None,
+	}
+}
+
+fn preview_annotations(
+	action: &str,
+	pr_number: &str,
+	branch: &str,
+	commit_sha: &str,
+) -> BTreeMap<String, String> {
+	BTreeMap::from([
+		(
+			"reinhardt.dev/preview-action".to_string(),
+			action.to_string(),
+		),
+		("reinhardt.dev/pr-number".to_string(), pr_number.to_string()),
+		("reinhardt.dev/pr-branch".to_string(), branch.to_string()),
+		(
+			"reinhardt.dev/build-trigger".to_string(),
+			commit_sha.to_string(),
+		),
+	])
+}

--- a/tests/e2e/source_build.rs
+++ b/tests/e2e/source_build.rs
@@ -1,7 +1,197 @@
-//! E2E tests for source build & deploy (#275).
-//!
-//! Test scenarios:
-//! - e2e_source_build_deploy: Deploy Project with spec.source only
-//!   → kaniko Job created → build completes → Deployment image updated
-//! - e2e_image_precedence: Set both spec.image + spec.source
-//!   → Source build skipped, spec.image used
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use anyhow::Result;
+use k8s_openapi::api::core::v1::LocalObjectReference;
+use kube::ResourceExt;
+use kube::api::ObjectMeta;
+use reinhardt_cloud_types::crd::source::{BuildSpec, GitProvider, SourceSpec};
+use reinhardt_cloud_types::crd::{Project, ProjectSpec};
+use rstest::rstest;
+use serial_test::serial;
+
+use crate::harness::{E2eHarness, e2e_labels, list_jobs};
+
+const SOURCE_APP: &str = "source-build-app";
+const IMAGE_ONLY_APP: &str = "image-only-app";
+
+#[rstest]
+#[tokio::test]
+#[serial(source_pipeline_e2e)]
+async fn source_build_trigger_creates_kaniko_job_and_updates_parent_image() -> Result<()> {
+	let Some(harness) = E2eHarness::start("source-build").await? else {
+		return Ok(());
+	};
+
+	let source_project =
+		source_build_project(harness.namespace(), SOURCE_APP, Some("abcdef1234567890"));
+	harness.create_project(&source_project).await?;
+
+	let job = harness
+		.wait_job_named("source-build-app-build-abcdef12")
+		.await?;
+	let job_metadata = job.metadata;
+	assert_eq!(
+		job_metadata.labels.as_ref().and_then(|labels| {
+			labels
+				.get("app.kubernetes.io/component")
+				.map(String::as_str)
+		}),
+		Some("build")
+	);
+	assert_eq!(
+		job_metadata
+			.owner_references
+			.as_ref()
+			.and_then(|refs| refs.first())
+			.map(|owner| owner.name.as_str()),
+		Some(SOURCE_APP)
+	);
+
+	let pod_spec = job
+		.spec
+		.as_ref()
+		.and_then(|spec| spec.template.spec.as_ref())
+		.expect("Kaniko Job should include a Pod spec");
+	assert_eq!(pod_spec.restart_policy.as_deref(), Some("Never"));
+	assert_eq!(
+		pod_spec
+			.image_pull_secrets
+			.as_ref()
+			.and_then(|refs| refs.first())
+			.map(|reference| reference.name.as_str()),
+		Some("registry-pull-secret")
+	);
+	let container = pod_spec
+		.containers
+		.first()
+		.expect("Kaniko Job should include one container");
+	assert_eq!(container.name, "kaniko");
+	assert_eq!(
+		container.image.as_deref(),
+		Some("gcr.io/kaniko-project/executor:latest")
+	);
+	assert_eq!(
+		container.args.as_deref(),
+		Some(
+			[
+				"--git=branch=main,url=https://github.com/kent8192/reinhardt-cloud".to_string(),
+				"--dockerfile=./Dockerfile.e2e".to_string(),
+				"--context=dir://.".to_string(),
+				"--destination=registry.local/reinhardt/source-build-app:source-build-app-abcdef12"
+					.to_string(),
+				"--cache=true".to_string(),
+				"--build-arg=PROFILE=e2e".to_string(),
+			]
+			.as_slice()
+		)
+	);
+	assert_eq!(
+		container.env.as_ref().map(|env| env
+			.iter()
+			.map(|item| item.name.as_str())
+			.collect::<Vec<_>>()),
+		Some(vec!["GIT_USERNAME", "GIT_PASSWORD"])
+	);
+	assert_eq!(
+		container
+			.volume_mounts
+			.as_ref()
+			.and_then(|mounts| mounts.first())
+			.map(|mount| (mount.name.as_str(), mount.mount_path.as_str())),
+		Some(("registry-auth", "/kaniko/.docker/config.json"))
+	);
+	assert_eq!(
+		pod_spec
+			.volumes
+			.as_ref()
+			.and_then(|volumes| volumes.first())
+			.map(|volume| volume.name.as_str()),
+		Some("registry-auth")
+	);
+
+	harness
+		.wait_project(SOURCE_APP, "built image patch", |project| {
+			project.spec.image
+				== "registry.local/reinhardt/source-build-app:source-build-app-abcdef12"
+				&& !project
+					.metadata
+					.annotations
+					.as_ref()
+					.is_some_and(|annotations| {
+						annotations.contains_key("reinhardt.dev/build-trigger")
+					})
+		})
+		.await?;
+
+	let image_only_project = image_only_project(harness.namespace(), IMAGE_ONLY_APP);
+	harness.create_project(&image_only_project).await?;
+	harness
+		.assert_no_job_named_after("image-only-app-build-image-only", Duration::from_secs(5))
+		.await?;
+	let jobs = list_jobs(&harness.jobs()).await?;
+	let image_only_jobs = jobs
+		.iter()
+		.filter(|job| job.name_any().starts_with("image-only-app-build-"))
+		.count();
+	assert_eq!(image_only_jobs, 0);
+
+	harness.collect_diagnostics("source-build").await;
+	Ok(())
+}
+
+fn source_build_project(namespace: &str, name: &str, trigger: Option<&str>) -> Project {
+	let annotations = trigger.map(|value| {
+		BTreeMap::from([("reinhardt.dev/build-trigger".to_string(), value.to_string())])
+	});
+
+	Project {
+		metadata: ObjectMeta {
+			name: Some(name.to_string()),
+			namespace: Some(namespace.to_string()),
+			labels: Some(e2e_labels()),
+			annotations,
+			..Default::default()
+		},
+		spec: ProjectSpec {
+			image: "registry.local/reinhardt/source-build-app:placeholder".to_string(),
+			replicas: Some(0),
+			source: Some(SourceSpec {
+				repository: "https://github.com/kent8192/reinhardt-cloud".to_string(),
+				branch: Some("main".to_string()),
+				provider: Some(GitProvider::GitHub),
+				credentials_secret: Some("git-credentials".to_string()),
+				build: Some(BuildSpec {
+					dockerfile: Some("./Dockerfile.e2e".to_string()),
+					context: Some(".".to_string()),
+					registry: Some("registry.local/reinhardt/source-build-app".to_string()),
+					build_args: BTreeMap::from([("PROFILE".to_string(), "e2e".to_string())]),
+				}),
+				webhook: None,
+				preview: None,
+			}),
+			image_pull_secrets: Some(vec![LocalObjectReference {
+				name: "registry-pull-secret".to_string(),
+			}]),
+			..Default::default()
+		},
+		status: None,
+	}
+}
+
+fn image_only_project(namespace: &str, name: &str) -> Project {
+	Project {
+		metadata: ObjectMeta {
+			name: Some(name.to_string()),
+			namespace: Some(namespace.to_string()),
+			labels: Some(e2e_labels()),
+			..Default::default()
+		},
+		spec: ProjectSpec {
+			image: "registry.local/reinhardt/image-only:latest".to_string(),
+			replicas: Some(0),
+			..Default::default()
+		},
+		status: None,
+	}
+}

--- a/tests/e2e/source_pipeline.rs
+++ b/tests/e2e/source_pipeline.rs
@@ -1,0 +1,6 @@
+//! Source pipeline E2E smoke tests.
+
+mod harness;
+mod preview;
+mod source_build;
+mod webhook;

--- a/tests/e2e/webhook.rs
+++ b/tests/e2e/webhook.rs
@@ -1,9 +1,200 @@
-//! E2E tests for webhook automation (#276).
-//!
-//! Test scenarios:
-//! - e2e_webhook_github_push: Send GitHub push webhook payload
-//!   → Signature verified → annotation updated → rebuild triggered
-//! - e2e_webhook_gitlab_push: Send GitLab push webhook payload
-//!   → Token verified → annotation updated → rebuild triggered
-//! - e2e_webhook_invalid_signature: Send with invalid signature
-//!   → 401 Unauthorized returned
+use anyhow::Result;
+use reinhardt_cloud_dashboard::apps::github::services::import::apply_webhook_action_to_manifest;
+use reinhardt_cloud_dashboard::apps::github::services::webhook::parse_github_webhook_dispatch;
+use reinhardt_cloud_dashboard::utils::vcs::events::WebhookAction;
+use reinhardt_cloud_dashboard::utils::vcs::signature::verify_github_signature;
+use rstest::rstest;
+
+#[rstest]
+fn github_push_webhook_updates_production_manifest_and_ignores_other_branches() -> Result<()> {
+	let yaml = source_project_yaml();
+	let production_payload = serde_json::json!({
+		"repository": { "id": 705 },
+		"ref": "refs/heads/main",
+		"after": "abcdef1234567890"
+	});
+	let feature_payload = serde_json::json!({
+		"repository": { "id": 705 },
+		"ref": "refs/heads/feature/login",
+		"after": "fedcba9876543210"
+	});
+
+	let production_dispatch =
+		parse_github_webhook_dispatch("push", &serde_json::to_vec(&production_payload)?)
+			.map_err(anyhow::Error::msg)?;
+	let feature_dispatch =
+		parse_github_webhook_dispatch("push", &serde_json::to_vec(&feature_payload)?)
+			.map_err(anyhow::Error::msg)?;
+	let updated = apply_webhook_action_to_manifest(&yaml, &production_dispatch.action, "main")
+		.map_err(anyhow::Error::msg)?
+		.expect("production branch push should update the manifest");
+	let ignored = apply_webhook_action_to_manifest(&yaml, &feature_dispatch.action, "main")
+		.map_err(anyhow::Error::msg)?;
+	let updated_value: serde_yaml::Value = serde_yaml::from_str(&updated)?;
+
+	assert_eq!(production_dispatch.repository_id, 705);
+	assert_eq!(
+		production_dispatch.action,
+		WebhookAction::BuildTrigger {
+			branch: "main".to_string(),
+			commit_sha: "abcdef1234567890".to_string(),
+		}
+	);
+	assert_eq!(ignored, None);
+	assert_eq!(
+		updated_value["metadata"]["annotations"]["reinhardt.dev/build-trigger"].as_str(),
+		Some("abcdef1234567890")
+	);
+	assert!(updated_value["metadata"]["annotations"]["reinhardt.dev/preview-action"].is_null());
+	Ok(())
+}
+
+#[rstest]
+fn github_pull_request_webhook_maps_preview_create_update_delete_annotations() -> Result<()> {
+	let yaml = source_project_yaml();
+	let opened_payload = serde_json::json!({
+		"repository": { "id": 705 },
+		"action": "opened",
+		"number": 42,
+		"pull_request": {
+			"head": {
+				"ref": "feature/login",
+				"sha": "abc123"
+			}
+		}
+	});
+	let synchronize_payload = serde_json::json!({
+		"repository": { "id": 705 },
+		"action": "synchronize",
+		"number": 42,
+		"pull_request": {
+			"head": {
+				"ref": "feature/login",
+				"sha": "def456"
+			}
+		}
+	});
+	let closed_payload = serde_json::json!({
+		"repository": { "id": 705 },
+		"action": "closed",
+		"number": 42,
+		"pull_request": {
+			"head": {
+				"ref": "feature/login",
+				"sha": "def456"
+			}
+		}
+	});
+
+	let opened_dispatch =
+		parse_github_webhook_dispatch("pull_request", &serde_json::to_vec(&opened_payload)?)
+			.map_err(anyhow::Error::msg)?;
+	let synchronize_dispatch =
+		parse_github_webhook_dispatch("pull_request", &serde_json::to_vec(&synchronize_payload)?)
+			.map_err(anyhow::Error::msg)?;
+	let closed_dispatch =
+		parse_github_webhook_dispatch("pull_request", &serde_json::to_vec(&closed_payload)?)
+			.map_err(anyhow::Error::msg)?;
+
+	let opened = apply_webhook_action_to_manifest(&yaml, &opened_dispatch.action, "main")
+		.map_err(anyhow::Error::msg)?
+		.expect("opened pull request should update the manifest");
+	let synchronized =
+		apply_webhook_action_to_manifest(&opened, &synchronize_dispatch.action, "main")
+			.map_err(anyhow::Error::msg)?
+			.expect("synchronized pull request should update the manifest");
+	let closed = apply_webhook_action_to_manifest(&synchronized, &closed_dispatch.action, "main")
+		.map_err(anyhow::Error::msg)?
+		.expect("closed pull request should update the manifest");
+	let opened_value: serde_yaml::Value = serde_yaml::from_str(&opened)?;
+	let synchronized_value: serde_yaml::Value = serde_yaml::from_str(&synchronized)?;
+	let closed_value: serde_yaml::Value = serde_yaml::from_str(&closed)?;
+
+	assert_eq!(
+		opened_dispatch.action,
+		WebhookAction::PreviewCreate {
+			pr_number: 42,
+			branch: "feature/login".to_string(),
+			commit_sha: "abc123".to_string(),
+		}
+	);
+	assert_eq!(
+		opened_value["metadata"]["annotations"]["reinhardt.dev/preview-action"].as_str(),
+		Some("create")
+	);
+	assert_eq!(
+		opened_value["metadata"]["annotations"]["reinhardt.dev/pr-number"].as_str(),
+		Some("42")
+	);
+	assert_eq!(
+		opened_value["metadata"]["annotations"]["reinhardt.dev/pr-branch"].as_str(),
+		Some("feature/login")
+	);
+	assert_eq!(
+		synchronized_value["metadata"]["annotations"]["reinhardt.dev/build-trigger"].as_str(),
+		Some("def456")
+	);
+	assert_eq!(
+		closed_value["metadata"]["annotations"]["reinhardt.dev/preview-action"].as_str(),
+		Some("delete")
+	);
+	assert!(closed_value["metadata"]["annotations"]["reinhardt.dev/pr-branch"].is_null());
+	assert!(closed_value["metadata"]["annotations"]["reinhardt.dev/build-trigger"].is_null());
+	Ok(())
+}
+
+#[rstest]
+fn github_webhook_signature_rejects_invalid_signature() {
+	let payload = br#"{"repository":{"id":705}}"#;
+
+	assert!(!verify_github_signature(
+		b"webhook-secret",
+		payload,
+		"sha256=0000000000000000000000000000000000000000000000000000000000000000"
+	));
+	assert!(!verify_github_signature(
+		b"webhook-secret",
+		payload,
+		"md5=00000000000000000000000000000000"
+	));
+}
+
+fn source_project_yaml() -> String {
+	serde_yaml::to_string(&serde_json::json!({
+		"apiVersion": "paas.reinhardt-cloud.dev/v1alpha2",
+		"kind": "Project",
+		"metadata": {
+			"name": "webhook-app",
+			"namespace": "default",
+			"labels": {
+				"reinhardt.dev/e2e-suite": "source-pipeline"
+			}
+		},
+		"spec": {
+			"image": "registry.local/reinhardt/webhook-app:placeholder",
+			"replicas": 0,
+			"source": {
+				"repository": "https://github.com/kent8192/reinhardt-cloud",
+				"branch": "main",
+				"provider": "github",
+				"build": {
+					"registry": "registry.local/reinhardt/webhook-app"
+				},
+				"webhook": {
+					"enabled": true,
+					"events": ["push", "pull_request"],
+					"secret_ref": "github-webhook-secret"
+				},
+				"preview": {
+					"enabled": true,
+					"ttl": "72h",
+					"url_template": "pr-{pr_number}.{app}.preview.example.test",
+					"overrides": {
+						"replicas": 1
+					}
+				}
+			}
+		}
+	}))
+	.expect("source Project YAML should serialize")
+}


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds executable source pipeline E2E smoke coverage for source build Jobs, GitHub webhook manifest actions, and preview lifecycle reconciliation.
- Adds `cargo make source-pipeline-e2e` for the deterministic smoke suite.
- Documents local prerequisites, skip behavior, operator modes, and artifact overrides.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds functionality)
- [x] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

The existing E2E source pipeline files were scenario notes only. This change turns them into an executable deterministic smoke suite that validates the operator and webhook control-plane contract without requiring an external registry or a real GitHub push.

Fixes #705

Related to: #

## How Was This Tested?

- `cargo test --locked -p reinhardt-cloud-integration-tests --test source_pipeline_e2e --no-run`
- `cargo test --locked -p reinhardt-cloud-integration-tests --test source_pipeline_e2e`
- `cargo clippy --locked -p reinhardt-cloud-integration-tests --test source_pipeline_e2e -- -D warnings`
- `cargo nextest run --locked -p reinhardt-cloud-integration-tests --test source_pipeline_e2e`
- `cargo fmt --check`
- `git diff --check`

Not run locally:

- `cargo make source-pipeline-e2e` because the active `orbstack` Kubernetes context refused connections at `127.0.0.1:26443`.
- `cargo make fmt-check` because unrelated existing Dashboard page DSL files were already reported as needing formatting: `dashboard/src/apps/auth/client/components/oauth_buttons.rs`, `dashboard/src/apps/auth/client/pages/account.rs`, `dashboard/src/apps/clusters/client/pages/list.rs`, `dashboard/src/apps/github/client/pages/list.rs`, and `dashboard/src/apps/deployments/client/pages/list.rs`.

## Performance Impact

No runtime performance impact. The new smoke suite compiles the Dashboard helper dependency for webhook assertions and only starts Kubernetes resources when `REINHARDT_CLOUD_SOURCE_PIPELINE_E2E=1` is set.

## Breaking Changes

None.

**Migration Guide:**

No migration required.

## Screenshots

Not applicable.

### Before

- E2E files documented scenarios only.

### After

- E2E files contain executable smoke tests and a documented cargo-make entrypoint.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo fmt`
- [x] I have checked the code with focused `cargo clippy`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #705

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [x] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [x] `kubernetes` - Kubernetes resources, controllers, operators
- [x] `deployment` - Application deployment logic
- [ ] `networking` - Ingress, services, network policies
- [ ] `storage` - Persistent volumes, storage classes
- [ ] `auth` - Authentication, authorization, RBAC
- [ ] `api` - REST API, serializers, handlers
- [ ] `cli` - Command-line interface
- [ ] `config` - Configuration management
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The default suite is deterministic smoke coverage. A future opt-in full-build tier can add registry-backed Kaniko clone/build/push verification once stable credentials are available.

Generated with [Codex](https://openai.com/codex)
