### PR TITLE
security: enforce DeploymentCreate RBAC for GitHub import endpoint

### DIFF
--- a/dashboard/src/apps/github/server_fn.rs
+++ b/dashboard/src/apps/github/server_fn.rs
@@ -3,6 +3,9 @@
 use reinhardt::pages::server_fn::{ServerFnError, server_fn};
 use serde::{Deserialize, Serialize};
 
+#[cfg(native)]
+use reinhardt::core::exception::Error as AppError;
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct GitHubInstallationInfo {
 	pub id: i64,
@@ -45,6 +48,18 @@ async fn current_org_id(user: &crate::apps::auth::models::User) -> Result<i64, S
 	crate::apps::organizations::helpers::current_organization_id_for_user(user.id)
 		.await
 		.map_err(|e| ServerFnError::application(e.to_string()))
+}
+
+#[cfg(native)]
+fn server_fn_error_from_app_error(err: AppError) -> ServerFnError {
+	match err {
+		AppError::Authentication(message) => ServerFnError::server(401, message),
+		AppError::Authorization(message) => ServerFnError::server(403, message),
+		_ => {
+			tracing::error!("GitHub server function authorization failed: {err}");
+			ServerFnError::application("Internal server error")
+		}
+	}
 }
 
 #[cfg(native)]
@@ -311,9 +326,12 @@ pub async fn import_github_repository_for_current_org(
 	use crate::apps::github::services::pipeline::{
 		GitHubDeployPipelineInput, run_github_deploy_pipeline,
 	};
+	use crate::apps::organizations::permissions::{Action, require_permission};
 
 	ensure_github_account_linked(&user).await?;
-	let organization_id = current_org_id(&user).await?;
+	let organization_id = require_permission(user.id, Action::DeploymentCreate)
+		.await
+		.map_err(server_fn_error_from_app_error)?;
 	let repository_id: i64 = repository_id
 		.parse()
 		.map_err(|_| ServerFnError::application("Invalid repository_id"))?;


### PR DESCRIPTION
### Motivation
- The GitHub repository import server function allowed any authenticated org member to create Deployments and GitHubProject records without checking the RBAC matrix, enabling low-privilege members (e.g. Viewers) to perform DeploymentCreate operations.
- This is a high-severity authorization gap because unauthorized deployment creation can cause undesired workload builds and resource consumption inside an organization cluster.

### Description
- Require `Action::DeploymentCreate` via the existing guard by calling `require_permission(user.id, Action::DeploymentCreate)` before resolving the organization and performing any import or deployment creation in `dashboard/src/apps/github/server_fn.rs`.
- Add a small mapper `server_fn_error_from_app_error` to convert `AppError::Authorization`/`Authentication` into appropriate `ServerFnError` `403`/`401` responses and treat unexpected guard errors as generic application errors.
- Add the necessary `use` import for `Action` and `require_permission` and wire the guard result into the existing import flow so deployment creation is gated by RBAC.

### Testing
- Ran `cargo fmt --check` which succeeded.
- Ran `git diff --check` which succeeded (no whitespace or diff issues detected).
- Attempted `cargo check -p reinhardt-cloud-dashboard` but the build could not complete in this environment due to `protoc` failing to locate protobuf well-known types (`google/protobuf/timestamp.proto`), so full type-checked compilation was not possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a350be0f9808327bf2e5e8534bbcb97)