### PR TITLE
docs: align agent policies with reinhardt-web

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,7 +175,7 @@ Autonomously Allowed (no per-action confirmation required):
 | `git commit` | On any non-protected branch |
 | `git push` | On any non-protected branch (`feature/...`, `fix/...`, `refactor/...`, `docs/...`, `chore/...`, `test/...`, `perf/...`, `debug/...`, etc.); **never** on `main`, `master`, `develop/*`, or `release/*` |
 | Create a **Draft** Pull Request | `gh pr create --draft` / MCP `create_pull_request` with `draft=true`; body MUST follow `.github/PULL_REQUEST_TEMPLATE.md` |
-| Convert Draft PR to **Ready for Review** | **Implementation-complete is the only readiness criterion** — CI completion is **not** required (overrides any "CI green" criterion elsewhere in this document or in `instructions/`) |
+| Convert Draft PR to **Ready for Review** | **CI completion is not required** — this overrides any "CI green / tests pass" criterion in `instructions/`. All other PC-4a readiness criteria (implementation complete, PR description follows template, fmt/clippy clean, docs updated) still apply — see `instructions/PR_GUIDELINE.md` § PC-4a |
 | Create an Issue | `gh issue create` / MCP `issue_write`; MUST follow the appropriate issue template and apply at least one type label |
 
 **Protected Branches** (commit/push always require explicit user authorization):
@@ -189,9 +189,7 @@ Still Requires Explicit User Authorization (no autonomy):
 - `git push --force`, `--force-with-lease`, or any other history-rewriting push
 - `git rebase`, `git reset --hard`, `git branch -D`, deleting tags, or any other history-destructive operation
 - Closing, merging, or deleting PRs
-- Closing or deleting Issues
-- Deleting or hiding comments (on PRs, Issues, or commits)
-- Resolving or unresolving review threads
+- Closing or deleting Issues, comments, or review threads
 - Creating release tags or any PR carrying the `release` label
 - Posting comments / replies / reviews on PRs/Issues — the comment-posting authorization model in `instructions/GITHUB_INTERACTION.md` PP-1 is unchanged; the autonomous policy covers only the **creation** of commits, pushes, Draft PRs, and Issues, not commenting
 
@@ -201,9 +199,17 @@ Unchanged Quality Guardrails (apply equally to autonomous operations):
 - Issue body MUST follow `.github/ISSUE_TEMPLATE/*.yml`
 - Branch naming, commit message format, Codex attribution footer, English-only policy, and all other rules in this document remain in force
 
+**Draft PR Policy:**
+- The agent MAY convert a Draft PR to Ready for Review autonomously once the PC-4a readiness criteria are met. CI completion is **not** required (the Autonomous Operation Policy overrides the previous "CI green / tests pass" prerequisite); fmt/clippy cleanliness and the other PC-4a criteria are still required
+- Explicit user instruction also authorizes conversion at any time (overrides readiness check)
+- The agent MUST NOT convert when any PC-4a readiness criterion (other than CI completion) is unmet, unless the user explicitly overrides
+- Use `gh pr ready <number>` (or GitHub MCP equivalent) for conversion
+- See instructions/PR_GUIDELINE.md § PC-4a for full details
+
 **Branch Operations:**
 - When merging branches and resolving conflicts, execute immediately without entering Plan Mode
 - Before creating branches, verify names don't conflict with existing ones using `git worktree list` and `git branch -a`
+- Issue-linked branches: `<type>/issue-XXXX-to-YYYY-<desc>` (range), `<type>/issue-XXXX-to-YYYY-and-WWWW-to-ZZZZ-<desc>` (multiple ranges)
 
 **PR Conflict Resolution:**
 - **MUST** use worktree-based merge strategy for resolving PR conflicts (NOT rebase or force-push)
@@ -254,7 +260,14 @@ See instructions/COMMIT_GUIDELINE.md for detailed commit guidelines including:
 
 ### Release & Publishing Policy
 
-This project manages releases manually using conventional commits and GitHub releases.
+**Automated Releases with release-plz:**
+
+This project uses [release-plz](https://release-plz.ieni.dev/) for automated release management:
+
+- **Automated Versioning**: Versions determined from conventional commits
+- **Automated CHANGELOGs**: Generated from commit messages
+- **Release PRs**: Automatically created when changes are pushed to main
+- **GitHub Releases**: Application and binary packages are released through GitHub Releases, not crates.io
 
 **Commit-to-Version Mapping:**
 
@@ -281,10 +294,29 @@ This project manages releases manually using conventional commits and GitHub rel
 | `test` | Testing |
 | `style` | Styling |
 
+**Tagging Strategy (Per-Package Tagging):**
+- Format: `[package-name]@v[version]`
+  - Examples: `reinhardt-cloud@v0.1.0`, `reinhardt-cloud-cli@v0.1.0`
+- Tags are created automatically by release-plz upon Release PR merge
+- **NEVER** create release tags manually
+
+**Release Workflow:**
+1. Write commits following Conventional Commits format
+2. Push to main branch
+3. release-plz creates Release PR with version bumps and CHANGELOG updates
+4. Review and merge Release PR
+5. release-plz creates GitHub Releases and Git tags according to `release-plz.toml`
+
+**Release PR Branch Policy:**
+- **NEVER** push code fixes directly to a release-plz branch (`release-plz-*` or `develop-release-plz-*`) — direct pushes bypass review and may be overwritten when release-plz regenerates the PR
+- If a code fix is needed before merging a Release PR, create a `fix/` or `hotfix/` branch from the Release PR's **base branch** (e.g., `main` or `develop/*`), open a PR targeting that base branch, and merge it — release-plz will regenerate the Release PR automatically
+- CHANGELOG or version edits on the Release PR branch are acceptable via GitHub UI when done immediately before merging (these are release metadata adjustments, not code changes)
+
 **Critical Rules:**
-- **MUST** use conventional commit format
-- **MUST** review changes before tagging a release
-- **NEVER** create release tags without confirming all CI checks pass
+- **MUST** use conventional commit format for proper version detection
+- **MUST** review Release PRs before merging
+- **NEVER** manually bump versions in feature branches
+- **NEVER** create release tags manually
 
 ### Workflow Best Practices
 
@@ -529,7 +561,7 @@ Before submitting code:
 - Delete temp files from `/tmp` immediately
 - Wait for explicit user instruction before commits (except where the Autonomous Operation Policy applies)
 - Understand that Plan Mode approval authorizes both implementation and commits
-- Treat the Autonomous Operation Policy (Reinhardt family) as a standing exception that allows commit and push on any non-protected branch (anything other than `main`/`master`/`develop/*`/`release/*`), Draft PR creation, Draft→Ready conversion (implementation-complete only — no CI requirement), and Issue creation without further confirmation
+- Treat the Autonomous Operation Policy (Reinhardt family) as a standing exception that allows commit and push on any non-protected branch (anything other than `main`/`master`/`develop/*`/`release/*`), Draft PR creation, Draft→Ready conversion once PC-4a readiness criteria are met (CI completion is not required), and Issue creation without further confirmation
 - When editing `AGENTS.md` or `CLAUDE.md`, mirror the change into the other file in the same commit (AGENTS.md ↔ CLAUDE.md sync policy)
 - Mark placeholders with `todo!()` or `// TODO:`
 - Use `#[serial(group_name)]` for global state tests
@@ -539,6 +571,7 @@ Before submitting code:
 - Start commit description with lowercase letter (e.g., `feat: add feature`)
 - Use `!` notation for breaking changes (e.g., `feat!:` or `feat(scope)!:`)
 - Write commit descriptions as standalone CHANGELOG entries (meaningful without additional context)
+- Let release-plz handle version bumps, changelog updates, GitHub Releases, and release tags from conventional commits
 - Use `security` type for security vulnerability fixes (dedicated CHANGELOG section)
 - Use `deprecated` type for marking features/APIs as deprecated (dedicated CHANGELOG section)
 - Use GitHub CLI (`gh`) for all GitHub operations (PR, issues, releases)
@@ -567,7 +600,7 @@ Before submitting code:
 - Use repository-relative paths (not absolute) in GitHub comments
 - Provide structured agent context using AC-2 template format
 - Fall back to `gh` CLI when GitHub MCP tools return errors
-- Wait for Copilot review after PR creation and handle all comments (see @instructions/PR_GUIDELINE.md RP-6)
+- Handle Copilot review comments according to @instructions/PR_GUIDELINE.md RP-6 and @instructions/GITHUB_INTERACTION.md CR-1 ~ CR-5 when authorized
 - Evaluate Copilot suggestions against project conventions before accepting
 - Resolve all Copilot review conversations before considering PR complete
 - Verify branch name uniqueness before creation (`git worktree list` and `git branch -a`)
@@ -594,6 +627,8 @@ Before submitting code:
 - Force-push, rebase-and-push, or otherwise rewrite history without explicit user authorization (the Autonomous Operation Policy does NOT cover history-rewriting pushes)
 - Close, merge, or delete PRs / Issues / comments without explicit user authorization (autonomy covers creation only, not destruction)
 - Create release tags or any PR with the `release` label without explicit user authorization
+- Push code fixes directly to a release-plz branch (`release-plz-*` or `develop-release-plz-*`)
+- Manually bump versions in feature branches
 - Commit a change that touches only `AGENTS.md` without mirroring it into `CLAUDE.md` (and vice versa)
 - Leave docs outdated after code changes
 - Document user requests or AI interactions in project documentation
@@ -639,7 +674,7 @@ Before submitting code:
 - Create PRs/Issues without following template structure
 - Enter Plan Mode for merge operations, branch deletion, or worktree cleanup
 - Retry GitHub MCP tools after errors instead of falling back to `gh` CLI
-- Leave Copilot review conversations unresolved on PRs
+- Leave Copilot review conversations unresolved on PRs when handling them is authorized
 - Accept Copilot suggestions that contradict project conventions without evaluation
 - Create branches without checking for name conflicts
 - Use rebase or force-push to resolve PR conflicts (use worktree merge instead)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,7 +175,7 @@ Autonomously Allowed (no per-action confirmation required):
 | `git commit` | On any non-protected branch |
 | `git push` | On any non-protected branch (`feature/...`, `fix/...`, `refactor/...`, `docs/...`, `chore/...`, `test/...`, `perf/...`, `debug/...`, etc.); **never** on `main`, `master`, `develop/*`, or `release/*` |
 | Create a **Draft** Pull Request | `gh pr create --draft` / MCP `create_pull_request` with `draft=true`; body MUST follow `.github/PULL_REQUEST_TEMPLATE.md` |
-| Convert Draft PR to **Ready for Review** | **Implementation-complete is the only readiness criterion** — CI completion is **not** required (overrides any "CI green" criterion elsewhere in this document or in `instructions/`) |
+| Convert Draft PR to **Ready for Review** | **CI completion is not required** — this overrides any "CI green / tests pass" criterion in `instructions/`. All other PC-4a readiness criteria (implementation complete, PR description follows template, fmt/clippy clean, docs updated) still apply — see `instructions/PR_GUIDELINE.md` § PC-4a |
 | Create an Issue | `gh issue create` / MCP `issue_write`; MUST follow the appropriate issue template and apply at least one type label |
 
 **Protected Branches** (commit/push always require explicit user authorization):
@@ -189,9 +189,7 @@ Still Requires Explicit User Authorization (no autonomy):
 - `git push --force`, `--force-with-lease`, or any other history-rewriting push
 - `git rebase`, `git reset --hard`, `git branch -D`, deleting tags, or any other history-destructive operation
 - Closing, merging, or deleting PRs
-- Closing or deleting Issues
-- Deleting or hiding comments (on PRs, Issues, or commits)
-- Resolving or unresolving review threads
+- Closing or deleting Issues, comments, or review threads
 - Creating release tags or any PR carrying the `release` label
 - Posting comments / replies / reviews on PRs/Issues — the comment-posting authorization model in `instructions/GITHUB_INTERACTION.md` PP-1 is unchanged; the autonomous policy covers only the **creation** of commits, pushes, Draft PRs, and Issues, not commenting
 
@@ -201,9 +199,17 @@ Unchanged Quality Guardrails (apply equally to autonomous operations):
 - Issue body MUST follow `.github/ISSUE_TEMPLATE/*.yml`
 - Branch naming, commit message format, Claude Code attribution footer, English-only policy, and all other rules in this document remain in force
 
+**Draft PR Policy:**
+- The agent MAY convert a Draft PR to Ready for Review autonomously once the PC-4a readiness criteria are met. CI completion is **not** required (the Autonomous Operation Policy overrides the previous "CI green / tests pass" prerequisite); fmt/clippy cleanliness and the other PC-4a criteria are still required
+- Explicit user instruction also authorizes conversion at any time (overrides readiness check)
+- The agent MUST NOT convert when any PC-4a readiness criterion (other than CI completion) is unmet, unless the user explicitly overrides
+- Use `gh pr ready <number>` (or GitHub MCP equivalent) for conversion
+- See instructions/PR_GUIDELINE.md § PC-4a for full details
+
 **Branch Operations:**
 - When merging branches and resolving conflicts, execute immediately without entering Plan Mode
 - Before creating branches, verify names don't conflict with existing ones using `git worktree list` and `git branch -a`
+- Issue-linked branches: `<type>/issue-XXXX-to-YYYY-<desc>` (range), `<type>/issue-XXXX-to-YYYY-and-WWWW-to-ZZZZ-<desc>` (multiple ranges)
 
 **PR Conflict Resolution:**
 - **MUST** use worktree-based merge strategy for resolving PR conflicts (NOT rebase or force-push)
@@ -254,7 +260,14 @@ See instructions/COMMIT_GUIDELINE.md for detailed commit guidelines including:
 
 ### Release & Publishing Policy
 
-This project manages releases manually using conventional commits and GitHub releases.
+**Automated Releases with release-plz:**
+
+This project uses [release-plz](https://release-plz.ieni.dev/) for automated release management:
+
+- **Automated Versioning**: Versions determined from conventional commits
+- **Automated CHANGELOGs**: Generated from commit messages
+- **Release PRs**: Automatically created when changes are pushed to main
+- **GitHub Releases**: Application and binary packages are released through GitHub Releases, not crates.io
 
 **Commit-to-Version Mapping:**
 
@@ -281,10 +294,29 @@ This project manages releases manually using conventional commits and GitHub rel
 | `test` | Testing |
 | `style` | Styling |
 
+**Tagging Strategy (Per-Package Tagging):**
+- Format: `[package-name]@v[version]`
+  - Examples: `reinhardt-cloud@v0.1.0`, `reinhardt-cloud-cli@v0.1.0`
+- Tags are created automatically by release-plz upon Release PR merge
+- **NEVER** create release tags manually
+
+**Release Workflow:**
+1. Write commits following Conventional Commits format
+2. Push to main branch
+3. release-plz creates Release PR with version bumps and CHANGELOG updates
+4. Review and merge Release PR
+5. release-plz creates GitHub Releases and Git tags according to `release-plz.toml`
+
+**Release PR Branch Policy:**
+- **NEVER** push code fixes directly to a release-plz branch (`release-plz-*` or `develop-release-plz-*`) — direct pushes bypass review and may be overwritten when release-plz regenerates the PR
+- If a code fix is needed before merging a Release PR, create a `fix/` or `hotfix/` branch from the Release PR's **base branch** (e.g., `main` or `develop/*`), open a PR targeting that base branch, and merge it — release-plz will regenerate the Release PR automatically
+- CHANGELOG or version edits on the Release PR branch are acceptable via GitHub UI when done immediately before merging (these are release metadata adjustments, not code changes)
+
 **Critical Rules:**
-- **MUST** use conventional commit format
-- **MUST** review changes before tagging a release
-- **NEVER** create release tags without confirming all CI checks pass
+- **MUST** use conventional commit format for proper version detection
+- **MUST** review Release PRs before merging
+- **NEVER** manually bump versions in feature branches
+- **NEVER** create release tags manually
 
 ### Workflow Best Practices
 
@@ -529,7 +561,7 @@ Before submitting code:
 - Delete temp files from `/tmp` immediately
 - Wait for explicit user instruction before commits (except where the Autonomous Operation Policy applies)
 - Understand that Plan Mode approval authorizes both implementation and commits
-- Treat the Autonomous Operation Policy (Reinhardt family) as a standing exception that allows commit and push on any non-protected branch (anything other than `main`/`master`/`develop/*`/`release/*`), Draft PR creation, Draft→Ready conversion (implementation-complete only — no CI requirement), and Issue creation without further confirmation
+- Treat the Autonomous Operation Policy (Reinhardt family) as a standing exception that allows commit and push on any non-protected branch (anything other than `main`/`master`/`develop/*`/`release/*`), Draft PR creation, Draft→Ready conversion once PC-4a readiness criteria are met (CI completion is not required), and Issue creation without further confirmation
 - When editing `CLAUDE.md` or `AGENTS.md`, mirror the change into the other file in the same commit (CLAUDE.md ↔ AGENTS.md sync policy)
 - Mark placeholders with `todo!()` or `// TODO:`
 - Use `#[serial(group_name)]` for global state tests
@@ -539,6 +571,7 @@ Before submitting code:
 - Start commit description with lowercase letter (e.g., `feat: add feature`)
 - Use `!` notation for breaking changes (e.g., `feat!:` or `feat(scope)!:`)
 - Write commit descriptions as standalone CHANGELOG entries (meaningful without additional context)
+- Let release-plz handle version bumps, changelog updates, GitHub Releases, and release tags from conventional commits
 - Use `security` type for security vulnerability fixes (dedicated CHANGELOG section)
 - Use `deprecated` type for marking features/APIs as deprecated (dedicated CHANGELOG section)
 - Use GitHub CLI (`gh`) for all GitHub operations (PR, issues, releases)
@@ -567,7 +600,7 @@ Before submitting code:
 - Use repository-relative paths (not absolute) in GitHub comments
 - Provide structured agent context using AC-2 template format
 - Fall back to `gh` CLI when GitHub MCP tools return errors
-- Wait for Copilot review after PR creation and handle all comments (see @instructions/PR_GUIDELINE.md RP-6)
+- Handle Copilot review comments according to @instructions/PR_GUIDELINE.md RP-6 and @instructions/GITHUB_INTERACTION.md CR-1 ~ CR-5 when authorized
 - Evaluate Copilot suggestions against project conventions before accepting
 - Resolve all Copilot review conversations before considering PR complete
 - Verify branch name uniqueness before creation (`git worktree list` and `git branch -a`)
@@ -594,6 +627,8 @@ Before submitting code:
 - Force-push, rebase-and-push, or otherwise rewrite history without explicit user authorization (the Autonomous Operation Policy does NOT cover history-rewriting pushes)
 - Close, merge, or delete PRs / Issues / comments without explicit user authorization (autonomy covers creation only, not destruction)
 - Create release tags or any PR with the `release` label without explicit user authorization
+- Push code fixes directly to a release-plz branch (`release-plz-*` or `develop-release-plz-*`)
+- Manually bump versions in feature branches
 - Commit a change that touches only `CLAUDE.md` without mirroring it into `AGENTS.md` (and vice versa)
 - Leave docs outdated after code changes
 - Document user requests or AI interactions in project documentation
@@ -639,7 +674,7 @@ Before submitting code:
 - Create PRs/Issues without following template structure
 - Enter Plan Mode for merge operations, branch deletion, or worktree cleanup
 - Retry GitHub MCP tools after errors instead of falling back to `gh` CLI
-- Leave Copilot review conversations unresolved on PRs
+- Leave Copilot review conversations unresolved on PRs when handling them is authorized
 - Accept Copilot suggestions that contradict project conventions without evaluation
 - Create branches without checking for name conflicts
 - Use rebase or force-push to resolve PR conflicts (use worktree merge instead)

--- a/instructions/COMMIT_GUIDELINE.md
+++ b/instructions/COMMIT_GUIDELINE.md
@@ -114,6 +114,71 @@ git apply --cached /tmp/changes.patch
 - Verify staged files before committing
 - Use `git status` to confirm no ignored files are included
 
+### CE-4a (MUST): Excluded Tooling Artifacts
+
+The following categories of files MUST NOT be committed, even if not in `.gitignore`:
+
+- **Superpowers skill documentation**: Any documentation, prompts, or reference material from the `superpowers` skill family or its sub-skills.
+  - Why: These are agent-runtime artifacts and are not part of the project's source of truth.
+  - How to apply: If `git status` shows files under paths like `superpowers/`, `.superpowers/`, or skill prompt dumps, exclude them from staging. If you find them already tracked, remove them in a dedicated `chore:` commit.
+- **Claude/agent runtime caches and tool-result spills**: Files under `.claude/projects/.../tool-results/`, `.claude/projects/.../memory/`, or similar runtime locations.
+  - Why: Per-machine, per-session, and may contain sensitive context.
+
+If unsure whether an artifact qualifies, default to excluding it and ask the user.
+
+### CE-5: Automated Releases with release-plz
+
+**Overview:**
+
+This project uses [release-plz](https://release-plz.ieni.dev/) for automated release management. Version bumps, CHANGELOG updates, GitHub Releases, and Git tags are handled automatically based on conventional commits and `release-plz.toml`.
+
+**How It Works:**
+
+1. Write commits following [Conventional Commits](https://www.conventionalcommits.org/) format
+2. Push to main branch
+3. release-plz automatically creates a Release PR with:
+   - Version bumps in `Cargo.toml` files
+   - Updated CHANGELOG.md files
+   - Summary of changes
+4. Review and merge the Release PR
+5. release-plz creates GitHub Releases and Git tags for configured packages
+
+**Commit-to-Version Mapping:**
+
+| Commit Type | Version Bump | Example |
+|-------------|--------------|---------|
+| `feat:` | MINOR | `feat(operator): add deployment rollout controls` |
+| `fix:` | PATCH | `fix(dashboard): resolve project import validation` |
+| `feat!:` or `BREAKING CHANGE:` | MAJOR | `feat!: change Project CRD apiVersion` |
+| Other types | PATCH | `docs:`, `chore:`, `refactor:`, etc. |
+
+**Manual Intervention:**
+
+- Edit the Release PR to adjust CHANGELOG entries or version numbers if needed
+- Release PRs can be modified before merging
+
+**Critical Rules:**
+- Use conventional commit format for proper version detection
+- Review Release PRs before merging
+- NEVER manually bump versions in feature branches (let release-plz handle it)
+- NEVER create release tags manually (release-plz creates them)
+
+The following diagram illustrates the release-plz automated workflow:
+
+```mermaid
+sequenceDiagram
+    participant Dev as Developer
+    participant Git as Git/GitHub
+    participant RP as release-plz
+
+    Dev->>Git: Push conventional commits to main
+    RP->>Git: Analyze commits since last release
+    RP->>Git: Create Release PR (version bumps + CHANGELOG)
+    Dev->>Git: Review and merge Release PR
+    RP->>Git: Create GitHub Releases
+    RP->>Git: Create git tags (package@vX.Y.Z)
+```
+
 ---
 
 ## Commit Message Structure
@@ -311,23 +376,40 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 
 ### CG-1: Commit Type to CHANGELOG Section Mapping
 
+The following diagram shows how commit types map to version bumps and CHANGELOG sections:
+
+```mermaid
+flowchart LR
+    A["feat:"] --> B["MINOR bump"]
+    C["fix:"] --> D["PATCH bump"]
+    E["feat!: / BREAKING CHANGE:"] --> F["MAJOR bump"]
+    G["other types"] --> H["PATCH bump"]
+
+    B --> I["Added section"]
+    D --> J["Fixed section"]
+    F --> K["Breaking section"]
+    H --> L["Maintenance/Other section"]
+```
+
 Every commit type maps to a specific CHANGELOG section:
 
-| Commit Type | CHANGELOG Section |
-|-------------|-------------------|
-| `feat` | Added |
-| `fix` | Fixed |
-| `perf` | Performance |
-| `refactor` | Changed |
-| `docs` | Documentation |
-| `revert` | Reverted |
-| `deprecated` | Deprecated |
-| `security` | Security |
-| `chore` | Maintenance |
-| `ci` | Maintenance |
-| `build` | Maintenance |
-| `test` | Testing |
-| `style` | Styling |
+| Commit Type | CHANGELOG Section | Keep a Changelog Category |
+|-------------|-------------------|---------------------------|
+| `feat` | Added | Added |
+| `fix` | Fixed | Fixed |
+| `perf` | Performance | — (custom) |
+| `refactor` | Changed | Changed |
+| `docs` | Documentation | — (custom) |
+| `revert` | Reverted | — (custom) |
+| `deprecated` | Deprecated | Deprecated |
+| `security` | Security | Security |
+| `chore` | Maintenance | — (custom) |
+| `ci` | Maintenance | — (custom) |
+| `build` | Maintenance | — (custom) |
+| `test` | Testing | — (custom) |
+| `style` | Styling | — (custom) |
+
+All commit types are included in the CHANGELOG. No commit type is silently dropped.
 
 ### CG-2: Writing CHANGELOG-Friendly Descriptions
 
@@ -338,9 +420,57 @@ Commit descriptions appear directly in the CHANGELOG. Write them so they make se
 - ✅ Good: `fix(reconciler): resolve status update panic when deployment is missing`
 - ✅ Good: `refactor(crd): extract condition builder into dedicated module`
 
+**Guidelines:**
+
+- Write descriptions that are meaningful to users reading release notes
+- Include the affected component in the scope when applicable
+- Be specific about what changed, not just that something changed
+
+### CG-3: Scope and Breaking Change Rendering
+
+**Scope**: The `(scope)` portion of the commit type is preserved in the CHANGELOG entry. Use scopes consistently to help users filter relevant changes.
+
+**Breaking changes**: When `protect_breaking_commits = true` is set in `release-plz.toml`, commits with `!` or `BREAKING CHANGE:` footer are always included in the CHANGELOG, even if the commit type would otherwise be skipped. Breaking changes are rendered with a `[**breaking**]` prefix in the CHANGELOG.
+
+### CG-4: GitHub Issue/PR Reference Auto-Linking
+
+References to GitHub issues and PRs in commit messages are automatically converted to clickable links:
+
+- `#123` → `[#123](https://github.com/kent8192/reinhardt-cloud/issues/123)`
+
+This is handled by `commit_preprocessors` in `release-plz.toml`. Use `#NNN` format in commit descriptions or bodies to reference issues.
+
+### CG-5: Automatically Skipped Commits
+
+The following commit patterns are excluded from CHANGELOG generation:
+
+| Pattern | Reason |
+|---------|--------|
+| `chore: release` | release-plz automation commits |
+| `Merge ...` | Git merge commits |
+| `Revert "..."` | GitHub-generated revert commits (manual `revert:` type commits are included) |
+| `Initial plan ...` | Plan mode initialization commits |
+
+**Note**: Even skipped commits with breaking changes are included due to `protect_breaking_commits = true`.
+
+### CG-6: CHANGELOG Verification
+
+After pushing commits, verify CHANGELOG generation in the Release PR:
+
+1. Check that each commit appears in the expected section
+2. Verify breaking changes are highlighted
+3. Confirm issue references are properly linked
+4. Review the Release PR diff for `CHANGELOG.md` files
+
+```bash
+# Preview what release-plz will generate (requires release-plz CLI)
+release-plz generate-changelog
+```
+
 ---
 
 ## Related Documentation
 
 - **Main Quick Reference**: @CLAUDE.md (see Quick Reference section)
 - **Main Standards**: @CLAUDE.md
+- **Release Configuration**: @release-plz.toml

--- a/instructions/GITHUB_INTERACTION.md
+++ b/instructions/GITHUB_INTERACTION.md
@@ -201,31 +201,169 @@ When changes affect multiple crates or modules, provide impact analysis:
 
 ## Copilot Review Handling
 
-### CR-1 (MUST): Automated Review Response Policy
+### CR-1 (MUST): Post-PR Copilot Review Workflow
 
-When GitHub Copilot posts review comments on a PR created by Claude Code:
+After creating a PR, Claude Code MUST handle GitHub Copilot's automated review comments as part of the PR workflow when authorized by PP-1 (explicit user instruction or Plan Mode approval).
 
-1. **Authorization**: Plan Mode approval or explicit user instruction to create a PR implicitly authorizes handling Copilot review comments
-2. **No additional user confirmation** is needed to resolve Copilot review conversations
-3. **Code fixes** resulting from valid Copilot suggestions follow normal commit policy
+**Workflow:**
 
-### CR-2 (MUST): Evaluation Criteria for Copilot Suggestions
+```mermaid
+flowchart TD
+    A[PR created] --> B[Fetch review threads via GraphQL]
+    B --> C{Copilot review exists?}
+    C -->|No| D[Report to user and wait]
+    C -->|Yes| E[Filter unresolved Copilot threads]
+    E --> F[Evaluate each thread]
+    F --> G{Valid concern?}
+    G -->|Yes| H[Fix code + reply + resolve]
+    G -->|False positive| I[Reply with explanation + resolve]
+    G -->|Already addressed| J[Reply with reference + resolve]
+    H --> K[Commit fixes]
+    I --> K
+    J --> K
+    K --> L[Report summary to user]
+```
 
-Evaluate each Copilot suggestion against:
+**Authorization:**
+- Follows PP-1: requires explicit user instruction or Plan Mode approval
+- When Plan Mode approves a PR creation workflow, Copilot review handling is included in that authorization scope
+- Fix commits follow standard commit policy (CE-1)
 
-| Criterion | Accept | Reject |
-|-----------|--------|--------|
-| Code correctness | Fixes a real bug or logic error | False positive or misunderstanding |
-| Project conventions | Aligns with CLAUDE.md and instructions/ | Contradicts project standards |
-| Security | Addresses a genuine vulnerability | Overly paranoid for internal code |
-| Performance | Measurable improvement | Premature optimization |
-| Readability | Genuinely improves clarity | Style preference with no clear benefit |
+### CR-2 (MUST): Fetching Copilot Review Threads
 
-### CR-3 (MUST): Resolution Protocol
+Use `gh api graphql` to retrieve review threads from a PR:
 
-- **Accepted suggestions**: Fix the code → commit → resolve the conversation
-- **Rejected suggestions**: Resolve the conversation (reply with brief technical justification only if the suggestion represents a common misconception that future reviewers might also raise)
-- **All conversations MUST be resolved** before the PR is considered complete
+```bash
+gh api graphql -f query='
+query($owner: String!, $repo: String!, $pr: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          comments(first: 10) {
+            nodes {
+              author {
+                login
+              }
+              body
+              path
+              line
+              diffHunk
+            }
+          }
+        }
+      }
+    }
+  }
+}' -f owner='kent8192' -f repo='reinhardt-cloud' -F pr=<PR_NUMBER>
+```
+
+**Filtering Criteria:**
+- Filter by `author.login` matching Copilot bot (e.g., `copilot-pull-request-reviewer[bot]`)
+- Filter by `isResolved == false` to process only unresolved threads
+
+**Polling Prohibition:**
+- **NEVER** poll in a loop waiting for Copilot review to appear
+- If no Copilot review exists yet, report to user once and wait for further instruction
+
+### CR-3 (MUST): Evaluating and Responding to Comments
+
+Evaluate each Copilot comment against these categories:
+
+| Category | Action | Response |
+|----------|--------|----------|
+| Valid concern | Fix code | Reply with fix description → Resolve |
+| False positive | No code change | Reply with technical explanation → Resolve |
+| Already addressed | No code change | Reply with reference to existing handling → Resolve |
+
+**Response Template (extends RR-2):**
+
+For valid concerns with code fix:
+```markdown
+**Fixed:** [Brief description of the fix]
+
+[Technical explanation of the change]
+
+Commit: [commit hash] — `path/to/file.rs:L42`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+For false positives or already addressed:
+```markdown
+**Re: [Copilot's concern summary]**
+
+[Technical explanation of why this is not an issue or is already handled]
+
+Reference: `path/to/file.rs:L42` — [Description of existing handling]
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+**Guidelines:**
+- Follow RR-3 for code reference format (repository-relative paths)
+- Follow FF-1 for Claude Code attribution footer
+- Follow CG-2 content restrictions (no absolute paths, no user request details)
+- Every thread MUST receive a reply before being resolved (no silent resolves)
+
+### CR-4 (MUST): Resolving Threads via GraphQL
+
+**Step 1: Reply to the thread**
+
+```bash
+gh api graphql -f query='
+mutation($threadId: ID!, $body: String!) {
+  addPullRequestReviewThreadReply(input: {
+    pullRequestReviewThreadId: $threadId,
+    body: $body
+  }) {
+    comment {
+      id
+    }
+  }
+}' -f threadId='<THREAD_ID>' -f body='<REPLY_BODY>'
+```
+
+**Step 2: Resolve the thread**
+
+```bash
+gh api graphql -f query='
+mutation($threadId: ID!) {
+  resolveReviewThread(input: {
+    threadId: $threadId
+  }) {
+    thread {
+      isResolved
+    }
+  }
+}' -f threadId='<THREAD_ID>'
+```
+
+**Rules:**
+- **MUST** reply before resolving (CR-3 compliance)
+- **NEVER** resolve a thread without posting a reply first
+- Verify `isResolved: true` in the mutation response
+
+### CR-5 (SHOULD): Completion Summary
+
+After processing all Copilot review threads, report a summary to the user:
+
+**Summary Format:**
+
+```markdown
+## Copilot Review Handling Summary
+
+| # | File | Line | Category | Action |
+|---|------|------|----------|--------|
+| 1 | `path/to/file.rs` | L42 | Valid concern | Fixed (commit abc1234) |
+| 2 | `path/to/other.rs` | L15 | False positive | Explained |
+| 3 | `path/to/third.rs` | L88 | Already addressed | Referenced |
+
+**Commits created:** 1
+**Threads resolved:** 3 / 3
+```
 
 ---
 

--- a/instructions/PR_GUIDELINE.md
+++ b/instructions/PR_GUIDELINE.md
@@ -24,20 +24,22 @@ This file defines the pull request (PR) policy for the Reinhardt Cloud project. 
 - **MUST** prefer GitHub MCP tools (`create_pull_request`) for creating pull requests when available
 - **Fallback**: Use GitHub CLI (`gh pr create`) when GitHub MCP is not available
 - **NEVER** use web browser UI for PR creation when MCP or CLI is available
-- **Autonomy (Reinhardt family)**: Creating a **Draft** PR is authorized without further user confirmation in `reinhardt-web` / `reinhardt-cloud` / `awesome-delions` / `reinhardt-cc` (see Autonomous Operation Policy in `CLAUDE.md` / `AGENTS.md`); the Draft PR body MUST still follow `.github/PULL_REQUEST_TEMPLATE.md` and `--draft` MUST be passed. Marking a PR as Ready for Review is also authorized autonomously once the implementation is complete (CI completion is **not** required).
+- **Autonomy (Reinhardt family)**: Creating a **Draft** PR is authorized without further user confirmation in `reinhardt-web` / `reinhardt-cloud` / `awesome-delions` / `reinhardt-cc` (see Autonomous Operation Policy in `CLAUDE.md` / `AGENTS.md`); the Draft PR body MUST still follow `.github/PULL_REQUEST_TEMPLATE.md` and `--draft` MUST be passed. Marking a PR as Ready for Review is **REQUIRED** (MUST) immediately once the implementation is complete; CI completion is **not** a prerequisite. See § PC-4a.
 
-The following diagram summarizes the PR creation flow:
+The following diagram summarizes the PR creation flow. Ready-for-Review conversion is governed separately by § PC-4a (MUST immediately upon implementation completion — CI completion is NOT a prerequisite):
 
 ```mermaid
 flowchart TD
-    A[Create new PR] --> B{GitHub MCP available?}
-    B -->|Yes| C[Use create_pull_request MCP tool]
-    B -->|No| D[Use gh pr create CLI]
+    A[Create new PR as Draft] --> B{GitHub MCP available?}
+    B -->|Yes| C[create_pull_request with draft=true]
+    B -->|No| D[gh pr create --draft]
     C --> E[Follow PR template structure]
     D --> E
     E --> F[Add appropriate labels]
-    F --> G[Run pre-review checks]
-    G --> H[Request review]
+    F --> G[PR created as Draft]
+    G --> H["Implementation complete?<br/>see § PC-4a"]
+    H -->|Yes - MUST| I[Mark Ready immediately<br/>gh pr ready]
+    H -->|No| G
 ```
 
 **PR Template Location:** `.github/PULL_REQUEST_TEMPLATE.md`
@@ -91,15 +93,63 @@ chore/ci-update-kubernetes-version
 ### PC-4 (SHOULD): Draft PRs for Work in Progress
 
 - Use draft PRs for incomplete work
-- Convert to Ready for Review **once the implementation is complete** — CI completion is **not** a prerequisite (the Reinhardt-family Autonomous Operation Policy in `CLAUDE.md` / `AGENTS.md` overrides any "wait for all tests to pass" criterion for the Draft→Ready transition)
+- **MUST** convert to Ready for Review **immediately once the implementation is complete** — CI completion is **not** a prerequisite (the Reinhardt-family Autonomous Operation Policy in `CLAUDE.md` / `AGENTS.md` overrides any "wait for all tests to pass" criterion for the Draft→Ready transition)
 - Draft PRs allow early feedback without formal review requests
 
 **Example:**
 ```bash
 gh pr create --draft --title "feat(crd): add Project CRD (WIP)"
 
-# Convert to Ready once implementation is complete (no need to wait for CI):
+# MUST convert to Ready immediately once implementation is complete (CI completion NOT required):
 gh pr ready <number>
+```
+
+### PC-4a (MUST): Mandatory Draft → Ready Conversion on Implementation Completion
+
+Converting a Draft PR to Ready for Review is **mandatory once the implementation is complete**. "Implementation complete" means no `todo!()` / `// TODO:` markers introduced by this PR remain in the diff. **CI completion is NOT a prerequisite** — the Reinhardt-family Autonomous Operation Policy explicitly waives "wait for CI green / tests to pass". The agent MUST convert immediately upon implementation completion, and MUST NOT leave the PR in Draft state once the implementation is complete.
+
+**Rules:**
+- The agent **MUST** convert a Draft PR to Ready for Review immediately once the implementation is complete
+- The agent **MUST** convert immediately upon explicit user instruction (regardless of CI state)
+- The agent **MUST NOT** leave a PR in Draft state after the implementation is complete
+- Use `gh pr ready <number>` (or the equivalent GitHub MCP call) for conversion
+
+**Readiness Criterion (single check):**
+- [ ] Implementation is complete (no remaining `todo!()` or `// TODO:` introduced by this PR)
+
+> Other quality requirements (fmt-clippy clean, PR description following the template, documentation updated) are already enforced by the commit/push policies and the PR creation policy — they are NOT additional preconditions for the Draft → Ready transition.
+
+**Example:**
+```bash
+# Mandatory conversion once implementation is complete
+gh pr ready 123
+
+# Verify PR status after conversion
+gh pr view 123 --json isDraft
+```
+
+**Authorization Comparison:**
+
+| Action | Explicit Instruction | Plan Mode Approval | Implementation Complete |
+|--------|---------------------|-------------------|--------------------------|
+| Commit | ✅ Authorized | ✅ Authorized | n/a |
+| Push | ✅ Authorized | ✅ Authorized | n/a |
+| GitHub Comments | ✅ Authorized | ✅ Authorized | n/a |
+| Draft PR → Ready | ✅ **REQUIRED** | ✅ **REQUIRED** | ✅ **REQUIRED (MUST convert immediately)** |
+
+The following diagram illustrates the Draft PR lifecycle:
+
+```mermaid
+stateDiagram-v2
+    [*] --> Draft: gh pr create --draft
+    Draft --> Draft: Implementation continues
+    Draft --> Draft: CI checks run
+    Draft --> ReadyForReview: Implementation complete OR user instructs (MANDATORY)
+    note right of ReadyForReview: Agent MUST convert immediately\nonce implementation is complete
+    ReadyForReview --> Review: Reviewers notified (incl. Copilot)
+    Review --> Merged: Approved and merged
+    Review --> Draft: Converted back to draft
+    Merged --> [*]
 ```
 
 ### PC-5 (MUST): PR Labels
@@ -225,9 +275,9 @@ Include additional sections when relevant:
 
 ## PR Review Process
 
-### RP-1 (MUST): Pre-Review Checklist
+### RP-1 (MUST): Pre-Merge Checklist
 
-Before requesting review, ensure:
+Before **merging** (NOT before Draft → Ready conversion — see § PC-4a, which mandates immediate Ready conversion upon implementation completion), ensure:
 
 - [ ] All CI checks pass
 - [ ] All tests pass locally
@@ -263,67 +313,45 @@ cargo make clippy-check
 
 ### RP-6 (MUST): Copilot Review Workflow
 
-After creating a PR, Claude Code MUST wait for GitHub Copilot's automated review and handle it as part of the PR completion process.
+After creating a PR, Claude Code MUST handle GitHub Copilot's automated review comments as part of the PR workflow when authorized by the posting policy in `instructions/GITHUB_INTERACTION.md` PP-1.
 
 **Workflow:**
 
-1. **Wait for Copilot review** — After PR creation, poll for Copilot's review using `gh pr checks` and `gh api` to monitor review status
-2. **Retrieve review comments** — Once Copilot review arrives, fetch all review comments using `gh pr view <number> --comments` and `gh api repos/{owner}/{repo}/pulls/{number}/comments`
+1. **Fetch review threads** — Use the GraphQL review-thread query documented in `instructions/GITHUB_INTERACTION.md` CR-2
+2. **Report once if absent** — If no Copilot review exists, report that state once and wait for further instruction; do not poll in a loop
 3. **Evaluate each comment** — For each Copilot suggestion:
    - Assess whether the suggestion is valid and improves code quality
    - Check if the suggestion aligns with project conventions (CLAUDE.md, instructions/)
    - Determine if the change is necessary or cosmetic
 4. **Act on evaluation:**
-   - **Valid suggestion** → Fix the code, commit the change, then resolve the conversation
-   - **Invalid or unnecessary suggestion** → Resolve the conversation without changes (reply with brief technical justification if needed)
+   - **Valid suggestion** → Fix the code, reply with the fix description, commit the change, then resolve the conversation
+   - **Invalid or unnecessary suggestion** → Reply with a brief technical justification, then resolve the conversation
 5. **Verify completion** — Ensure all Copilot review conversations are resolved before considering the PR ready
 
 The following diagram summarizes the Copilot review handling flow:
 
 ```mermaid
 flowchart TD
-    A[PR created] --> B[Poll for Copilot review]
-    B --> C{Copilot review received?}
-    C -->|No| D[Wait and retry]
-    D --> C
-    C -->|Yes| E[Fetch all review comments]
+    A[PR created] --> B[Fetch review threads via GraphQL]
+    B --> C{Copilot review exists?}
+    C -->|No| D[Report once and wait]
+    C -->|Yes| E[Filter unresolved Copilot threads]
     E --> F[Evaluate each comment]
     F --> G{Suggestion valid?}
-    G -->|Yes| H[Fix code and commit]
+    G -->|Yes| H[Fix code + reply + commit]
     H --> I[Resolve conversation]
-    G -->|No| J[Resolve conversation<br/>with justification]
+    G -->|No| J[Reply with justification<br/>then resolve]
     I --> K{More comments?}
     J --> K
     K -->|Yes| F
     K -->|No| L[All conversations resolved]
 ```
 
-**Polling Commands:**
-```bash
-# Check PR review status
-gh pr checks <number>
-
-# List reviews on a PR
-gh api repos/{owner}/{repo}/pulls/{number}/reviews
-
-# Get review comments
-gh api repos/{owner}/{repo}/pulls/{number}/comments
-
-# Resolve a review thread (GraphQL)
-gh api graphql -f query='
-  mutation {
-    resolveReviewThread(input: {threadId: "<thread_id>"}) {
-      thread { isResolved }
-    }
-  }
-'
-```
-
 **Important Notes:**
 - Copilot review is treated as automated feedback, NOT as a blocking human review
-- Plan Mode approval authorizes handling Copilot review comments (no additional user confirmation needed)
+- Plan Mode approval authorizes handling Copilot review comments within the approved PR workflow
 - Fixes for Copilot suggestions follow the same commit policy as other changes
-- If Copilot review does not arrive within a reasonable time, proceed without it
+- Every thread MUST receive a reply before being resolved; see `instructions/GITHUB_INTERACTION.md` CR-3 and CR-4
 
 ### RP-4 (SHOULD): Keep PRs Small
 
@@ -463,12 +491,13 @@ docs(operator): update deployment guide for Kubernetes 1.29
 - Follow Conventional Commits format for titles
 - Include Summary, Type of Change, Motivation and Context, How Was This Tested, Checklist sections
 - Include Labels to Apply section with appropriate type and scope labels
-- Run all checks before requesting review
+- Run all checks before **merging** (NOT before Draft → Ready conversion — § PC-4a mandates immediate Ready conversion)
 - Address all review comments
-- Wait for Copilot review after PR creation and handle all comments (RP-6)
+- Handle Copilot review comments according to RP-6 when authorized
 - Resolve all Copilot review conversations before considering PR complete
 - Ensure all CI checks pass before merge
 - Use three-dot diff (`main...branch`) for PR verification to exclude merge history noise
+- **MUST** convert Draft PRs to Ready for Review **immediately** once the implementation is complete (CI completion is NOT required), OR upon explicit user instruction (see § PC-4a)
 
 ### ❌ NEVER DO
 - Write PR titles or descriptions in non-English languages
@@ -481,6 +510,8 @@ docs(operator): update deployment guide for Kubernetes 1.29
 - Force push after review has started (unless explicitly requested)
 - Use rebase or force-push to resolve PR conflicts (use worktree merge instead)
 - Use two-dot diff (`main..branch`) for PR verification (includes merge history noise)
+- Convert Draft PRs to Ready for Review while the implementation is incomplete (`todo!()` or `// TODO:` introduced by the PR still present), without explicit user override
+- Leave a PR in Draft state after the implementation is complete (MUST convert to Ready for Review immediately; CI completion is NOT a prerequisite)
 
 ---
 


### PR DESCRIPTION
## Summary

This PR addresses:

- Aligns Reinhardt Cloud agent commit/push and PR policies with the current Reinhardt Web policy model.
- Documents PC-4a Draft PR to Ready conversion requirements and release-plz ownership of release metadata.
- Updates Copilot review handling to require reply-before-resolve review-thread workflow.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

- Keeps Reinhardt Cloud agent guidance consistent with the Reinhardt family workflow used by reinhardt-web.
- Reduces ambiguity around autonomous commit/push behavior, Draft PR readiness, release-plz branches, and Copilot review-thread handling.

Related to: reinhardt-web policy alignment

## How Was This Tested?

- [x] `git diff --check`
- [x] Verified `CLAUDE.md` / `AGENTS.md` differ only by documented mechanical substitutions
- [x] Verified old `implementation-complete only` and `Wait for Copilot review` wording is not present in the updated policy files

## Performance Impact

- Not applicable; documentation-only change.

## Breaking Changes

- None.

**Migration Guide:**

- Not applicable.

## Screenshots

Not applicable; documentation-only change.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (not applicable; documentation-only change)
- [ ] New and existing unit tests pass locally with my changes (not applicable; documentation-only change)
- [ ] I have formatted the code with `cargo make fmt-fix` (not applicable; markdown-only change)
- [ ] I have checked the code with `cargo make clippy-check` (not applicable; markdown-only change)
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- None.

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [x] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [ ] `kubernetes` - Kubernetes resources, controllers, operators
- [ ] `deployment` - Application deployment logic
- [ ] `networking` - Ingress, services, network policies
- [ ] `storage` - Persistent volumes, storage classes
- [ ] `auth` - Authentication, authorization, RBAC
- [ ] `api` - REST API, serializers, handlers
- [ ] `cli` - Command-line interface
- [x] `config` - Configuration management
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - High priority
- [ ] `medium` - Medium priority
- [ ] `low` - Low priority

🤖 Generated with [Codex](https://openai.com/codex)
