### PR TITLE
fix(e2e): update dashboard self-deploy harness

### DIFF
--- a/docs/development/LOCAL_E2E_TESTING.md
+++ b/docs/development/LOCAL_E2E_TESTING.md
@@ -54,10 +54,16 @@ when no in-cluster Operator is already installed, generates the Dashboard
 `Project` with `reinhardt-cloud deploy --dir dashboard --dry-run`, requires
 Dashboard `manage introspect` to succeed, applies the same contract through
 `--direct`, waits for the Operator-owned Deployment, Service, cache/database
-resources, Pods, and live `Project`, seeds an active Dashboard user with
+resources, revision migration Job, Pods, and live `Project`, seeds an active Dashboard user with
 its Personal Organization, verifies login through the deployed frontend server
-function, checks authenticated Dashboard pages, then removes the temporary
+function, checks authenticated Dashboard route shells, then removes the temporary
 namespace.
+
+By default, the harness first uses the configured Kubernetes context when it is
+reachable. If the current context is stopped or missing and `kind` is installed,
+it creates or reuses a local `reinhardt-dashboard-e2e` kind cluster and loads the
+Dashboard image there. Set `DASHBOARD_SELF_DEPLOY_CLUSTER_MODE=existing` to keep
+the older fail-fast behavior.
 
 Useful overrides:
 
@@ -66,17 +72,23 @@ Useful overrides:
 | `DASHBOARD_SELF_DEPLOY_NAMESPACE` | `reinhardt-dashboard-e2e-<timestamp>` | Reuse or name the test namespace. |
 | `DASHBOARD_SELF_DEPLOY_IMAGE` | `reinhardt-cloud-dashboard:e2e` | Dashboard image used in the generated CRD. |
 | `DASHBOARD_SELF_DEPLOY_BUILD_IMAGE` | `1` | Set to `0` to use an already-built image. |
+| `DASHBOARD_SELF_DEPLOY_DOCKERFILE` | `dashboard/Dockerfile` | Dockerfile template used for the Dashboard image build. |
+| `DASHBOARD_SELF_DEPLOY_RUST_VERSION` | nearest `rust-toolchain.toml` channel | Rust image version used when preparing the build Dockerfile. |
 | `DASHBOARD_SELF_DEPLOY_OPERATOR_MODE` | `auto` | `auto`, `existing`, `local`, or `skip`. |
 | `DASHBOARD_SELF_DEPLOY_OPERATOR_METRICS_ADDR` | `127.0.0.1:19090` | Metrics/health bind address for the local Operator process. |
 | `DASHBOARD_SELF_DEPLOY_OPERATOR_BIN` | `target/debug/reinhardt-cloud-operator` | Override the local Operator binary path. |
 | `DASHBOARD_SELF_DEPLOY_CLI_BIN` | `target/debug/reinhardt-cloud` | Override the local CLI binary path. |
 | `DASHBOARD_SELF_DEPLOY_MANAGE_BIN` | `target/debug/manage` | Override the Dashboard `manage` binary used for strict introspection. |
 | `DASHBOARD_SELF_DEPLOY_REINHARDT_ENV` | `ci` | `REINHARDT_ENV` used by local Dashboard `manage introspect`. |
+| `DASHBOARD_SELF_DEPLOY_CORE_SECRET_KEY` | self-deploy fixture value | `REINHARDT_CORE__SECRET_KEY` used by local Dashboard `manage introspect`. |
+| `DASHBOARD_SELF_DEPLOY_JWT_SECRET` | self-deploy fixture value | `REINHARDT_CLOUD_JWT_SECRET` used by local Dashboard `manage introspect`. |
+| `DASHBOARD_SELF_DEPLOY_DATABASE_PASSWORD` | `postgres` | `REINHARDT_DATABASE_PASSWORD` used by local Dashboard `manage introspect`. |
 | `DASHBOARD_SELF_DEPLOY_KEEP_RESOURCES` | `0` | Set to `1` to keep the namespace after the run. |
 | `DASHBOARD_SELF_DEPLOY_INTROSPECT_TIMEOUT_SECONDS` | `30` | Timeout for each CLI `manage introspect` attempt. The harness fails instead of using zero-config fallback. |
 | `DASHBOARD_SELF_DEPLOY_ARTIFACT_DIR` | `target/dashboard-self-deploy-e2e/<namespace>` | Failure diagnostics and generated YAML. |
+| `DASHBOARD_SELF_DEPLOY_CLUSTER_MODE` | `auto` | `auto`, `existing`, or `create-kind`. `auto` uses a reachable context, then falls back to kind. |
 | `DASHBOARD_SELF_DEPLOY_KUBECTL_CONTEXT` | current context | Kubernetes context for `kubectl`. |
-| `DASHBOARD_SELF_DEPLOY_KIND_CLUSTER` | inferred from `kind-*` context | Explicit `kind load docker-image` target. |
+| `DASHBOARD_SELF_DEPLOY_KIND_CLUSTER` | inferred from `kind-*` context, otherwise `reinhardt-dashboard-e2e` when kind is created | Explicit `kind` cluster target for creation and `kind load docker-image`. |
 | `DASHBOARD_SELF_DEPLOY_E2E_USERNAME` | `e2e-user` | Username seeded inside the deployed Dashboard Pod for authenticated flow checks. |
 | `DASHBOARD_SELF_DEPLOY_E2E_PASSWORD` | `e2e-password-123456` | Password assigned to the seeded Dashboard user. |
 | `DASHBOARD_SELF_DEPLOY_E2E_EMAIL` | `e2e@example.test` | Email assigned to the seeded Dashboard user. |

--- a/scripts/dashboard_self_deploy_e2e.sh
+++ b/scripts/dashboard_self_deploy_e2e.sh
@@ -17,10 +17,17 @@ OPERATOR_METRICS_ADDR="${DASHBOARD_SELF_DEPLOY_OPERATOR_METRICS_ADDR:-127.0.0.1:
 OPERATOR_BIN="${DASHBOARD_SELF_DEPLOY_OPERATOR_BIN:-${ROOT_DIR}/target/debug/reinhardt-cloud-operator}"
 CLI_BIN="${DASHBOARD_SELF_DEPLOY_CLI_BIN:-${ROOT_DIR}/target/debug/reinhardt-cloud}"
 MANAGE_BIN="${DASHBOARD_SELF_DEPLOY_MANAGE_BIN:-${ROOT_DIR}/target/debug/manage}"
+DOCKERFILE="${DASHBOARD_SELF_DEPLOY_DOCKERFILE:-${PROJECT_DIR}/Dockerfile}"
+RUST_VERSION="${DASHBOARD_SELF_DEPLOY_RUST_VERSION:-}"
 MANAGE_ENV="${DASHBOARD_SELF_DEPLOY_REINHARDT_ENV:-${REINHARDT_ENV:-ci}}"
+MANAGE_CORE_SECRET_KEY="${DASHBOARD_SELF_DEPLOY_CORE_SECRET_KEY:-dashboard-self-deploy-core-secret-key-minimum-32-bytes}"
+MANAGE_JWT_SECRET="${DASHBOARD_SELF_DEPLOY_JWT_SECRET:-dashboard-self-deploy-jwt-secret-minimum-32-bytes}"
+MANAGE_DATABASE_PASSWORD="${DASHBOARD_SELF_DEPLOY_DATABASE_PASSWORD:-postgres}"
 RUNTIME_SECRET="${DASHBOARD_SELF_DEPLOY_RUNTIME_SECRET:-reinhardt-cloud-dashboard-secrets}"
 KUBECTL_CONTEXT="${DASHBOARD_SELF_DEPLOY_KUBECTL_CONTEXT:-}"
 KIND_CLUSTER="${DASHBOARD_SELF_DEPLOY_KIND_CLUSTER:-}"
+DEFAULT_KIND_CLUSTER="reinhardt-dashboard-e2e"
+CLUSTER_MODE="${DASHBOARD_SELF_DEPLOY_CLUSTER_MODE:-auto}"
 E2E_USERNAME="${DASHBOARD_SELF_DEPLOY_E2E_USERNAME:-e2e-user}"
 E2E_PASSWORD="${DASHBOARD_SELF_DEPLOY_E2E_PASSWORD:-e2e-password-123456}"
 E2E_EMAIL="${DASHBOARD_SELF_DEPLOY_E2E_EMAIL:-e2e@example.test}"
@@ -36,10 +43,6 @@ CREATED_NAMESPACE=0
 
 kubectl_args=()
 cli_cluster_args=()
-if [[ -n "${KUBECTL_CONTEXT}" ]]; then
-	kubectl_args+=(--context "${KUBECTL_CONTEXT}")
-	cli_cluster_args+=(--cluster "${KUBECTL_CONTEXT}")
-fi
 
 log() {
 	printf '[dashboard-self-deploy-e2e] %s\n' "$*"
@@ -54,8 +57,104 @@ command_exists() {
 	command -v "$1" >/dev/null 2>&1
 }
 
+set_kubectl_context() {
+	local context=$1
+	KUBECTL_CONTEXT="${context}"
+	kubectl_args=()
+	cli_cluster_args=()
+	if [[ -n "${KUBECTL_CONTEXT}" ]]; then
+		kubectl_args+=(--context "${KUBECTL_CONTEXT}")
+		cli_cluster_args+=(--cluster "${KUBECTL_CONTEXT}")
+	fi
+}
+
 kubectl_cmd() {
 	kubectl "${kubectl_args[@]}" "$@"
+}
+
+kubectl_cluster_reachable() {
+	kubectl_cmd cluster-info >/dev/null 2>&1
+}
+
+current_kubectl_context() {
+	kubectl config current-context 2>/dev/null || true
+}
+
+kind_cluster_exists() {
+	local cluster=$1
+	kind get clusters 2>/dev/null | grep -Fxq "${cluster}"
+}
+
+ensure_kind_cluster() {
+	local cluster=$1
+	command_exists kind || die "Kubernetes cluster is not reachable and kind is not installed; start OrbStack Kubernetes, set DASHBOARD_SELF_DEPLOY_KUBECTL_CONTEXT, or install kind"
+
+	if kind_cluster_exists "${cluster}"; then
+		log "using existing kind cluster ${cluster}"
+	else
+		log "creating kind cluster ${cluster}"
+		kind create cluster --name "${cluster}"
+	fi
+
+	KIND_CLUSTER="${cluster}"
+	kind export kubeconfig --name "${cluster}" >/dev/null
+	set_kubectl_context "kind-${cluster}"
+	kubectl_cluster_reachable || die "kind cluster ${cluster} was created but is not reachable"
+}
+
+ensure_kubernetes_cluster() {
+	local current_context
+	local target_kind_cluster
+
+	case "${CLUSTER_MODE}" in
+		existing)
+			kubectl_cluster_reachable || die "Kubernetes cluster is not reachable"
+			current_context="${KUBECTL_CONTEXT:-$(current_kubectl_context)}"
+			if [[ -n "${current_context}" ]]; then
+				set_kubectl_context "${current_context}"
+			fi
+			return
+			;;
+		create-kind)
+			target_kind_cluster="${KIND_CLUSTER:-${DEFAULT_KIND_CLUSTER}}"
+			ensure_kind_cluster "${target_kind_cluster}"
+			return
+			;;
+		auto)
+			if kubectl_cluster_reachable; then
+				current_context="${KUBECTL_CONTEXT:-$(current_kubectl_context)}"
+				if [[ -n "${current_context}" ]]; then
+					set_kubectl_context "${current_context}"
+					log "using reachable Kubernetes context ${current_context}"
+				else
+					log "using reachable Kubernetes context"
+				fi
+				return
+			fi
+
+			if [[ -n "${KUBECTL_CONTEXT}" ]]; then
+				die "Kubernetes context ${KUBECTL_CONTEXT} is not reachable"
+			fi
+
+			current_context="$(current_kubectl_context)"
+			if [[ -n "${current_context}" ]]; then
+				log "current Kubernetes context ${current_context} is not reachable"
+			else
+				log "no current Kubernetes context is reachable"
+			fi
+
+			if [[ "${current_context}" == kind-* && -z "${KIND_CLUSTER}" ]]; then
+				target_kind_cluster="${current_context#kind-}"
+			else
+				target_kind_cluster="${KIND_CLUSTER:-${DEFAULT_KIND_CLUSTER}}"
+			fi
+			ensure_kind_cluster "${target_kind_cluster}"
+			return
+			;;
+		*)
+			die "invalid DASHBOARD_SELF_DEPLOY_CLUSTER_MODE=${CLUSTER_MODE}; expected auto, existing, or create-kind"
+			;;
+	esac
 }
 
 collect_diagnostics() {
@@ -68,10 +167,16 @@ collect_diagnostics() {
 	kubectl_cmd get all,secrets,configmaps,pvc -n "${NAMESPACE}" -o wide >"${ARTIFACT_DIR}/namespace-resources.txt" 2>&1 || true
 	kubectl_cmd get events -n "${NAMESPACE}" --sort-by=.lastTimestamp >"${ARTIFACT_DIR}/events.txt" 2>&1 || true
 	kubectl_cmd get deployment "${APP_NAME}" -n "${NAMESPACE}" -o yaml >"${ARTIFACT_DIR}/deployment-live.yaml" 2>&1 || true
-	kubectl_cmd get deployment,service,statefulset,job,pod -n "${NAMESPACE}" \
+	kubectl_cmd get deployment,service,statefulset,job,pod,hpa,ingress,networkpolicy -n "${NAMESPACE}" \
 		-l "app.kubernetes.io/name=${APP_NAME}" -o yaml >"${ARTIFACT_DIR}/owned-resources.yaml" 2>&1 || true
+	kubectl_cmd get job -n "${NAMESPACE}" \
+		-l "app.kubernetes.io/name=${APP_NAME},app.kubernetes.io/component=migration" \
+		-o yaml >"${ARTIFACT_DIR}/migration-jobs.yaml" 2>&1 || true
 	kubectl_cmd logs -n "${NAMESPACE}" \
 		-l "app.kubernetes.io/name=${APP_NAME}" --all-containers --tail=250 --prefix >"${ARTIFACT_DIR}/owned-pod-logs.txt" 2>&1 || true
+	kubectl_cmd logs -n "${NAMESPACE}" \
+		-l "app.kubernetes.io/name=${APP_NAME},app.kubernetes.io/component=migration" \
+		--all-containers --tail=250 --prefix >"${ARTIFACT_DIR}/migration-job-logs.txt" 2>&1 || true
 	kubectl_cmd logs -A \
 		-l "app.kubernetes.io/name=reinhardt-cloud-operator" --all-containers --tail=250 --prefix >"${ARTIFACT_DIR}/cluster-operator-logs.txt" 2>&1 || true
 }
@@ -128,10 +233,11 @@ require_prerequisites() {
 	command_exists kubectl || die "kubectl is required"
 	command_exists cargo || die "cargo is required"
 	command_exists curl || die "curl is required"
+	[[ -f "${DOCKERFILE}" ]] || die "Dockerfile ${DOCKERFILE} does not exist"
 
 	docker info >/dev/null || die "Docker is not reachable"
 	kubectl_cmd version --client >/dev/null || die "kubectl client is not usable"
-	kubectl_cmd cluster-info >/dev/null || die "Kubernetes cluster is not reachable"
+	ensure_kubernetes_cluster
 }
 
 ensure_namespace() {
@@ -179,15 +285,51 @@ ensure_runtime_secret() {
 		done
 }
 
-build_dashboard_image() {
-	if [[ "${BUILD_IMAGE}" != "1" ]]; then
-		log "using prebuilt dashboard image ${IMAGE}"
+locate_rust_toolchain_file() {
+	local dir
+	dir="$(cd "${PROJECT_DIR}" && pwd)"
+	while [[ "${dir}" != "/" ]]; do
+		if [[ -f "${dir}/rust-toolchain.toml" ]]; then
+			printf '%s\n' "${dir}/rust-toolchain.toml"
+			return
+		fi
+		dir="$(dirname "${dir}")"
+	done
+}
+
+read_rust_version() {
+	local toolchain_file
+	if [[ -n "${RUST_VERSION}" ]]; then
+		printf '%s\n' "${RUST_VERSION}"
 		return
 	fi
 
-	log "building dashboard image ${IMAGE}"
-	docker build -f "${ROOT_DIR}/dashboard/Dockerfile" -t "${IMAGE}" "${ROOT_DIR}"
+	toolchain_file="$(locate_rust_toolchain_file)"
+	if [[ -z "${toolchain_file}" ]]; then
+		return
+	fi
 
+	sed -n 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "${toolchain_file}" | head -n 1
+}
+
+prepare_dashboard_dockerfile() {
+	local rust_version
+	local artifact_dockerfile
+	rust_version="$(read_rust_version)"
+
+	if [[ -z "${rust_version}" ]]; then
+		printf '%s\n' "${DOCKERFILE}"
+		return
+	fi
+
+	mkdir -p "${ARTIFACT_DIR}"
+	artifact_dockerfile="${ARTIFACT_DIR}/Dockerfile"
+	sed -E "s|^FROM rust:[^[:space:]]+(-bookworm)( AS .*)$|FROM rust:${rust_version}\\1\\2|" \
+		"${DOCKERFILE}" >"${artifact_dockerfile}"
+	printf '%s\n' "${artifact_dockerfile}"
+}
+
+load_dashboard_image_into_kind() {
 	if [[ -n "${KIND_CLUSTER}" ]]; then
 		command_exists kind || die "kind is required when DASHBOARD_SELF_DEPLOY_KIND_CLUSTER is set"
 		log "loading ${IMAGE} into kind cluster ${KIND_CLUSTER}"
@@ -196,11 +338,25 @@ build_dashboard_image() {
 	fi
 
 	local current_context
-	current_context="$(kubectl_cmd config current-context 2>/dev/null || true)"
+	current_context="${KUBECTL_CONTEXT:-$(current_kubectl_context)}"
 	if [[ "${current_context}" == kind-* ]] && command_exists kind; then
 		log "loading ${IMAGE} into kind cluster ${current_context#kind-}"
 		kind load docker-image "${IMAGE}" --name "${current_context#kind-}"
 	fi
+}
+
+build_dashboard_image() {
+	local build_dockerfile
+	if [[ "${BUILD_IMAGE}" != "1" ]]; then
+		log "using prebuilt dashboard image ${IMAGE}"
+		load_dashboard_image_into_kind
+		return
+	fi
+
+	build_dockerfile="$(prepare_dashboard_dockerfile)"
+	log "building dashboard image ${IMAGE} with ${build_dockerfile}"
+	docker build -f "${build_dockerfile}" -t "${IMAGE}" "${ROOT_DIR}"
+	load_dashboard_image_into_kind
 }
 
 build_local_binaries() {
@@ -292,8 +448,11 @@ generate_project_yaml() {
 	log "generating dry-run Project YAML"
 	(
 		cd "${ROOT_DIR}"
-		export REINHARDT_ENV="${MANAGE_ENV}"
-		"${CLI_BIN}" deploy \
+		REINHARDT_ENV="${MANAGE_ENV}" \
+			REINHARDT_CLOUD_JWT_SECRET="${MANAGE_JWT_SECRET}" \
+			REINHARDT_CORE__SECRET_KEY="${MANAGE_CORE_SECRET_KEY}" \
+			REINHARDT_DATABASE_PASSWORD="${MANAGE_DATABASE_PASSWORD}" \
+			"${CLI_BIN}" deploy \
 			--dir "${PROJECT_DIR}" \
 			--name "${APP_NAME}" \
 			--image "${IMAGE}" \
@@ -310,8 +469,11 @@ apply_project_direct() {
 	log "applying Project through the CLI --direct path"
 	(
 		cd "${ROOT_DIR}"
-		export REINHARDT_ENV="${MANAGE_ENV}"
-		"${CLI_BIN}" deploy \
+		REINHARDT_ENV="${MANAGE_ENV}" \
+			REINHARDT_CLOUD_JWT_SECRET="${MANAGE_JWT_SECRET}" \
+			REINHARDT_CORE__SECRET_KEY="${MANAGE_CORE_SECRET_KEY}" \
+			REINHARDT_DATABASE_PASSWORD="${MANAGE_DATABASE_PASSWORD}" \
+			"${CLI_BIN}" deploy \
 			--dir "${PROJECT_DIR}" \
 			--name "${APP_NAME}" \
 			--image "${IMAGE}" \
@@ -397,8 +559,41 @@ wait_for_app_ready_condition() {
 	die "Project/${APP_NAME} did not reach phase=running and Ready=True before ${TIMEOUT}"
 }
 
+wait_for_migration_ready_condition() {
+	local deadline
+	local status
+	local reason
+	local message
+	local jobs
+	deadline=$((SECONDS + $(timeout_seconds)))
+
+	log "waiting for Project/${APP_NAME} MigrationReady condition"
+	while (( SECONDS < deadline )); do
+		status="$(kubectl_cmd get project "${APP_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.conditions[?(@.type=="MigrationReady")].status}' 2>/dev/null || true)"
+		reason="$(kubectl_cmd get project "${APP_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.conditions[?(@.type=="MigrationReady")].reason}' 2>/dev/null || true)"
+		message="$(kubectl_cmd get project "${APP_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.conditions[?(@.type=="MigrationReady")].message}' 2>/dev/null || true)"
+		if [[ "${status}" == "True" ]]; then
+			log "Project/${APP_NAME} MigrationReady=True (${reason:-unknown})"
+			return
+		fi
+		if [[ "${reason}" == "MigrationFailed" ]]; then
+			jobs="$(kubectl_cmd get job -n "${NAMESPACE}" \
+				-l "app.kubernetes.io/name=${APP_NAME},app.kubernetes.io/component=migration" \
+				-o jsonpath='{range .items[*]}{.metadata.name}{" "}{end}' 2>/dev/null || true)"
+			die "Project/${APP_NAME} migration failed: ${message:-no status message}; jobs=${jobs:-none}"
+		fi
+		sleep 3
+	done
+
+	die "Project/${APP_NAME} did not reach MigrationReady=True before ${TIMEOUT}; last reason=${reason:-unknown}; message=${message:-none}"
+}
+
 wait_for_reconciliation() {
 	log "waiting for operator-owned resources"
+	wait_for_first_resource_exists statefulset "${APP_NAME}-db" "${APP_NAME}-postgresql"
+	kubectl_cmd wait --for=jsonpath='{.status.readyReplicas}'=1 "statefulset/${FOUND_RESOURCE_NAME}" -n "${NAMESPACE}" --timeout="${TIMEOUT}"
+	wait_for_migration_ready_condition
+
 	wait_for_resource_exists deployment "${APP_NAME}"
 	kubectl_cmd wait --for=condition=Available "deployment/${APP_NAME}" -n "${NAMESPACE}" --timeout="${TIMEOUT}"
 	wait_for_resource_exists service "${APP_NAME}"
@@ -406,13 +601,10 @@ wait_for_reconciliation() {
 
 	wait_for_resource_exists deployment "${APP_NAME}-redis"
 	kubectl_cmd wait --for=condition=Available "deployment/${APP_NAME}-redis" -n "${NAMESPACE}" --timeout="${TIMEOUT}"
-
-	wait_for_first_resource_exists statefulset "${APP_NAME}-db" "${APP_NAME}-postgresql"
-	kubectl_cmd wait --for=jsonpath='{.status.readyReplicas}'=1 "statefulset/${FOUND_RESOURCE_NAME}" -n "${NAMESPACE}" --timeout="${TIMEOUT}"
 	wait_for_app_ready_condition
 
 	kubectl_cmd get project "${APP_NAME}" -n "${NAMESPACE}" -o yaml >"${ARTIFACT_DIR}/project-ready.yaml"
-	kubectl_cmd get deployment,service,statefulset,pod -n "${NAMESPACE}" \
+	kubectl_cmd get deployment,service,statefulset,job,pod,hpa,ingress -n "${NAMESPACE}" \
 		-l "app.kubernetes.io/name=${APP_NAME}" -o wide >"${ARTIFACT_DIR}/ready-resources.txt"
 }
 
@@ -422,6 +614,7 @@ dashboard_pod_name() {
 	deadline=$((SECONDS + $(timeout_seconds)))
 
 	while (( SECONDS < deadline )); do
+		# shellcheck disable=SC2016
 		pods="$(kubectl_cmd get pod -n "${NAMESPACE}" \
 			-l "app.kubernetes.io/name=${APP_NAME},app.kubernetes.io/component=web" \
 			-o go-template='{{range .items}}{{ $name := .metadata.name }}{{ if not .metadata.deletionTimestamp }}{{ range .status.conditions }}{{ if and (eq .type "Ready") (eq .status "True") }}{{ $name }}{{ "\n" }}{{ end }}{{ end }}{{ end }}{{ end }}' \
@@ -514,16 +707,21 @@ verify_authenticated_frontend_flows() {
 		|| die "login server function did not return success=true; see ${login_body}"
 
 	fetch_authenticated_dashboard_page \
-		"${base_url}" "${cookie_jar}" "/clusters/" "${ARTIFACT_DIR}/clusters.html" "Cluster Inventory"
+		"${base_url}" "${cookie_jar}" "/clusters/" "${ARTIFACT_DIR}/clusters.html" "Reinhardt WASM Auto-Loader"
 	fetch_authenticated_dashboard_page \
-		"${base_url}" "${cookie_jar}" "/deployments/" "${ARTIFACT_DIR}/deployments.html" "Deployment Inventory"
+		"${base_url}" "${cookie_jar}" "/deployments/" "${ARTIFACT_DIR}/deployments.html" "Reinhardt WASM Auto-Loader"
 }
 
 main() {
+	set_kubectl_context "${KUBECTL_CONTEXT}"
 	log "namespace=${NAMESPACE}"
 	log "app=${APP_NAME}"
 	log "image=${IMAGE}"
 	log "manage-env=${MANAGE_ENV}"
+	log "cluster-mode=${CLUSTER_MODE}"
+	if [[ -n "${KUBECTL_CONTEXT}" ]]; then
+		log "kubectl-context=${KUBECTL_CONTEXT}"
+	fi
 	log "artifacts=${ARTIFACT_DIR}"
 	export REINHARDT_CLOUD_DEPLOY_INTROSPECT_TIMEOUT_SECONDS="${INTROSPECT_TIMEOUT_SECONDS}"
 


### PR DESCRIPTION
## Summary

This PR addresses:

- Updates `scripts/dashboard_self_deploy_e2e.sh` for recent Dashboard deployment, migration, settings, and route-backed frontend changes.
- Adds automatic `kind` fallback when the current Kubernetes context is unreachable.
- Documents the new self-deploy harness behavior and overrides.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update
- [x] CI/CD changes

## Motivation and Context

The local Dashboard self-deploy harness could fail before exercising the current deployment contract when the active Kubernetes context was down, and it had drifted from recent changes around Rust toolchain selection, required Dashboard settings, revision migration Jobs, and SPA route rendering.

Related to: #702, #713, #714, #716, #723, #724

## How Was This Tested?

- `bash -n scripts/dashboard_self_deploy_e2e.sh`
- `shellcheck scripts/dashboard_self_deploy_e2e.sh`
- `git diff --check`
- `DASHBOARD_SELF_DEPLOY_BUILD_IMAGE=0 DASHBOARD_SELF_DEPLOY_TIMEOUT=240s ./scripts/dashboard_self_deploy_e2e.sh`

## Performance Impact

None expected.

## Breaking Changes

None.

## Screenshots

Not applicable.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Related PRs: #702, #713, #714, #716, #723, #724

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `deployment` - Application deployment logic
- [x] `ci-cd` - CI/CD workflow changes
- [x] `config` - Configuration management

### Priority Label (for maintainers)
- [ ] `high` - Important fix or feature

---

**Additional Context:**

Created as a draft because full `cargo make fmt-check` and `cargo make clippy-check` were not run locally.

🤖 Generated with [Codex](https://openai.com/codex)