### PR TITLE
docs: align dashboard self-hosting manifest references with Project CRD

### DIFF
--- a/.github/workflows/build-release-assets.yml
+++ b/.github/workflows/build-release-assets.yml
@@ -169,7 +169,7 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         # release-plz tags look like `reinhardt-cloud-dashboard@v0.1.0`.
         # The portion after `@` is the semver we want on the image tag.
-        # Match `manifests/dashboard-app.yaml::spec.image`, which expects
+        # Match `manifests/dashboard-project.yaml::spec.image`, which expects
         # the leading `v` to be stripped (the deploy workflow does the
         # same on its side).
         run: |

--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -1,6 +1,6 @@
 name: Deploy Dashboard
 
-# Applies the canonical dashboard ReinhardtApp manifest whenever a new
+# Applies the canonical dashboard Project manifest whenever a new
 # release is published. Also runnable manually via workflow_dispatch so that
 # operators can pin a specific version without cutting a new release.
 #
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   deploy-dashboard:
-    name: Deploy dashboard via ReinhardtApp
+    name: Deploy dashboard via Project
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -61,7 +61,7 @@ jobs:
 
       - name: Configure kubeconfig
         # The KUBECONFIG secret must contain a base64-encoded kubeconfig that
-        # grants permission to apply ReinhardtApp resources in the
+        # grants permission to apply Project resources in the
         # reinhardt-cloud-system namespace. Cluster operators should scope
         # this credential tightly (see docs/self-hosting.md).
         env:
@@ -81,18 +81,18 @@ jobs:
         run: |
           # Substitute the __VERSION__ placeholder so the committed manifest
           # stays generic while the applied manifest pins a concrete tag.
-          sed "s|__VERSION__|${VERSION}|g" manifests/dashboard-app.yaml \
-            > /tmp/dashboard-app.rendered.yaml
+          sed "s|__VERSION__|${VERSION}|g" manifests/dashboard-project.yaml \
+            > /tmp/dashboard-project.rendered.yaml
           echo "Rendered manifest:"
-          cat /tmp/dashboard-app.rendered.yaml
+          cat /tmp/dashboard-project.rendered.yaml
 
-      - name: Apply ReinhardtApp manifest
+      - name: Apply Project manifest
         run: |
-          kubectl apply -f /tmp/dashboard-app.rendered.yaml
+          kubectl apply -f /tmp/dashboard-project.rendered.yaml
 
       - name: Wait for rollout
         run: |
           kubectl -n reinhardt-cloud-system wait \
             --for=condition=Ready \
             --timeout=5m \
-            reinhardtapp/reinhardt-cloud-dashboard
+            project/reinhardt-cloud-dashboard

--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ Breaking changes will be documented in release notes.
 ## Self-hosting
 
 The Reinhardt Cloud Dashboard can be self-hosted through its own operator
-as a `Project`. A canonical manifest (`manifests/dashboard-app.yaml`)
+as a `Project`. A canonical manifest (`manifests/dashboard-project.yaml`)
 and a release-triggered deploy workflow
 (`.github/workflows/deploy-dashboard.yml`) implement this GitOps-driven
 dogfooding flow. See [docs/self-hosting.md](docs/self-hosting.md) for

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -18,7 +18,7 @@ This page covers:
 - [Observability](#observability)
 - [Deployment flow architecture](architecture/deployment-flow.md)
 
-The canonical manifest lives at [`manifests/dashboard-app.yaml`](../manifests/dashboard-app.yaml)
+The canonical manifest lives at [`manifests/dashboard-project.yaml`](../manifests/dashboard-project.yaml)
 and the workflow at
 [`.github/workflows/deploy-dashboard.yml`](../.github/workflows/deploy-dashboard.yml).
 
@@ -129,7 +129,7 @@ placeholder; replace the placeholder values (`<region>`, `<project-id>`,
 
    ```bash
    VERSION=1.0.0
-   sed "s|__VERSION__|${VERSION}|g" manifests/dashboard-app.yaml \
+   sed "s|__VERSION__|${VERSION}|g" manifests/dashboard-project.yaml \
      | kubectl apply -f -
    ```
 

--- a/docs/tools/dashboard.md
+++ b/docs/tools/dashboard.md
@@ -134,7 +134,7 @@ There is no `settings` application module in `dashboard/src/apps/` at this commi
 
 ### Installation options
 
-There is no Helm chart for the Dashboard. The `charts/` directory contains only `charts/reinhardt-cloud-operator/`. Deploy the Dashboard by applying the canonical `Project` manifest in `manifests/dashboard-app.yaml`.
+There is no Helm chart for the Dashboard. The `charts/` directory contains only `charts/reinhardt-cloud-operator/`. Deploy the Dashboard by applying the canonical `Project` manifest in `manifests/dashboard-project.yaml`.
 
 The published Dashboard image contains two runtime binaries:
 


### PR DESCRIPTION
## Summary

- Point dashboard self-hosting docs (`README.md`, `docs/self-hosting.md`, `docs/tools/dashboard.md`) at the canonical `manifests/dashboard-project.yaml`.
- Align `.github/workflows/deploy-dashboard.yml` with the `Project` CRD: rename the render source/output, switch `ReinhardtApp` terminology to `Project` (header comment, job name, kubeconfig comment, apply step), and target `project/reinhardt-cloud-dashboard` in the rollout-wait step (the operator writes the `Ready` condition onto `Project` status).
- Update the image-tag contract comment in `.github/workflows/build-release-assets.yml`.

## Type of Change

- [x] Documentation update
- [x] CI/CD workflow change
- [ ] Bug fix (code)
- [ ] New feature
- [ ] Breaking change

## Motivation and Context

The dashboard self-hosting surface was renamed from the `ReinhardtApp` CRD to `Project`, and the canonical manifest from `manifests/dashboard-app.yaml` to `manifests/dashboard-project.yaml`. Docs and the deploy workflow still referenced the old filename/kind, so the documented bootstrap path and the workflow's wait target no longer matched the committed manifest or the reconciled `Project` resource.

Fixes #710

## How Was This Tested

- `actionlint` clean on both modified workflows.
- `grep` confirms zero remaining `dashboard-app.yaml`, `reinhardtapp/reinhardt-cloud-dashboard`, and dashboard-context `ReinhardtApp` references in `README.md`, `docs/`, and `.github/workflows/`.
- Doc link target resolves to the existing `manifests/dashboard-project.yaml`.
- No Rust code changed, so no unit/integration tests apply.

## Checklist

- [x] Code follows project style guidelines
- [x] Documentation is updated (this PR *is* the doc update)
- [x] Commit history is clean and logical (two intent-grouped commits: docs, ci)
- [x] PR description is complete and accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated self-hosting guides, installation instructions, and README with current deployment configuration references for the Reinhardt Cloud Dashboard, ensuring users have accurate setup guidance.

* **Chores**
  * Updated internal deployment workflows and manifest configurations to align with the latest specifications for consistent dashboard deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->