### PR TITLE
ci: run coverage only on main

### DIFF
--- a/.github/workflows/cancel-on-pr-close.yml
+++ b/.github/workflows/cancel-on-pr-close.yml
@@ -20,7 +20,7 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const branch = context.payload.pull_request.head.ref;
-            const targetWorkflows = ['ci.yml', 'coverage.yml'];
+            const targetWorkflows = ['ci.yml'];
 
             // Phase 1: Find and cancel all non-completed runs
             const cancelledRunIds = [];

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,20 +221,6 @@ jobs:
       runner: ${{ needs.determine-runner.outputs.runner }}
       cargo-build-jobs: ${{ needs.determine-runner.outputs.cargo-build-jobs }}
 
-  coverage:
-    name: Coverage
-    needs: [unit-test, intra-crate-integration-test, cross-crate-integration-test, determine-runner]
-    if: >-
-      always() &&
-      needs.unit-test.result == 'success' &&
-      needs.intra-crate-integration-test.result == 'success' &&
-      needs.cross-crate-integration-test.result == 'success'
-    uses: ./.github/workflows/coverage.yml
-    secrets: inherit
-    with:
-      runner: ${{ needs.determine-runner.outputs.runner }}
-      cargo-build-jobs: ${{ needs.determine-runner.outputs.cargo-build-jobs }}
-
   terraform-check:
     name: Terraform Check
     needs: [check-branch-status]
@@ -262,7 +248,6 @@ jobs:
       - bruno-tests
       - security-audit
       - todo-check
-      - coverage
       - terraform-check
       - cross-platform-check
       - public-api-diff
@@ -279,7 +264,6 @@ jobs:
           BRUNO_TESTS_RESULT: ${{ needs.bruno-tests.result }}
           SECURITY_AUDIT_RESULT: ${{ needs.security-audit.result }}
           TODO_CHECK_RESULT: ${{ needs.todo-check.result }}
-          COVERAGE_RESULT: ${{ needs.coverage.result }}
           TERRAFORM_CHECK_RESULT: ${{ needs.terraform-check.result }}
           CROSS_PLATFORM_RESULT: ${{ needs.cross-platform-check.result }}
           PUBLIC_API_DIFF_RESULT: ${{ needs.public-api-diff.result }}
@@ -314,7 +298,6 @@ jobs:
 
           # Selectively-skippable checks (can be 'success' or 'skipped')
           selectively_skippable=(
-            "coverage:$COVERAGE_RESULT"
             "terraform-check:$TERRAFORM_CHECK_RESULT"
             "cross-platform-check:$CROSS_PLATFORM_RESULT"
             "public-api-diff:$PUBLIC_API_DIFF_RESULT"
@@ -331,6 +314,6 @@ jobs:
 
   cross-platform-check:
     name: Cross-Platform Check
-    needs: [fmt, clippy]
+    needs: [fmt, clippy, check-branch-status]
     if: needs.check-branch-status.outputs.has-conflicts != 'true'
     uses: ./.github/workflows/cross-platform-check.yml

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,9 @@
 name: Coverage
 
 on:
+  push:
+    branches:
+      - main
   workflow_call:
     inputs:
       runner:
@@ -19,6 +22,10 @@ on:
       DOCKERHUB_TOKEN:
         required: false
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary

This PR addresses:

- Run the Coverage workflow on pushes to `main` instead of as part of every PR CI run.
- Add Coverage workflow concurrency so newer runs cancel older runs for the same ref.
- Remove Coverage from PR CI aggregation and stale PR-close cancellation.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

Running coverage on every PR makes PR feedback slower and duplicates the main test pipeline. Running it after merge keeps Codecov updates on the canonical branch while keeping PR CI focused on faster checks.

Fixes: N/A

Related to: N/A

## How Was This Tested?

- `actionlint .github/workflows/coverage.yml .github/workflows/ci.yml .github/workflows/cancel-on-pr-close.yml`
- `git diff --check`

## Performance Impact

PR CI no longer waits for the expensive coverage job. Coverage still runs on `main`, and stale Coverage runs for the same ref are canceled when a newer run starts.

## Breaking Changes

None.

## Screenshots

N/A.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (not applicable; workflow-only change)
- [ ] New and existing unit tests pass locally with my changes (not run; workflow-only change)
- [ ] I have formatted the code with `cargo make fmt-fix` (not applicable; workflow-only change)
- [ ] I have checked the code with `cargo make clippy-check` (not applicable; workflow-only change)
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

N/A.

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [x] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [ ] `kubernetes` - Kubernetes resources, controllers, operators
- [ ] `deployment` - Application deployment logic
- [ ] `networking` - Ingress, services, network policies
- [ ] `storage` - Persistent volumes, storage classes
- [ ] `auth` - Authentication, authorization, RBAC
- [ ] `api` - REST API, serializers, handlers
- [ ] `cli` - Command-line interface
- [ ] `config` - Configuration management
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

N/A.

🤖 Generated with [Codex](https://openai.com/codex)
