### PR TITLE
feat(operator): gate rollouts on revision migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,14 @@ spec:
 
 The operator reports the following conditions on the CRD status:
 
-`Ready`, `Progressing`, `Degraded`, `DatabaseReady`, `CacheReady`, `WorkerReady`, `IngressReady`
+`Ready`, `Progressing`, `Degraded`, `MigrationReady`, `DatabaseReady`, `CacheReady`, `WorkerReady`, `IngressReady`
+
+For database-backed projects, the operator runs a revision-scoped migration
+Job before applying the new workload `Deployment`. `MigrationReady=False`
+with reason `MigrationRunning` means rollout is waiting on that Job;
+`MigrationReady=False` with reason `MigrationFailed` blocks the rollout and
+marks the project degraded until the spec changes or the failed revision is
+handled.
 
 ## Installation
 

--- a/charts/reinhardt-cloud-operator/crds/project-crd.yaml
+++ b/charts/reinhardt-cloud-operator/crds/project-crd.yaml
@@ -983,6 +983,7 @@ spec:
                       - Ready
                       - Progressing
                       - Degraded
+                      - MigrationReady
                       - DatabaseReady
                       - CacheReady
                       - WorkerReady

--- a/charts/reinhardt-cloud-operator/templates/clusterrole.yaml
+++ b/charts/reinhardt-cloud-operator/templates/clusterrole.yaml
@@ -19,6 +19,10 @@ rules:
   - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Base: Job management for source builds and deployment revision migrations.
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   # Base: Service, ConfigMap, Secret management (always required)
   - apiGroups: [""]
     resources: ["services", "configmaps", "secrets"]

--- a/crates/reinhardt-cloud-operator/src/inference/env_vars.rs
+++ b/crates/reinhardt-cloud-operator/src/inference/env_vars.rs
@@ -11,6 +11,59 @@ use reinhardt_cloud_types::crd::Project;
 
 use super::platform::Platform;
 
+/// Build the complete application environment managed by the operator.
+///
+/// This is shared by the workload `Deployment` and revision-scoped
+/// migration `Job` so database, cache, auth, and telemetry settings stay
+/// consistent across rollout gates and the serving Pods.
+pub(crate) fn build_application_env_vars(app: &Project, platform: &Platform) -> Vec<EnvVar> {
+	let project_name = app.name_any();
+	let explicit_db = app.spec.database.is_some();
+	let introspect_db = app.spec.introspect.as_ref().is_some_and(|i| {
+		reinhardt_cloud_core::inference::requires_postgresql(&i.features.infrastructure_signals)
+	});
+	let needs_db_env = explicit_db || introspect_db;
+	let explicit_cache = app.spec.cache.is_some();
+	let introspect_cache = app.spec.introspect.as_ref().is_some_and(|i| {
+		reinhardt_cloud_core::inference::requires_cache(&i.features.infrastructure_signals)
+	});
+	let redis_session_backend = app.spec.introspect.as_ref().is_some_and(|i| {
+		i.features.infrastructure_signals.session_backend.as_deref() == Some("redis")
+	});
+	let needs_redis_env = explicit_cache || introspect_cache || redis_session_backend;
+
+	let mut auto_vars = build_system_env_vars();
+	auto_vars.extend(build_core_secret_key_env_vars(&project_name));
+	if app.spec.auth.as_ref().is_some_and(|auth| auth.jwt) {
+		auto_vars.push(build_jwt_secret_env_var(&project_name));
+	}
+	if needs_redis_env {
+		auto_vars.push(build_redis_cache_env_var(&project_name));
+	}
+	if needs_db_env {
+		let db_host = if explicit_db {
+			format!("{project_name}-db")
+		} else {
+			format!("{project_name}-postgresql")
+		};
+		auto_vars.extend(build_database_env_vars_from_secret(
+			app,
+			platform,
+			&db_host,
+			&app.spec.env,
+		));
+	}
+
+	let mut merged_env = merge_env_vars(&auto_vars, &app.spec.env);
+	let otel_vars = build_otel_env_vars(&project_name);
+	for var in otel_vars {
+		if !merged_env.iter().any(|env| env.name == var.name) {
+			merged_env.push(var);
+		}
+	}
+	merged_env
+}
+
 /// Build database connection environment variables that reference a
 /// Kubernetes `Secret` for the password, keeping the sensitive value out
 /// of the pod spec.

--- a/crates/reinhardt-cloud-operator/src/inference/env_vars.rs
+++ b/crates/reinhardt-cloud-operator/src/inference/env_vars.rs
@@ -159,28 +159,23 @@ pub(crate) fn build_database_env_vars_from_secret(
 
 /// Build OpenTelemetry environment variables for an application Pod.
 ///
-/// Propagates the active trace context into the Pod so that application spans
-/// are correlated with the operator's reconcile span. Also sets standard OTel
-/// configuration variables so the Pod's SDK picks up the correct exporter and
-/// service identity without requiring manual configuration.
+/// Sets standard OTel configuration variables so the Pod's SDK picks up the
+/// correct exporter and service identity without requiring manual
+/// configuration.
 ///
 /// * `project_name` — value for `OTEL_SERVICE_NAME` (typically the app's name).
 ///
 /// Variables injected:
-/// * `TRACEPARENT` — W3C `traceparent` of the current reconcile span (omitted
-///   when the current span context is not valid). Note: OTel SDKs do not read
-///   `TRACEPARENT` automatically; the application must bootstrap context by
-///   reading this variable and explicitly setting it as the parent for the
-///   process's root span.
 /// * `OTEL_PROPAGATORS` — fixed to `tracecontext`.
 /// * `OTEL_SERVICE_NAME` — set to `project_name`.
 /// * `OTEL_EXPORTER_OTLP_ENDPOINT` — forwarded from the operator's own
 ///   environment variable of the same name when present.
+///
+/// The operator's per-reconcile `TRACEPARENT` is deliberately not injected:
+/// it is reconcile-scoped, so embedding it in a long-lived workload template
+/// would change the Pod spec on every reconciliation and trigger repeated
+/// rollouts. Application spans therefore start as independent roots.
 pub(crate) fn build_otel_env_vars(project_name: &str) -> Vec<EnvVar> {
-	use opentelemetry::trace::TraceContextExt;
-	use tracing::Span;
-	use tracing_opentelemetry::OpenTelemetrySpanExt;
-
 	let mut vars = vec![
 		env_var("OTEL_PROPAGATORS", "tracecontext"),
 		env_var("OTEL_SERVICE_NAME", project_name),
@@ -192,16 +187,6 @@ pub(crate) fn build_otel_env_vars(project_name: &str) -> Vec<EnvVar> {
 		&& !endpoint.is_empty()
 	{
 		vars.push(env_var("OTEL_EXPORTER_OTLP_ENDPOINT", &endpoint));
-	}
-
-	// Propagate the current reconcile span's traceparent so that application
-	// spans are nested inside the operator's reconcile trace.
-	let otel_cx = Span::current().context();
-	let otel_span = otel_cx.span();
-	if otel_span.span_context().is_valid()
-		&& let Some(tp) = reinhardt_cloud_telemetry::traceparent_from_context(&otel_cx)
-	{
-		vars.push(env_var("TRACEPARENT", &tp));
 	}
 
 	vars

--- a/crates/reinhardt-cloud-operator/src/reconciler.rs
+++ b/crates/reinhardt-cloud-operator/src/reconciler.rs
@@ -12,7 +12,7 @@ use k8s_openapi::api::core::v1::{
 	ConfigMap, LimitRange, Namespace, Secret, Service, ServiceAccount,
 };
 use k8s_openapi::api::networking::v1::{Ingress, NetworkPolicy};
-use kube::api::{Api, DeleteParams, Patch, PatchParams, PostParams};
+use kube::api::{Api, DeleteParams, ListParams, Patch, PatchParams, PostParams};
 use kube::runtime::controller::{Action, Controller};
 use kube::runtime::finalizer::{Event as FinalizerEvent, finalizer};
 use kube::runtime::watcher;
@@ -30,6 +30,9 @@ use crate::inference::platform::{Platform, PlatformConfig, ResourceDefaults};
 use crate::inference::secrets::{build_core_secret_key_secret, build_jwt_secret};
 use crate::metrics::Metrics;
 use crate::resources::credentials;
+use crate::resources::migration::{
+	build_migration_job, migration_job_name, migration_revision_key,
+};
 use crate::resources::preview;
 use crate::resources::security::limit_range::build_limit_range;
 use crate::resources::security::network_policy::{
@@ -41,7 +44,7 @@ use crate::resources::source::{
 use crate::resources::tenant as tenant_resources;
 use crate::resources::{
 	self, build_db_secret, build_db_service, build_db_statefulset, build_deployment, build_ingress,
-	build_migration_job, build_service,
+	build_service,
 };
 use k8s_openapi::api::core::v1::PersistentVolumeClaim;
 use kube::api::DynamicObject;
@@ -302,31 +305,7 @@ async fn apply(app: Arc<Project>, ctx: &Context, namespace: &str) -> Result<Acti
 		reconcile_app_service_account(&ctx.client, namespace, &workload_sa).await?;
 	}
 
-	// Reconcile owned Deployment via server-side apply
 	let deployments: Api<Deployment> = Api::namespaced(ctx.client.clone(), namespace);
-	let desired_deployment = build_deployment(&app, pages_config.as_ref(), &ctx.platform.platform)?;
-	deployments
-		.patch(
-			&name,
-			&PatchParams::apply("reinhardt-cloud-operator").force(),
-			&Patch::Apply(&desired_deployment),
-		)
-		.await
-		.map_err(Error::Kube)?;
-	info!("Reconciled Deployment {namespace}/{name}");
-
-	// Reconcile owned Service via server-side apply
-	let services: Api<Service> = Api::namespaced(ctx.client.clone(), namespace);
-	let desired_service = build_service(&app, pages_config.is_some())?;
-	services
-		.patch(
-			&name,
-			&PatchParams::apply("reinhardt-cloud-operator").force(),
-			&Patch::Apply(&desired_service),
-		)
-		.await
-		.map_err(Error::Kube)?;
-	info!("Reconciled Service {namespace}/{name}");
 
 	// Database provisioning — explicit spec.database takes precedence,
 	// falling back to introspect infrastructure signals.
@@ -363,8 +342,50 @@ async fn apply(app: Arc<Project>, ctx: &Context, namespace: &str) -> Result<Acti
 		reconcile_db_secret(&app, &ctx.client, namespace).await?;
 		reconcile_db_statefulset(&app, &ctx.client, namespace).await?;
 		reconcile_db_service_resource(&app, &ctx.client, namespace).await?;
-		reconcile_migration_job_resource(&app, &ctx.client, namespace).await?;
 	}
+
+	let migration_state = if should_provision_postgresql(&app) {
+		reconcile_migration_job_resource(&app, &ctx.client, namespace, &ctx.platform.platform)
+			.await?
+	} else {
+		MigrationGateState::NotRequired
+	};
+
+	if matches!(
+		migration_state,
+		MigrationGateState::Running | MigrationGateState::Failed
+	) {
+		let ready_replicas = observed_ready_replicas(&deployments, &name).await?;
+		update_status(&app, ctx, namespace, false, ready_replicas, migration_state).await?;
+		return Ok(Action::await_change());
+	}
+
+	// Reconcile owned Deployment only after the target migration revision
+	// has completed, so a new workload image never serves before its schema
+	// change gate succeeds.
+	let desired_deployment = build_deployment(&app, pages_config.as_ref(), &ctx.platform.platform)?;
+	deployments
+		.patch(
+			&name,
+			&PatchParams::apply("reinhardt-cloud-operator").force(),
+			&Patch::Apply(&desired_deployment),
+		)
+		.await
+		.map_err(Error::Kube)?;
+	info!("Reconciled Deployment {namespace}/{name}");
+
+	// Reconcile owned Service via server-side apply
+	let services: Api<Service> = Api::namespaced(ctx.client.clone(), namespace);
+	let desired_service = build_service(&app, pages_config.is_some())?;
+	services
+		.patch(
+			&name,
+			&PatchParams::apply("reinhardt-cloud-operator").force(),
+			&Patch::Apply(&desired_service),
+		)
+		.await
+		.map_err(Error::Kube)?;
+	info!("Reconciled Service {namespace}/{name}");
 
 	// Ingress — explicit services.ingress_host takes precedence,
 	// falling back to introspect routes.
@@ -710,19 +731,23 @@ async fn apply(app: Arc<Project>, ctx: &Context, namespace: &str) -> Result<Acti
 	}
 
 	// Derive readiness from the observed Deployment status
-	let live_deployment = deployments.get(&name).await.map_err(Error::Kube)?;
 	let desired_replicas = app.spec.replicas.unwrap_or(1);
-	let ready_replicas = live_deployment
-		.status
-		.as_ref()
-		.and_then(|s| s.ready_replicas)
-		.unwrap_or(0);
+	let ready_replicas = observed_ready_replicas(&deployments, &name).await?;
 	let ready = ready_replicas >= desired_replicas;
 
 	// Update status sub-resource
-	update_status(&app, ctx, namespace, ready, ready_replicas).await?;
+	update_status(&app, ctx, namespace, ready, ready_replicas, migration_state).await?;
 
 	Ok(Action::await_change())
+}
+
+async fn observed_ready_replicas(deployments: &Api<Deployment>, name: &str) -> Result<i32, Error> {
+	Ok(deployments
+		.get_opt(name)
+		.await
+		.map_err(Error::Kube)?
+		.and_then(|deployment| deployment.status.and_then(|status| status.ready_replicas))
+		.unwrap_or(0))
 }
 
 /// Clean up external resources when a `Project` is deleted.
@@ -786,7 +811,7 @@ async fn cleanup(app: Arc<Project>, ctx: &Context, namespace: &str) -> Result<Ac
 	// (Ingress, migration Job). These have ownerReferences but we delete
 	// explicitly for a cleaner teardown sequence.
 	delete_if_exists::<Ingress>(&ctx.client, namespace, &name).await?;
-	delete_if_exists::<Job>(&ctx.client, namespace, &format!("{name}-migrate")).await?;
+	delete_migration_jobs(&ctx.client, namespace, &name).await?;
 
 	match app.spec.deletion_policy {
 		DeletionPolicy::Retain => {
@@ -882,6 +907,41 @@ fn should_provision_cache(app: &Project) -> bool {
 			reinhardt_cloud_core::inference::requires_cache(&i.features.infrastructure_signals)
 		})
 		.unwrap_or(false)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MigrationGateState {
+	NotRequired,
+	Running,
+	Succeeded,
+	Failed,
+}
+
+impl MigrationGateState {
+	fn condition_status(self) -> ConditionStatus {
+		match self {
+			Self::NotRequired | Self::Succeeded => ConditionStatus::True,
+			Self::Running | Self::Failed => ConditionStatus::False,
+		}
+	}
+
+	fn reason(self) -> &'static str {
+		match self {
+			Self::NotRequired => "MigrationNotRequired",
+			Self::Running => "MigrationRunning",
+			Self::Succeeded => "MigrationSucceeded",
+			Self::Failed => "MigrationFailed",
+		}
+	}
+
+	fn message(self) -> &'static str {
+		match self {
+			Self::NotRequired => "No database migration is required for this project",
+			Self::Running => "Waiting for the deployment revision migration to complete",
+			Self::Succeeded => "Deployment revision migration completed successfully",
+			Self::Failed => "Deployment revision migration failed; rollout is blocked",
+		}
+	}
 }
 
 /// Resolve the effective application port.
@@ -1058,51 +1118,56 @@ async fn reconcile_db_service_resource(
 
 /// Reconciles the database migration `Job`.
 ///
-/// - If the job completed successfully, skips re-creation.
-/// - If the job failed, deletes it and recreates.
-/// - If the job is still running, skips.
-/// - If no job exists, creates one.
+/// - If the revision job completed successfully, returns `Succeeded`.
+/// - If the revision job failed, returns `Failed` and leaves it for inspection.
+/// - If the revision job is still running, returns `Running`.
+/// - If no revision job exists, creates one and returns `Running`.
 async fn reconcile_migration_job_resource(
 	app: &Project,
 	client: &Client,
 	namespace: &str,
-) -> Result<(), Error> {
-	let name = app.name_any();
-	let job_name = format!("{name}-migrate");
+	platform: &Platform,
+) -> Result<MigrationGateState, Error> {
+	let revision_key = migration_revision_key(app);
+	let job_name = migration_job_name(app, &revision_key);
 	let job_api: Api<Job> = Api::namespaced(client.clone(), namespace);
 
 	if let Some(existing) = job_api.get_opt(&job_name).await.map_err(Error::Kube)? {
 		let status = existing.status.as_ref();
 		let succeeded = status.and_then(|s| s.succeeded).unwrap_or(0);
-		let failed = status.and_then(|s| s.failed).unwrap_or(0);
-		let active = status.and_then(|s| s.active).unwrap_or(0);
 
-		if succeeded > 0 {
-			info!("Migration Job {namespace}/{job_name} already completed, skipping");
-			return Ok(());
+		if succeeded > 0 || job_condition_is_true(status, "Complete") {
+			info!("Migration Job {namespace}/{job_name} completed for current revision");
+			return Ok(MigrationGateState::Succeeded);
 		}
-		if active > 0 {
-			info!("Migration Job {namespace}/{job_name} is still running, skipping");
-			return Ok(());
+		if job_condition_is_true(status, "Failed") {
+			warn!("Migration Job {namespace}/{job_name} failed for current revision");
+			return Ok(MigrationGateState::Failed);
 		}
-		if failed > 0 {
-			warn!("Migration Job {namespace}/{job_name} failed, deleting for re-creation");
-			// Use propagation policy to clean up pods
-			let dp = DeleteParams {
-				propagation_policy: Some(kube::api::PropagationPolicy::Background),
-				..Default::default()
-			};
-			job_api.delete(&job_name, &dp).await.map_err(Error::Kube)?;
-		}
+		info!("Migration Job {namespace}/{job_name} is still running");
+		return Ok(MigrationGateState::Running);
 	}
 
-	let desired = build_migration_job(app)?;
+	let desired = build_migration_job(app, platform, &revision_key)?;
 	job_api
 		.create(&PostParams::default(), &desired)
 		.await
 		.map_err(|e| Error::DatabaseProvisioning(e.to_string()))?;
 	info!("Created migration Job {namespace}/{job_name}");
-	Ok(())
+	Ok(MigrationGateState::Running)
+}
+
+fn job_condition_is_true(
+	status: Option<&k8s_openapi::api::batch::v1::JobStatus>,
+	condition_type: &str,
+) -> bool {
+	status
+		.and_then(|status| status.conditions.as_ref())
+		.is_some_and(|conditions| {
+			conditions
+				.iter()
+				.any(|condition| condition.type_ == condition_type && condition.status == "True")
+		})
 }
 
 /// Apply a database `StatefulSet` via server-side apply.
@@ -1701,6 +1766,37 @@ async fn reconcile_pss_labels(client: &Client, namespace: &str) -> Result<(), Er
 	Ok(())
 }
 
+fn build_condition(
+	app: &Project,
+	condition_type: ConditionType,
+	status: ConditionStatus,
+	reason: &str,
+	message: &str,
+) -> ProjectCondition {
+	let existing_condition = app.status.as_ref().and_then(|s| {
+		s.conditions
+			.iter()
+			.find(|condition| condition.type_ == condition_type)
+	});
+	let last_transition_time = if should_update_transition_time(
+		existing_condition.map(|condition| &condition.status),
+		&status,
+	) {
+		Some(chrono::Utc::now().to_rfc3339())
+	} else {
+		existing_condition.and_then(|condition| condition.last_transition_time.clone())
+	};
+
+	ProjectCondition {
+		type_: condition_type,
+		status,
+		reason: reason.to_string(),
+		message: message.to_string(),
+		last_transition_time,
+		observed_generation: app.metadata.generation,
+	}
+}
+
 /// Deletes a namespaced Kubernetes resource if it exists.
 ///
 /// Silently succeeds if the resource is already absent.
@@ -1721,12 +1817,41 @@ where
 	Ok(())
 }
 
+async fn delete_migration_jobs(
+	client: &Client,
+	namespace: &str,
+	app_name: &str,
+) -> Result<(), Error> {
+	let api: Api<Job> = Api::namespaced(client.clone(), namespace);
+	let jobs = api
+		.list(&ListParams::default().labels(&format!(
+			"app.kubernetes.io/name={app_name},app.kubernetes.io/component=migration"
+		)))
+		.await
+		.map_err(Error::Kube)?;
+	for job in jobs {
+		if let Some(name) = job.metadata.name {
+			api.delete(&name, &DeleteParams::default())
+				.await
+				.map_err(Error::Kube)?;
+		}
+	}
+	Ok(())
+}
+
 /// Builds the desired `ProjectStatus` for the given readiness state.
 ///
 /// Pure function that computes the status without any Kubernetes API
 /// calls, making it independently testable.
-fn build_status(app: &Project, ready: bool, ready_replicas: i32) -> ProjectStatus {
-	let phase = if ready {
+fn build_status(
+	app: &Project,
+	ready: bool,
+	ready_replicas: i32,
+	migration_state: MigrationGateState,
+) -> ProjectStatus {
+	let phase = if migration_state == MigrationGateState::Failed {
+		ProjectPhase::Degraded
+	} else if ready {
 		ProjectPhase::Running
 	} else {
 		ProjectPhase::Deploying
@@ -1738,31 +1863,17 @@ fn build_status(app: &Project, ready: bool, ready_replicas: i32) -> ProjectStatu
 	};
 	let reason = if ready {
 		"ReconcileSuccess"
+	} else if migration_state == MigrationGateState::Failed {
+		"MigrationFailed"
 	} else {
 		"ReconcileInProgress"
 	};
 	let message = if ready {
 		"Application is ready"
+	} else if migration_state == MigrationGateState::Failed {
+		"Migration failed; rollout is blocked"
 	} else {
 		"Waiting for deployment rollout to complete"
-	};
-
-	// Determine lastTransitionTime: preserve existing value if status unchanged
-	let existing_ready_condition = app.status.as_ref().and_then(|s| {
-		s.conditions
-			.iter()
-			.find(|c| c.type_ == ConditionType::Ready)
-	});
-
-	let last_transition_time = if should_update_transition_time(
-		existing_ready_condition.map(|c| &c.status),
-		&condition_status,
-	) {
-		// Status changed or no prior condition: set new transition time
-		Some(chrono::Utc::now().to_rfc3339())
-	} else {
-		// Status unchanged: preserve existing transition time
-		existing_ready_condition.and_then(|c| c.last_transition_time.clone())
 	};
 
 	// Track database sub-resource status if database is configured
@@ -1776,16 +1887,29 @@ fn build_status(app: &Project, ready: bool, ready_replicas: i32) -> ProjectStatu
 		None
 	};
 
+	let mut conditions = vec![
+		build_condition(app, ConditionType::Ready, condition_status, reason, message),
+		build_condition(
+			app,
+			ConditionType::MigrationReady,
+			migration_state.condition_status(),
+			migration_state.reason(),
+			migration_state.message(),
+		),
+	];
+	if migration_state == MigrationGateState::Failed {
+		conditions.push(build_condition(
+			app,
+			ConditionType::Degraded,
+			ConditionStatus::True,
+			"MigrationFailed",
+			"Migration failed for the target deployment revision",
+		));
+	}
+
 	ProjectStatus {
 		phase: Some(phase),
-		conditions: vec![ProjectCondition {
-			type_: ConditionType::Ready,
-			status: condition_status,
-			reason: reason.to_string(),
-			message: message.to_string(),
-			last_transition_time,
-			observed_generation: app.metadata.generation,
-		}],
+		conditions,
 		observed_generation: app.metadata.generation,
 		ready_replicas: Some(ready_replicas),
 		database,
@@ -1803,9 +1927,10 @@ async fn update_status(
 	namespace: &str,
 	ready: bool,
 	ready_replicas: i32,
+	migration_state: MigrationGateState,
 ) -> Result<(), Error> {
 	let api: Api<Project> = Api::namespaced(ctx.client.clone(), namespace);
-	let typed_status = build_status(app, ready, ready_replicas);
+	let typed_status = build_status(app, ready, ready_replicas, migration_state);
 
 	let phase_label_for_gauge = typed_status.phase.as_ref().map(phase_label);
 	let status = serde_json::json!({ "status": typed_status });
@@ -1939,6 +2064,7 @@ pub(crate) fn error_policy(obj: Arc<Project>, error: &Error, ctx: Arc<Context>) 
 pub(crate) async fn run(client: Client, metrics: Arc<Metrics>) {
 	let apps: Api<Project> = Api::all(client.clone());
 	let deployments: Api<Deployment> = Api::all(client.clone());
+	let jobs: Api<Job> = Api::all(client.clone());
 	let services: Api<Service> = Api::all(client.clone());
 	let statefulsets: Api<StatefulSet> = Api::all(client.clone());
 	let network_policies: Api<NetworkPolicy> = Api::all(client.clone());
@@ -1956,6 +2082,11 @@ pub(crate) async fn run(client: Client, metrics: Arc<Metrics>) {
 	Controller::new(apps, watcher::Config::default())
 		.owns(
 			deployments,
+			watcher::Config::default()
+				.labels("app.kubernetes.io/managed-by=reinhardt-cloud-operator"),
+		)
+		.owns(
+			jobs,
 			watcher::Config::default()
 				.labels("app.kubernetes.io/managed-by=reinhardt-cloud-operator"),
 		)
@@ -2016,6 +2147,14 @@ mod tests {
 		}
 	}
 
+	fn find_condition(status: &ProjectStatus, condition_type: ConditionType) -> &ProjectCondition {
+		status
+			.conditions
+			.iter()
+			.find(|condition| condition.type_ == condition_type)
+			.expect("condition should exist")
+	}
+
 	// ── should_update_transition_time tests ──────────────────────────
 
 	#[rstest]
@@ -2073,15 +2212,18 @@ mod tests {
 		let app = make_test_app("ready-app");
 
 		// Act
-		let status = build_status(&app, true, 3);
+		let status = build_status(&app, true, 3, MigrationGateState::NotRequired);
 
 		// Assert
 		assert_eq!(status.phase, Some(ProjectPhase::Running));
-		assert_eq!(status.conditions.len(), 1);
-		assert_eq!(status.conditions[0].type_, ConditionType::Ready);
-		assert_eq!(status.conditions[0].status, ConditionStatus::True);
-		assert_eq!(status.conditions[0].reason, "ReconcileSuccess");
-		assert_eq!(status.conditions[0].message, "Application is ready");
+		assert_eq!(status.conditions.len(), 2);
+		let ready = find_condition(&status, ConditionType::Ready);
+		assert_eq!(ready.status, ConditionStatus::True);
+		assert_eq!(ready.reason, "ReconcileSuccess");
+		assert_eq!(ready.message, "Application is ready");
+		let migration = find_condition(&status, ConditionType::MigrationReady);
+		assert_eq!(migration.status, ConditionStatus::True);
+		assert_eq!(migration.reason, "MigrationNotRequired");
 	}
 
 	#[rstest]
@@ -2090,18 +2232,51 @@ mod tests {
 		let app = make_test_app("deploying-app");
 
 		// Act
-		let status = build_status(&app, false, 0);
+		let status = build_status(&app, false, 0, MigrationGateState::NotRequired);
 
 		// Assert
 		assert_eq!(status.phase, Some(ProjectPhase::Deploying));
-		assert_eq!(status.conditions.len(), 1);
-		assert_eq!(status.conditions[0].type_, ConditionType::Ready);
-		assert_eq!(status.conditions[0].status, ConditionStatus::False);
-		assert_eq!(status.conditions[0].reason, "ReconcileInProgress");
-		assert_eq!(
-			status.conditions[0].message,
-			"Waiting for deployment rollout to complete"
-		);
+		assert_eq!(status.conditions.len(), 2);
+		let ready = find_condition(&status, ConditionType::Ready);
+		assert_eq!(ready.status, ConditionStatus::False);
+		assert_eq!(ready.reason, "ReconcileInProgress");
+		assert_eq!(ready.message, "Waiting for deployment rollout to complete");
+		let migration = find_condition(&status, ConditionType::MigrationReady);
+		assert_eq!(migration.status, ConditionStatus::True);
+		assert_eq!(migration.reason, "MigrationNotRequired");
+	}
+
+	#[rstest]
+	fn test_build_status_sets_migration_running_condition() {
+		// Arrange
+		let app = make_test_app("migration-running-app");
+
+		// Act
+		let status = build_status(&app, false, 0, MigrationGateState::Running);
+
+		// Assert
+		assert_eq!(status.phase, Some(ProjectPhase::Deploying));
+		let migration = find_condition(&status, ConditionType::MigrationReady);
+		assert_eq!(migration.status, ConditionStatus::False);
+		assert_eq!(migration.reason, "MigrationRunning");
+	}
+
+	#[rstest]
+	fn test_build_status_sets_degraded_phase_when_migration_failed() {
+		// Arrange
+		let app = make_test_app("migration-failed-app");
+
+		// Act
+		let status = build_status(&app, false, 0, MigrationGateState::Failed);
+
+		// Assert
+		assert_eq!(status.phase, Some(ProjectPhase::Degraded));
+		let migration = find_condition(&status, ConditionType::MigrationReady);
+		assert_eq!(migration.status, ConditionStatus::False);
+		assert_eq!(migration.reason, "MigrationFailed");
+		let degraded = find_condition(&status, ConditionType::Degraded);
+		assert_eq!(degraded.status, ConditionStatus::True);
+		assert_eq!(degraded.reason, "MigrationFailed");
 	}
 
 	#[rstest]
@@ -2111,7 +2286,7 @@ mod tests {
 		app.metadata.generation = Some(5);
 
 		// Act
-		let status = build_status(&app, true, 1);
+		let status = build_status(&app, true, 1, MigrationGateState::NotRequired);
 
 		// Assert
 		assert_eq!(status.observed_generation, Some(5));
@@ -2124,7 +2299,7 @@ mod tests {
 		let app = make_test_app("replicas-app");
 
 		// Act
-		let status = build_status(&app, true, 7);
+		let status = build_status(&app, true, 7, MigrationGateState::NotRequired);
 
 		// Assert
 		assert_eq!(status.ready_replicas, Some(7));
@@ -2151,7 +2326,7 @@ mod tests {
 		});
 
 		// Act — same readiness state (ready=true matching existing True)
-		let status = build_status(&app, true, 1);
+		let status = build_status(&app, true, 1, MigrationGateState::NotRequired);
 
 		// Assert — transition time should be preserved
 		assert_eq!(
@@ -2181,7 +2356,7 @@ mod tests {
 		});
 
 		// Act — readiness changed from True to False
-		let status = build_status(&app, false, 0);
+		let status = build_status(&app, false, 0, MigrationGateState::NotRequired);
 
 		// Assert — transition time should be updated (not the old value)
 		assert_ne!(
@@ -2197,7 +2372,7 @@ mod tests {
 		let app = make_test_app("new-app");
 
 		// Act
-		let status = build_status(&app, true, 1);
+		let status = build_status(&app, true, 1, MigrationGateState::NotRequired);
 
 		// Assert — should have a transition time since there's no prior condition
 		assert!(status.conditions[0].last_transition_time.is_some());
@@ -2217,7 +2392,7 @@ mod tests {
 		});
 
 		// Act
-		let status = build_status(&app, true, 1);
+		let status = build_status(&app, true, 1, MigrationGateState::NotRequired);
 
 		// Assert
 		let db_status = status.database.expect("database status should be present");
@@ -2235,7 +2410,7 @@ mod tests {
 		let app = make_test_app("no-db-app");
 
 		// Act
-		let status = build_status(&app, true, 1);
+		let status = build_status(&app, true, 1, MigrationGateState::NotRequired);
 
 		// Assert
 		assert!(status.database.is_none());

--- a/crates/reinhardt-cloud-operator/src/resources.rs
+++ b/crates/reinhardt-cloud-operator/src/resources.rs
@@ -24,7 +24,6 @@ pub(crate) mod worker;
 pub(crate) use database::{build_db_secret, build_db_service, build_db_statefulset};
 pub(crate) use deployment::build_deployment;
 pub(crate) use ingress::build_ingress;
-pub(crate) use migration::build_migration_job;
 pub(crate) use service::build_service;
 // source::build_kaniko_job and source::should_build_from_source are used
 // directly via crate::resources::source in the reconciler.

--- a/crates/reinhardt-cloud-operator/src/resources/database.rs
+++ b/crates/reinhardt-cloud-operator/src/resources/database.rs
@@ -53,8 +53,9 @@ fn sanitize_db_name(name: &str) -> String {
 
 /// Builds a `Secret` containing PostgreSQL credentials for the given `Project`.
 ///
-/// The secret includes `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`,
-/// and a fully-formed `DATABASE_URL` connection string.
+/// The secret includes `username`/`password` aliases for application env
+/// injection, `POSTGRES_*` keys for the database container, and a
+/// fully-formed `DATABASE_URL` connection string for compatibility.
 pub(crate) fn build_db_secret(app: &Project) -> Result<Secret, Error> {
 	let labels = standard_labels(app, Component::Database);
 	let namespace = super::require_namespace(app)?;
@@ -79,6 +80,8 @@ pub(crate) fn build_db_secret(app: &Project) -> Result<Secret, Error> {
 		},
 		type_: Some("Opaque".to_string()),
 		string_data: Some(BTreeMap::from([
+			("username".to_string(), user.clone()),
+			("password".to_string(), password.clone()),
 			("POSTGRES_USER".to_string(), user),
 			("POSTGRES_PASSWORD".to_string(), password),
 			("POSTGRES_DB".to_string(), db),
@@ -264,6 +267,8 @@ mod tests {
 		let data = secret.string_data.as_ref().unwrap();
 
 		// Assert
+		assert!(data.contains_key("username"));
+		assert!(data.contains_key("password"));
 		assert!(data.contains_key("POSTGRES_USER"));
 		assert!(data.contains_key("POSTGRES_PASSWORD"));
 		assert!(data.contains_key("POSTGRES_DB"));

--- a/crates/reinhardt-cloud-operator/src/resources/deployment.rs
+++ b/crates/reinhardt-cloud-operator/src/resources/deployment.rs
@@ -19,10 +19,7 @@ use super::security::context::{build_container_security_context, build_pod_secur
 use super::security::runtime_class::resolve_runtime_class_name;
 use super::validate_port;
 use crate::error::Error;
-use crate::inference::env_vars::{
-	build_core_secret_key_env_vars, build_database_env_vars_from_secret, build_jwt_secret_env_var,
-	build_otel_env_vars, build_redis_cache_env_var, build_system_env_vars, merge_env_vars,
-};
+use crate::inference::env_vars::build_application_env_vars;
 use crate::inference::pages::ResolvedPagesConfig;
 use crate::inference::platform::Platform;
 
@@ -76,67 +73,7 @@ pub(crate) fn build_deployment(
 
 	let owner_ref = owner_reference(app)?;
 
-	// Build merged environment variables (system + database + user overrides + OTel).
-	// Inject database connection env vars when a database will be provisioned,
-	// either via an explicit spec.database field or via introspect-derived
-	// infrastructure signals (requires_postgresql).
-	//
-	// The DB host differs between the two provisioning paths:
-	// - Explicit spec.database: "{project_name}-db" (headless Service from infer_database_resources)
-	// - Introspect path: "{project_name}-postgresql" (Service from reconcile_db_service_resource)
-	//
-	// Note: user-provided spec.env values take priority over auto-generated DB env vars
-	// (including REINHARDT_DATABASE_PASSWORD). This is intentional — users may need to
-	// override connection parameters — but plaintext credentials in spec.env are discouraged.
-	let project_name = app.name_any();
-	let explicit_db = app.spec.database.is_some();
-	let introspect_db = app.spec.introspect.as_ref().is_some_and(|i| {
-		reinhardt_cloud_core::inference::requires_postgresql(&i.features.infrastructure_signals)
-	});
-	let needs_db_env = explicit_db || introspect_db;
-	let explicit_cache = app.spec.cache.is_some();
-	let introspect_cache = app.spec.introspect.as_ref().is_some_and(|i| {
-		reinhardt_cloud_core::inference::requires_cache(&i.features.infrastructure_signals)
-	});
-	let redis_session_backend = app.spec.introspect.as_ref().is_some_and(|i| {
-		i.features.infrastructure_signals.session_backend.as_deref() == Some("redis")
-	});
-	let needs_redis_env = explicit_cache || introspect_cache || redis_session_backend;
-	let mut auto_vars = build_system_env_vars();
-	// Inject the per-app `core.secret_key` env var unconditionally so the
-	// generated `production.toml` can resolve its secret-key interpolation at
-	// startup; the value lives in the operator-managed `<app>-core-secret-key`
-	// Secret, never in the Pod spec.
-	auto_vars.extend(build_core_secret_key_env_vars(&project_name));
-	if app.spec.auth.as_ref().is_some_and(|auth| auth.jwt) {
-		auto_vars.push(build_jwt_secret_env_var(&project_name));
-	}
-	if needs_redis_env {
-		auto_vars.push(build_redis_cache_env_var(&project_name));
-	}
-	if needs_db_env {
-		let db_host = if explicit_db {
-			format!("{project_name}-db")
-		} else {
-			format!("{project_name}-postgresql")
-		};
-		auto_vars.extend(build_database_env_vars_from_secret(
-			app,
-			platform,
-			&db_host,
-			&app.spec.env,
-		));
-	}
-	let mut merged_env = merge_env_vars(&auto_vars, &app.spec.env);
-	// Append OTel variables after user-supplied vars. OTel vars are skipped
-	// when a user-supplied var with the same name already exists — user-supplied
-	// env vars take precedence over operator-injected OTel defaults.
-	let otel_vars = build_otel_env_vars(&project_name);
-	for v in otel_vars {
-		if !merged_env.iter().any(|e| e.name == v.name) {
-			merged_env.push(v);
-		}
-	}
+	let merged_env = build_application_env_vars(app, platform);
 
 	// dentdelion WASM plugin volumes and mounts. Empty when spec.plugins is
 	// absent or empty; callers of build_plugin_configmap provision the
@@ -151,30 +88,7 @@ pub(crate) fn build_deployment(
 	let mut volumes: Vec<Volume> = plugin_volumes;
 	let volume_mounts: Vec<VolumeMount> = plugin_mounts;
 
-	// Init container for database migrations when database will be provisioned
-	let mut init_containers: Vec<Container> = if needs_db_env {
-		vec![Container {
-			name: "migrate".to_string(),
-			image: Some(app.spec.image.clone()),
-			command: Some(vec!["manage".to_string(), "migrate".to_string()]),
-			env: Some(merged_env.clone()),
-			volume_mounts: Some(volume_mounts.clone()),
-			resources: Some(ResourceRequirements {
-				requests: Some(BTreeMap::from([
-					("cpu".to_string(), Quantity("100m".to_string())),
-					("memory".to_string(), Quantity("128Mi".to_string())),
-				])),
-				limits: Some(BTreeMap::from([
-					("cpu".to_string(), Quantity("500m".to_string())),
-					("memory".to_string(), Quantity("256Mi".to_string())),
-				])),
-				..Default::default()
-			}),
-			..Default::default()
-		}]
-	} else {
-		Vec::new()
-	};
+	let mut init_containers: Vec<Container> = Vec::new();
 
 	let isolated = app.spec.isolation.is_some();
 
@@ -190,7 +104,7 @@ pub(crate) fn build_deployment(
 			..Default::default()
 		});
 
-		// collectstatic initContainer (after migrate)
+		// collectstatic initContainer
 		let mut collectstatic_mounts = volume_mounts.clone();
 		collectstatic_mounts.push(VolumeMount {
 			name: "static-files".to_string(),
@@ -365,9 +279,9 @@ pub(crate) fn build_deployment(
 					volumes: Some(volumes),
 					// Forward spec.imagePullSecrets verbatim so the kubelet can
 					// authenticate to private registries when pulling the main
-					// application container, the migrate init-container, the
-					// collectstatic init-container, and the static-server
-					// sidecar — they all share this PodSpec.
+					// application container, the collectstatic init-container,
+					// and the static-server sidecar — they all share this
+					// PodSpec.
 					image_pull_secrets: app.spec.image_pull_secrets.clone(),
 					// Bind the workload to a per-app KSA when configured.
 					// The name resolution is centralized in
@@ -668,7 +582,7 @@ mod tests {
 	}
 
 	#[rstest]
-	fn test_build_deployment_includes_init_container_when_database() {
+	fn test_build_deployment_has_no_migration_init_container_when_database() {
 		// Arrange
 		let app = make_test_app_with_database();
 
@@ -678,11 +592,12 @@ mod tests {
 		let pod_spec = deployment.spec.unwrap().template.spec.unwrap();
 
 		// Assert
-		let init_containers = pod_spec.init_containers.unwrap();
-		assert_eq!(init_containers.len(), 1);
-		assert_eq!(init_containers[0].name, "migrate");
-		let expected_command = vec!["manage".to_string(), "migrate".to_string()];
-		assert_eq!(init_containers[0].command.as_ref(), Some(&expected_command));
+		assert!(
+			pod_spec
+				.init_containers
+				.as_deref()
+				.is_none_or(|containers| !containers.iter().any(|c| c.name == "migrate"))
+		);
 	}
 
 	#[rstest]
@@ -838,20 +753,14 @@ mod tests {
 			build_deployment(&app, None, &Platform::Onpremise).expect("build should succeed");
 		let pod_spec = deployment.spec.unwrap().template.spec.unwrap();
 		let main_env = pod_spec.containers[0].env.as_ref().unwrap();
-		let init_env = pod_spec.init_containers.as_ref().unwrap()[0]
-			.env
-			.as_ref()
-			.unwrap();
 
 		// Assert
-		for env in [main_env, init_env] {
-			let var = env
-				.iter()
-				.find(|e| e.name == "REINHARDT_CLOUD_REDIS_URL")
-				.expect("Redis URL env must exist");
-			assert_eq!(var.value.as_deref(), Some("redis://web-redis:6379/0"));
-			assert!(var.value_from.is_none());
-		}
+		let var = main_env
+			.iter()
+			.find(|e| e.name == "REINHARDT_CLOUD_REDIS_URL")
+			.expect("Redis URL env must exist");
+		assert_eq!(var.value.as_deref(), Some("redis://web-redis:6379/0"));
+		assert!(var.value_from.is_none());
 	}
 
 	#[rstest]
@@ -872,45 +781,63 @@ mod tests {
 	}
 
 	#[rstest]
-	fn test_build_deployment_init_container_has_same_image_as_main() {
+	fn test_build_deployment_collectstatic_has_same_image_as_main() {
 		// Arrange
-		let app = make_test_app_with_database();
+		let app = make_test_app("web", "web:latest", None);
+		let pages = make_default_pages_config();
 
 		// Act
-		let deployment =
-			build_deployment(&app, None, &Platform::Onpremise).expect("build should succeed");
+		let deployment = build_deployment(&app, Some(&pages), &Platform::Onpremise)
+			.expect("build should succeed");
 		let pod_spec = deployment.spec.unwrap().template.spec.unwrap();
 
 		// Assert
 		let main_image = pod_spec.containers[0].image.as_deref();
-		let init_image = pod_spec.init_containers.as_ref().unwrap()[0]
-			.image
-			.as_deref();
+		let collectstatic = pod_spec
+			.init_containers
+			.as_ref()
+			.unwrap()
+			.iter()
+			.find(|container| container.name == "collectstatic")
+			.expect("collectstatic init container should exist");
+		let init_image = collectstatic.image.as_deref();
 		assert_eq!(main_image, init_image);
 		assert_eq!(main_image, Some("web:latest"));
 	}
 
 	#[rstest]
-	fn test_build_deployment_init_container_has_resource_limits() {
+	fn test_build_deployment_collectstatic_extends_main_env() {
 		// Arrange
-		let app = make_test_app_with_database();
+		let app = make_test_app("web", "web:latest", None);
+		let pages = make_default_pages_config();
 
 		// Act
-		let deployment =
-			build_deployment(&app, None, &Platform::Onpremise).expect("build should succeed");
+		let deployment = build_deployment(&app, Some(&pages), &Platform::Onpremise)
+			.expect("build should succeed");
 		let pod_spec = deployment.spec.unwrap().template.spec.unwrap();
-		let init_container = &pod_spec.init_containers.as_ref().unwrap()[0];
+		let main_env = pod_spec.containers[0].env.as_ref().unwrap();
+		let collectstatic = pod_spec
+			.init_containers
+			.as_ref()
+			.unwrap()
+			.iter()
+			.find(|container| container.name == "collectstatic")
+			.expect("collectstatic init container should exist");
+		let collectstatic_env = collectstatic.env.as_ref().unwrap();
 
 		// Assert
-		let resources = init_container.resources.as_ref().unwrap();
-		assert!(resources.requests.is_some());
-		assert!(resources.limits.is_some());
-		let requests = resources.requests.as_ref().unwrap();
-		assert!(requests.contains_key("cpu"));
-		assert!(requests.contains_key("memory"));
-		let limits = resources.limits.as_ref().unwrap();
-		assert!(limits.contains_key("cpu"));
-		assert!(limits.contains_key("memory"));
+		for env in main_env {
+			assert!(
+				collectstatic_env
+					.iter()
+					.any(|candidate| candidate.name == env.name),
+				"collectstatic env should include {}",
+				env.name
+			);
+		}
+		assert!(collectstatic_env.iter().any(|env| {
+			env.name == "REINHARDT_STATIC_ROOT" && env.value.as_deref() == Some("/app/staticfiles")
+		}));
 	}
 
 	#[rstest]
@@ -933,23 +860,6 @@ mod tests {
 		// Verify no duplicates
 		let count = env.iter().filter(|e| e.name == "REINHARDT_ENV").count();
 		assert_eq!(count, 1);
-	}
-
-	#[rstest]
-	fn test_build_deployment_init_container_shares_env_with_main() {
-		// Arrange
-		let app = make_test_app_with_database();
-
-		// Act
-		let deployment =
-			build_deployment(&app, None, &Platform::Onpremise).expect("build should succeed");
-		let pod_spec = deployment.spec.unwrap().template.spec.unwrap();
-		let main_env = pod_spec.containers[0].env.clone();
-		let init_containers = pod_spec.init_containers.unwrap();
-		let init_env = init_containers[0].env.clone();
-
-		// Assert
-		assert_eq!(main_env, init_env);
 	}
 
 	// ── Pages sidecar tests ───────────────────────────────────────────
@@ -1337,8 +1247,8 @@ mod tests {
 
 		// Arrange — a pages-enabled deployment shares the same PodSpec
 		// across the main container, the static-server sidecar, and the
-		// migrate / collectstatic init-containers, so a single pod-level
-		// imagePullSecrets covers them all.
+		// collectstatic init-container, so a single pod-level imagePullSecrets
+		// setting covers them all.
 		let mut app = make_test_app_with_database();
 		app.spec.image_pull_secrets = Some(vec![LocalObjectReference {
 			name: "regcred".to_string(),
@@ -1358,7 +1268,7 @@ mod tests {
 		assert_eq!(pull_secrets[0].name, "regcred");
 		// Sanity check: the PodSpec really does host the additional containers.
 		let init_containers = pod_spec.init_containers.as_ref().unwrap();
-		assert!(init_containers.iter().any(|c| c.name == "migrate"));
+		assert!(!init_containers.iter().any(|c| c.name == "migrate"));
 		assert!(init_containers.iter().any(|c| c.name == "collectstatic"));
 		assert!(
 			pod_spec

--- a/crates/reinhardt-cloud-operator/src/resources/migration.rs
+++ b/crates/reinhardt-cloud-operator/src/resources/migration.rs
@@ -227,7 +227,10 @@ mod tests {
 		let revision_key = migration_revision_key(&app);
 
 		// Assert
-		assert!(revision_key.contains("@sha256:0123456789abcdef"));
+		assert_eq!(
+			revision_key,
+			"image=registry.example.com/my-app@sha256:0123456789abcdef;version=unknown"
+		);
 	}
 
 	#[rstest]
@@ -258,7 +261,11 @@ mod tests {
 
 		// Assert
 		assert!(name.len() <= 63);
-		assert!(name.contains("-migrate-"));
+		let (prefix, suffix) = name
+			.rsplit_once("-migrate-")
+			.expect("job name must include -migrate- delimiter");
+		assert_eq!(suffix.len(), REVISION_ID_HEX_LEN);
+		assert!(!prefix.is_empty());
 	}
 
 	#[rstest]

--- a/crates/reinhardt-cloud-operator/src/resources/migration.rs
+++ b/crates/reinhardt-cloud-operator/src/resources/migration.rs
@@ -1,33 +1,93 @@
 //! Migration Job builder for operator-managed `Project` resources.
 
+use std::collections::BTreeMap;
+
 use k8s_openapi::api::batch::v1::{Job, JobSpec};
-use k8s_openapi::api::core::v1::{
-	Container, EnvFromSource, PodSpec, PodTemplateSpec, SecretEnvSource,
-};
+use k8s_openapi::api::core::v1::{Container, PodSpec, PodTemplateSpec};
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use kube::ResourceExt;
 use reinhardt_cloud_types::crd::Project;
 
 use super::labels::{Component, owner_reference, standard_labels};
 use crate::error::Error;
+use crate::inference::env_vars::build_application_env_vars;
+use crate::inference::platform::Platform;
+
+/// Label carrying the short revision identifier used by migration Jobs.
+pub(crate) const MIGRATION_REVISION_LABEL: &str = "paas.reinhardt-cloud.dev/migration-revision";
+/// Annotation carrying the full migration revision key for diagnostics.
+pub(crate) const MIGRATION_REVISION_KEY_ANNOTATION: &str =
+	"paas.reinhardt-cloud.dev/migration-revision-key";
+
+const JOB_NAME_MAX_LEN: usize = 63;
+const REVISION_ID_HEX_LEN: usize = 16;
+
+/// Derives the migration revision key for a `Project`.
+///
+/// The key is intentionally based on the image reference and application
+/// version currently present in the CRD. If the image reference includes a
+/// digest, the digest is part of the key.
+pub(crate) fn migration_revision_key(app: &Project) -> String {
+	let app_version = app
+		.spec
+		.introspect
+		.as_ref()
+		.map(|introspect| introspect.app.version.trim())
+		.filter(|version| !version.is_empty())
+		.unwrap_or("unknown");
+	format!("image={};version={app_version}", app.spec.image)
+}
+
+/// Builds a stable short identifier for the migration revision key.
+pub(crate) fn migration_revision_id(revision_key: &str) -> String {
+	let mut hash = 0xcbf29ce484222325u64;
+	for byte in revision_key.as_bytes() {
+		hash ^= u64::from(*byte);
+		hash = hash.wrapping_mul(0x100000001b3);
+	}
+	format!("{hash:0width$x}", width = REVISION_ID_HEX_LEN)
+}
+
+/// Builds the Kubernetes Job name for a project/revision pair.
+pub(crate) fn migration_job_name(app: &Project, revision_key: &str) -> String {
+	let revision_id = migration_revision_id(revision_key);
+	let suffix = format!("-migrate-{revision_id}");
+	let max_prefix_len = JOB_NAME_MAX_LEN.saturating_sub(suffix.len());
+	let mut prefix: String = app.name_any().chars().take(max_prefix_len).collect();
+	prefix = prefix.trim_matches('-').to_string();
+	if prefix.is_empty() {
+		prefix = "project".to_string();
+	}
+	format!("{prefix}{suffix}")
+}
 
 /// Builds a `Job` that runs database migrations for the given `Project`.
 ///
 /// The job uses the same image as the application and executes
-/// `["manage", "migrate"]`. Database credentials are injected from the
-/// `{project_name}-db-credentials` secret via `envFrom`.
-pub(crate) fn build_migration_job(app: &Project) -> Result<Job, Error> {
+/// `["manage", "migrate"]`. The environment matches the application
+/// workload so migrations use the same database and settings contract.
+pub(crate) fn build_migration_job(
+	app: &Project,
+	platform: &Platform,
+	revision_key: &str,
+) -> Result<Job, Error> {
 	let namespace = super::require_namespace(app)?;
-	let labels = standard_labels(app, Component::Migration);
+	let revision_id = migration_revision_id(revision_key);
+	let mut labels = standard_labels(app, Component::Migration);
+	labels.insert(MIGRATION_REVISION_LABEL.to_string(), revision_id.clone());
 	let owner_ref = owner_reference(app)?;
-	let project_name = app.name_any();
-	let secret_name = format!("{}-db-credentials", project_name);
+	let job_name = migration_job_name(app, revision_key);
+	let annotations = BTreeMap::from([(
+		MIGRATION_REVISION_KEY_ANNOTATION.to_string(),
+		revision_key.to_string(),
+	)]);
 
 	Ok(Job {
 		metadata: ObjectMeta {
-			name: Some(format!("{}-migrate", project_name)),
+			name: Some(job_name),
 			namespace: Some(namespace),
 			labels: Some(labels.clone()),
+			annotations: Some(annotations),
 			owner_references: Some(vec![owner_ref]),
 			..Default::default()
 		},
@@ -44,13 +104,7 @@ pub(crate) fn build_migration_job(app: &Project) -> Result<Job, Error> {
 						name: "migrate".to_string(),
 						image: Some(app.spec.image.clone()),
 						command: Some(vec!["manage".to_string(), "migrate".to_string()]),
-						env_from: Some(vec![EnvFromSource {
-							secret_ref: Some(SecretEnvSource {
-								name: secret_name,
-								..Default::default()
-							}),
-							..Default::default()
-						}]),
+						env: Some(build_application_env_vars(app, platform)),
 						..Default::default()
 					}],
 					// Forward spec.imagePullSecrets so the migration Job can
@@ -68,8 +122,10 @@ pub(crate) fn build_migration_job(app: &Project) -> Result<Job, Error> {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::inference::platform::Platform;
 	use kube::api::ObjectMeta;
 	use reinhardt_cloud_types::crd::ProjectSpec;
+	use reinhardt_cloud_types::introspect::{AppMetadata, IntrospectOutput};
 	use rstest::rstest;
 
 	fn test_app(name: &str, image: &str) -> Project {
@@ -88,16 +144,121 @@ mod tests {
 		}
 	}
 
+	fn build_test_job(app: &Project) -> Job {
+		let revision_key = migration_revision_key(app);
+		build_migration_job(app, &Platform::Onpremise, &revision_key).expect("build should succeed")
+	}
+
+	fn set_app_version(app: &mut Project, version: &str) {
+		app.spec.introspect = Some(IntrospectOutput {
+			app: AppMetadata {
+				name: app.name_any(),
+				version: version.to_string(),
+			},
+			..Default::default()
+		});
+	}
+
+	#[rstest]
+	fn test_migration_revision_key_is_stable_for_same_image_and_version() {
+		// Arrange
+		let mut first = test_app("my-app", "registry.example.com/my-app:v1");
+		let mut second = test_app("my-app", "registry.example.com/my-app:v1");
+		set_app_version(&mut first, "1.2.3");
+		set_app_version(&mut second, "1.2.3");
+
+		// Act
+		let first_key = migration_revision_key(&first);
+		let second_key = migration_revision_key(&second);
+
+		// Assert
+		assert_eq!(first_key, second_key);
+		assert_eq!(
+			migration_revision_id(&first_key),
+			migration_revision_id(&second_key)
+		);
+	}
+
+	#[rstest]
+	fn test_migration_revision_key_changes_when_image_changes() {
+		// Arrange
+		let mut first = test_app("my-app", "registry.example.com/my-app:v1");
+		let mut second = test_app("my-app", "registry.example.com/my-app:v2");
+		set_app_version(&mut first, "1.2.3");
+		set_app_version(&mut second, "1.2.3");
+
+		// Act
+		let first_key = migration_revision_key(&first);
+		let second_key = migration_revision_key(&second);
+
+		// Assert
+		assert_ne!(first_key, second_key);
+		assert_ne!(
+			migration_revision_id(&first_key),
+			migration_revision_id(&second_key)
+		);
+	}
+
+	#[rstest]
+	fn test_migration_revision_key_changes_when_app_version_changes() {
+		// Arrange
+		let mut first = test_app("my-app", "registry.example.com/my-app:v1");
+		let mut second = test_app("my-app", "registry.example.com/my-app:v1");
+		set_app_version(&mut first, "1.2.3");
+		set_app_version(&mut second, "1.2.4");
+
+		// Act
+		let first_key = migration_revision_key(&first);
+		let second_key = migration_revision_key(&second);
+
+		// Assert
+		assert_ne!(first_key, second_key);
+	}
+
+	#[rstest]
+	fn test_migration_revision_key_includes_image_digest() {
+		// Arrange
+		let app = test_app(
+			"my-app",
+			"registry.example.com/my-app@sha256:0123456789abcdef",
+		);
+
+		// Act
+		let revision_key = migration_revision_key(&app);
+
+		// Assert
+		assert!(revision_key.contains("@sha256:0123456789abcdef"));
+	}
+
 	#[rstest]
 	fn test_build_migration_job_name() {
 		// Arrange
 		let app = test_app("my-app", "my-app:v1");
+		let revision_key = migration_revision_key(&app);
 
 		// Act
-		let job = build_migration_job(&app).expect("build should succeed");
+		let job = build_test_job(&app);
 
 		// Assert
-		assert_eq!(job.metadata.name.as_deref(), Some("my-app-migrate"));
+		let expected = format!("my-app-migrate-{}", migration_revision_id(&revision_key));
+		assert_eq!(job.metadata.name.as_deref(), Some(expected.as_str()));
+	}
+
+	#[rstest]
+	fn test_build_migration_job_name_is_kubernetes_safe_for_long_project_name() {
+		// Arrange
+		let app = test_app(
+			"very-long-project-name-that-would-exceed-the-job-name-limit-with-suffix",
+			"my-app:v1",
+		);
+
+		// Act
+		let job = build_test_job(&app);
+		let name = job.metadata.name.expect("job name should be set");
+
+		// Assert
+		assert!(name.len() <= 63);
+		assert!(name.contains("-migrate-"));
 	}
 
 	#[rstest]
@@ -106,7 +267,7 @@ mod tests {
 		let app = test_app("my-app", "my-app:v1");
 
 		// Act
-		let job = build_migration_job(&app).expect("build should succeed");
+		let job = build_test_job(&app);
 		let container = &job.spec.unwrap().template.spec.unwrap().containers[0];
 
 		// Assert
@@ -122,7 +283,7 @@ mod tests {
 		let app = test_app("my-app", "registry.example.com/my-app:v2");
 
 		// Act
-		let job = build_migration_job(&app).expect("build should succeed");
+		let job = build_test_job(&app);
 		let container = &job.spec.unwrap().template.spec.unwrap().containers[0];
 
 		// Assert
@@ -138,7 +299,7 @@ mod tests {
 		let app = test_app("my-app", "my-app:v1");
 
 		// Act
-		let job = build_migration_job(&app).expect("build should succeed");
+		let job = build_test_job(&app);
 		let pod_spec = job.spec.unwrap().template.spec.unwrap();
 
 		// Assert
@@ -151,10 +312,35 @@ mod tests {
 		let app = test_app("my-app", "my-app:v1");
 
 		// Act
-		let job = build_migration_job(&app).expect("build should succeed");
+		let job = build_test_job(&app);
 
 		// Assert
 		assert_eq!(job.spec.unwrap().backoff_limit, Some(3));
+	}
+
+	#[rstest]
+	fn test_build_migration_job_sets_revision_metadata() {
+		// Arrange
+		let app = test_app("my-app", "my-app:v1");
+		let revision_key = migration_revision_key(&app);
+		let revision_id = migration_revision_id(&revision_key);
+
+		// Act
+		let job = build_test_job(&app);
+
+		// Assert
+		let labels = job.metadata.labels.expect("labels should be set");
+		let annotations = job.metadata.annotations.expect("annotations should be set");
+		assert_eq!(
+			labels.get(MIGRATION_REVISION_LABEL).map(String::as_str),
+			Some(revision_id.as_str())
+		);
+		assert_eq!(
+			annotations
+				.get(MIGRATION_REVISION_KEY_ANNOTATION)
+				.map(String::as_str),
+			Some(revision_key.as_str())
+		);
 	}
 
 	// ── Image pull secrets tests ───────────────────────────────────────────
@@ -165,7 +351,7 @@ mod tests {
 		let app = test_app("my-app", "my-app:v1");
 
 		// Act
-		let job = build_migration_job(&app).expect("build should succeed");
+		let job = build_test_job(&app);
 		let pod_spec = job.spec.unwrap().template.spec.unwrap();
 
 		// Assert
@@ -183,7 +369,7 @@ mod tests {
 		}]);
 
 		// Act
-		let job = build_migration_job(&app).expect("build should succeed");
+		let job = build_test_job(&app);
 		let pod_spec = job.spec.unwrap().template.spec.unwrap();
 
 		// Assert
@@ -210,7 +396,7 @@ mod tests {
 		]);
 
 		// Act
-		let job = build_migration_job(&app).expect("build should succeed");
+		let job = build_test_job(&app);
 		let pod_spec = job.spec.unwrap().template.spec.unwrap();
 
 		// Assert

--- a/crates/reinhardt-cloud-types/src/crd/status.rs
+++ b/crates/reinhardt-cloud-types/src/crd/status.rs
@@ -14,6 +14,8 @@ pub enum ConditionType {
 	Ready,
 	Progressing,
 	Degraded,
+	/// Database migration for the active deployment revision has completed.
+	MigrationReady,
 	/// Database sub-resource is provisioned and reachable
 	DatabaseReady,
 	/// Cache sub-resource is provisioned and reachable
@@ -122,6 +124,7 @@ mod tests {
 			(ConditionType::Ready, "\"Ready\""),
 			(ConditionType::Progressing, "\"Progressing\""),
 			(ConditionType::Degraded, "\"Degraded\""),
+			(ConditionType::MigrationReady, "\"MigrationReady\""),
 			(ConditionType::DatabaseReady, "\"DatabaseReady\""),
 			(ConditionType::CacheReady, "\"CacheReady\""),
 			(ConditionType::WorkerReady, "\"WorkerReady\""),

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -201,7 +201,8 @@ kubectl -n reinhardt-cloud-system get pods \
   -l app.kubernetes.io/name=reinhardt-cloud-dashboard
 ```
 
-The `Project` status surfaces standard Kubernetes conditions
-(`Ready`, `Progressing`, `Degraded`). If `Ready` stays `False` for longer
-than the workflow's wait timeout, investigate the operator logs before
-re-running the workflow.
+The `Project` status surfaces standard Kubernetes conditions including
+`Ready`, `MigrationReady`, `Progressing`, and `Degraded`. If `Ready` or a
+database-backed deployment's `MigrationReady` stays `False` for longer than
+the workflow's wait timeout, investigate the operator logs before re-running
+the workflow.

--- a/docs/tools/operator.md
+++ b/docs/tools/operator.md
@@ -197,11 +197,18 @@ From `charts/reinhardt-cloud-operator/crds/`:
 | Field | Type | Description |
 |---|---|---|
 | `phase` | `ProjectPhase` | Top-level application lifecycle phase. Values: `pending`, `provisioning`, `deploying`, `running`, `degraded`, `failed`, `terminating` |
-| `conditions` | `[]Condition` | Standard Kubernetes conditions. Observed types: `Ready`, `Progressing`, `Degraded` |
+| `conditions` | `[]Condition` | Standard Kubernetes conditions. Observed types include `Ready`, `Progressing`, `Degraded`, `MigrationReady`, `DatabaseReady`, `CacheReady`, `WorkerReady`, `IngressReady` |
 | `database.phase` | `ResourcePhase` | Database provisioning phase. Values: `Pending`, `Provisioning`, `Ready`, `Failed` |
 | `cache.phase` | `ResourcePhase` | Cache provisioning phase. Same values as `database.phase` |
 | `worker.phase` | `ResourcePhase` | Worker deployment phase. Same values as `database.phase` |
 | `observedGeneration` | int64 | Last generation observed by the controller |
+
+For projects that provision PostgreSQL, the operator creates a migration Job
+for each deployment revision and waits for it before applying the new
+application `Deployment`. A running migration reports `MigrationReady=False`
+with reason `MigrationRunning`; a failed migration reports
+`MigrationReady=False`, `Degraded=True`, and leaves the current workload
+unchanged.
 
 Note: the served/storage version matrix may change release-to-release. The upcoming
 `reinhardt-cloud crd generate` workflow pins a specific version at CLI build time; tracking at


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds revision-scoped migration Jobs derived from the Project image and app version.
- Gates workload Deployment reconciliation until the target migration Job succeeds.
- Removes the duplicate `manage migrate` Deployment init container.
- Surfaces rollout migration state through the `MigrationReady` Project condition.
- Updates RBAC, CRD output, docs, and focused tests for the migration lifecycle.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

The operator previously had two migration paths: a migration Job builder and a per-Pod `manage migrate` init container. That made migration execution duplicate-prone and did not provide deployment-aware rollout ordering.

This change gives migrations a single atomic rollout gate. Each deployment revision gets a stable migration Job name, the operator waits for that Job before applying the workload Deployment, and failed migrations block rollout with degraded Project status.

Fixes #706

Related to: #

## How Was This Tested?

- `cargo test -p reinhardt-cloud-types`
- `cargo test -p reinhardt-cloud-operator`
- `cargo make generate-crd`
- `cargo make clippy-check`
- `git diff --check`
- `cargo make fmt-check`
  - Failed only on pre-existing dashboard DSL formatter output in files not touched by this PR:
    - `dashboard/src/apps/auth/client/components/oauth_buttons.rs`
    - `dashboard/src/apps/auth/client/pages/account.rs`
    - `dashboard/src/apps/clusters/client/pages/list.rs`
    - `dashboard/src/apps/github/client/pages/list.rs`
    - `dashboard/src/apps/deployments/client/pages/list.rs`

## Performance Impact

Not performance-related.

## Breaking Changes

None.

**Migration Guide:**

No manual migration is required. Database-backed Projects now run migrations through revision-scoped Jobs before the workload Deployment advances.

## Screenshots

Not a UI change.

### Before

N/A

### After

N/A

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #706

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [x] `kubernetes` - Kubernetes resources, controllers, operators
- [x] `deployment` - Application deployment logic
- [ ] `networking` - Ingress, services, network policies
- [x] `storage` - Persistent volumes, storage classes
- [ ] `auth` - Authentication, authorization, RBAC
- [ ] `api` - REST API, serializers, handlers
- [ ] `cli` - Command-line interface
- [x] `config` - Configuration management
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The PR intentionally leaves failed migration Jobs in place for inspection instead of deleting and recreating them on every reconcile.

Generated with [Codex](https://openai.com/codex)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added migration readiness status condition to track database schema updates
  * Deployments now wait for migration completion before rolling out new versions, preventing schema incompatibility
  * Enhanced status conditions for migration progress and failure reporting

* **Documentation**
  * Updated operator CRD documentation with migration condition details and troubleshooting guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->