### PR TITLE
ci(release): publish crates through release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -13,12 +13,10 @@ on:
 jobs:
   # Native two-step release workflow:
   # 1. Push to main -> release-plz creates Release PR (branch: release-plz-*)
-  # 2. Merge Release PR -> release-plz detects commit from release-plz-* branch and creates GitHub Release
+  # 2. Merge Release PR -> release-plz detects changed local versions, publishes crates, and creates releases
   #
   # IMPORTANT: pr_branch_prefix must remain "release-plz-" in release-plz.toml
   # to ensure this two-step detection works correctly.
-  #
-  # Note: reinhardt-cloud is not published to crates.io, so CARGO_REGISTRY_TOKEN is not needed.
 
   release-plz-pr:
     name: Release PR
@@ -61,10 +59,28 @@ jobs:
           command: release-pr
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   release-plz-release:
     name: Release
-    if: github.event_name == 'push'
+    # Publish only after a verified Release PR merge. The release-plz-pr job
+    # still runs on every main push so routine feature merges keep the next
+    # Release PR up to date without entering the publish path.
+    #
+    # Accepted Release PR merge shapes:
+    # - merge commit from a release-plz-* branch
+    # - squash commit titled "chore: release (#N)"
+    if: |
+      github.event_name == 'push' && (
+        (
+          startsWith(github.event.head_commit.message, 'Merge pull request #') &&
+          contains(github.event.head_commit.message, '/release-plz-')
+        ) ||
+        (
+          startsWith(github.event.head_commit.message, 'chore: release ') &&
+          contains(github.event.head_commit.message, '(#')
+        )
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 30
     concurrency:
@@ -97,11 +113,74 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
+      - name: Verify release branch name
+        if: "startsWith(github.event.head_commit.message, 'Merge pull request #')"
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          # Extract branch name from merge commit message.
+          # Format: "Merge pull request #N from owner/BRANCH_NAME"
+          BRANCH=$(echo "$COMMIT_MSG" | grep -oP 'from [^/]+/\K.+$' || true)
+          if [ -z "$BRANCH" ]; then
+            echo "::error::Could not extract branch name from commit message"
+            exit 1
+          fi
+          echo "Extracted branch name: $BRANCH"
+          case "$BRANCH" in
+            release-plz-*)
+              echo "Branch '$BRANCH' matches release branch pattern"
+              ;;
+            *)
+              echo "::error::Branch '$BRANCH' does not start with 'release-plz-'"
+              echo "::error::This push does not originate from a release-plz branch. Refusing to publish."
+              exit 1
+              ;;
+          esac
+
+      - name: Verify release PR label
+        if: "startsWith(github.event.head_commit.message, 'Merge pull request #') || (startsWith(github.event.head_commit.message, 'chore: release ') && contains(github.event.head_commit.message, '(#'))"
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          # Extract PR number from merge-commit or squash-merge commit message.
+          # Formats:
+          # - "Merge pull request #N from owner/BRANCH_NAME"
+          # - "chore: release (#N)"
+          PR_NUMBER=$(echo "$COMMIT_MSG" | grep -oP '^Merge pull request #\K\d+' || true)
+          if [ -z "$PR_NUMBER" ]; then
+            PR_NUMBER=$(printf '%s\n' "$COMMIT_MSG" | head -n1 | sed -nE 's/^chore: release \(#([0-9]+)\).*$/\1/p')
+          fi
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::error::Could not extract PR number from commit message"
+            exit 1
+          fi
+          echo "Verifying PR #$PR_NUMBER has the 'release' label..."
+          LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' 2>/dev/null || echo "")
+          if ! echo "$LABELS" | grep -qx 'release'; then
+            echo "::error::PR #$PR_NUMBER does not have the 'release' label. Labels found: $LABELS"
+            echo "::error::Only PRs with the 'release' label are allowed to publish. Refusing to publish."
+            exit 1
+          fi
+          echo "PR #$PR_NUMBER has the 'release' label; proceeding with publish"
+
+          MERGE_COMMIT_SHA=$(gh pr view "$PR_NUMBER" --json mergeCommit --jq '.mergeCommit.oid // ""' 2>/dev/null || echo "")
+          if [ -z "$MERGE_COMMIT_SHA" ]; then
+            echo "::error::Could not determine merge commit SHA for PR #$PR_NUMBER"
+            exit 1
+          fi
+          if [ "$MERGE_COMMIT_SHA" != "$GITHUB_SHA" ]; then
+            echo "::error::Pushed SHA $GITHUB_SHA does not match release PR #$PR_NUMBER merge commit $MERGE_COMMIT_SHA"
+            echo "::error::Refusing to publish from an unverified release commit."
+            exit 1
+          fi
+          echo "Pushed SHA matches PR #$PR_NUMBER merge commit; proceeding with publish"
+
       # Workaround for gix slotmap overflow (GitoxideLabs/gitoxide#1788)
       - name: Clear cargo registry git index cache
         run: rm -rf ~/.cargo/registry/index/github.com-*
 
-      - name: Create GitHub Release (attempt 1/3)
+      - name: Publish to crates.io and create releases (attempt 1/3)
         id: release-attempt-1
         continue-on-error: true
         uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5
@@ -109,6 +188,7 @@ jobs:
           command: release
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: Wait before retry (attempt 1)
         if: steps.release-attempt-1.outcome == 'failure'
@@ -120,7 +200,7 @@ jobs:
         if: steps.release-attempt-1.outcome == 'failure'
         run: rm -rf ~/.cargo/registry/index/github.com-*
 
-      - name: Create GitHub Release (attempt 2/3)
+      - name: Publish to crates.io and create releases (attempt 2/3)
         id: release-attempt-2
         if: steps.release-attempt-1.outcome == 'failure'
         continue-on-error: true
@@ -129,6 +209,7 @@ jobs:
           command: release
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: Wait before retry (attempt 2)
         if: steps.release-attempt-1.outcome == 'failure' && steps.release-attempt-2.outcome == 'failure'
@@ -140,10 +221,11 @@ jobs:
         if: steps.release-attempt-1.outcome == 'failure' && steps.release-attempt-2.outcome == 'failure'
         run: rm -rf ~/.cargo/registry/index/github.com-*
 
-      - name: Create GitHub Release (attempt 3/3)
+      - name: Publish to crates.io and create releases (attempt 3/3)
         if: steps.release-attempt-1.outcome == 'failure' && steps.release-attempt-2.outcome == 'failure'
         uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5
         with:
           command: release
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5472,8 +5472,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reinhardt-admin"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "739cb5f726f8e91f9743639dfc408c00a81f8546a233fa499ceb6d2dc01088fd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5523,8 +5524,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-apps"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ec9a75ab3a1235fb42f69844ffefca33fef188ec3760a673e6b53e20d0dc9b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5553,8 +5555,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-auth"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "073c2165070a9c20e4f81b2647f4352e6aba268d62d019e5a027c672a25f666d"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5600,8 +5603,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-auth-macros"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a3d8d46a3743fdf6cef8d704fb2358fd7b07a82c99c7bf8bb848525de83cbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5923,8 +5927,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-commands"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d125aba137ec363bd5a7ce2b3520c823111233bcd5d90897975e07f41e3628"
 dependencies = [
  "async-trait",
  "bollard",
@@ -5985,8 +5990,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-conf"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97b8fd2fb59c1ab9f84db2cc843256486b7fe480d14eee02f3792601aab2a45"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -6013,8 +6019,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-core"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4a3414f135ed030444e259fecc903223c032dffd7cc28834a4d284538c5b3c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6058,8 +6065,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-db"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95bfe674be29fc9cbeb747d7e0e8b80e60f6bed2e641294445f62d0f1ce8a99b"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -6111,8 +6119,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-di"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "505d17e1c6ad74f969cedf4c50be5cb7064e74d0c3f254cbe0cdb8adc3a7bd00"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6135,8 +6144,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-di-macros"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "052deaf38d2c50d47b2dae685edc2ae619cd979faab8d8b80477bc6ed832fd8b"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6146,8 +6156,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-forms"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76c5b4dee130e8fd0904fe796d32468e746fd4200050608996a2cb47a1b9f0dc"
 dependencies = [
  "anyhow",
  "aquamarine 0.5.0",
@@ -6163,8 +6174,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-http"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c112c8ce00effb06e1e941a41ff922cf330f0b900b51203846549b58151142c"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6184,8 +6196,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-macros"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb56cbf7529b12ccd53d51b4913dd399999f39c4f8a7ad172bb73fc81947df8"
 dependencies = [
  "ctor 0.8.0",
  "inventory",
@@ -6198,8 +6211,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-mail"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "068c8ca74ebd05c9cab7c31a16e6f008d9833b9bdc092ce5d97244963d572f8b"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6219,8 +6233,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-manouche"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "573d847c78b382f194e35f1f4d307c2363ea445b9d1846472cad57f08ddd22f2"
 dependencies = [
  "convert_case",
  "darling 0.20.11",
@@ -6231,8 +6246,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-middleware"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d470bc909f09e3f8c3e7b06388748982c36f550e813f6c61ea80dfc96a6986"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6264,8 +6280,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-openapi"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0426a2f5d6a53978bdc8738bdbe218ad2d62b741767807ae98d90953060323f6"
 dependencies = [
  "async-trait",
  "reinhardt-http",
@@ -6276,8 +6293,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-openapi-macros"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5407d3916533ff801a36ac5772752760cfb9f77b4cd436bfb4b073e994ee028e"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6287,8 +6305,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-pages"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88bef65504ac9f00fa219fa150556d831270b385c0b0d89e6170922fd0f69a6"
 dependencies = [
  "async-trait",
  "bon",
@@ -6330,8 +6349,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-pages-ast"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45142117ba5251efef071f3bf21a934f3c787ad5d9a6297dd44d9f4176b827f8"
 dependencies = [
  "convert_case",
  "darling 0.20.11",
@@ -6343,8 +6363,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-pages-macros"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29997d1dcc876d105fddd840a94305ffb65f22a1b55580cdc5a42bab8aedbca9"
 dependencies = [
  "convert_case",
  "darling 0.20.11",
@@ -6357,8 +6378,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-query"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed9718db633918eb30dc6cb941cb19eea69ac2bcb9fd3b59e1dc140291d0aa9"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -6371,8 +6393,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-query-macros"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9e13462fce04249187b74408cd96dc76a85b5fbee0fc549f25fdba5bee85d80"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -6382,8 +6405,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-rest"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea474c9ee3659b10a3be6d071b926fe62a8d3969c24577d0a732ba0037ae34f3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6432,13 +6456,15 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-router"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f36c18e667af3d03473fe037d26c381749ebab566d5aa22697743aaa470b95"
 
 [[package]]
 name = "reinhardt-routers-macros"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0df7afc041fde9557710c2de96826f463d68766e8147f5f09f8eff33cad7e6bc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6447,8 +6473,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-server"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33f3e0b1149a375b282aa9f72b947a832e4657c99968fa23a7cf775304ad0071"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6468,8 +6495,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-shortcuts"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aacd29de773556fd0c29cc5b9b16e4955b320988c9ac7470aaea9201f872350"
 dependencies = [
  "bytes",
  "hyper",
@@ -6486,8 +6514,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-test"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9a8398715349daae0ef112f6ad09c4d3072f13da913de456c95c795da4d749f"
 dependencies = [
  "cfg_aliases",
  "reinhardt-auth",
@@ -6506,8 +6535,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-testkit"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc15962b65efa03c3fd73b9f6ff2700e536f344e9d3fba75056afc851df84110"
 dependencies = [
  "astral-tokio-tar",
  "async-dropper",
@@ -6563,8 +6593,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-testkit-macros"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "080a4ca1a113d14397d96a9e2470ce0658778b9e907448e739a632505f6677ea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6573,8 +6604,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-throttling"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee236c3c636731d2bcef563928b0b5b6abff52526c09ab17eccb66c4496de06"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -6584,8 +6616,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-urls"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b00d73a9f26ec4216760deed68e4b8b2994a5fc706273b842c60dae4c19e764f"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -6618,8 +6651,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-utils"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34e328352f13086724c2c05f81e1e608bf58998ed3fc709120eeb7ec6255d4ec"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6654,8 +6688,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-views"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58832b79536f4163b9ed3ccccc0d68e3e7fc760fbf4e8d810775fe4bf7de0c10"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6689,8 +6724,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-web"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7d2fc7afbf978f2862ecedcb06d5daf3592fe6c7a341375b949bf8e4cfdd9a0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6731,8 +6767,9 @@ dependencies = [
 
 [[package]]
 name = "reinhardt-websockets"
-version = "0.2.0"
-source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56bc7614ce9cfc3a979b7ca74a95b2c91834a4a012759a4b6308823c3ca10486"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ rustls = { version = "0.23", default-features = false, features = ["ring"] }
 # Reinhardt — umbrella crate providing: HTTP server, auth (JWT + Argon2), database (SeaQuery),
 # configuration, DI container, middleware, OpenAPI, and management commands.
 # Direct hyper/jsonwebtoken/argon2/sea-query deps are NOT needed — reinhardt provides them.
-reinhardt = { package = "reinhardt-web", git = "https://github.com/kent8192/reinhardt-web", branch = "develop/0.3.0", features = ["database", "db-postgres", "auth", "auth-jwt", "auth-social", "argon2-hasher", "core", "conf", "server", "di", "middleware", "middleware-security", "middleware-auth-jwt", "rest", "openapi", "openapi-router", "commands-server", "introspect", "test", "testcontainers", "pages", "websockets", "admin", "sessions", "session-redis", "mail", "static-files", "client-router"] }
+reinhardt = { package = "reinhardt-web", version = "0.3.0-rc.2", features = ["database", "db-postgres", "auth", "auth-jwt", "auth-social", "argon2-hasher", "core", "conf", "server", "di", "middleware", "middleware-security", "middleware-auth-jwt", "rest", "openapi", "openapi-router", "commands-server", "introspect", "test", "testcontainers", "pages", "websockets", "admin", "sessions", "session-redis", "mail", "static-files", "client-router"] }
 
 # PostgreSQL driver (sea-query is available via reinhardt::prelude — no direct dep needed)
 tokio-postgres = { version = "0.7", features = ["with-serde_json-1"] }
@@ -92,13 +92,13 @@ tokio-tungstenite = { version = "0.28", features = ["rustls-tls-webpki-roots"] }
 async-stream = "0.3"
 
 # Internal workspace crates
-reinhardt-cloud = { path = "crates/reinhardt-cloud" }
-reinhardt-cloud-types = { path = "crates/reinhardt-cloud-types" }
-reinhardt-cloud-core = { path = "crates/reinhardt-cloud-core" }
-reinhardt-cloud-k8s = { path = "crates/reinhardt-cloud-k8s" }
-reinhardt-cloud-proto = { path = "crates/reinhardt-cloud-proto" }
-reinhardt-cloud-grpc = { path = "crates/reinhardt-cloud-grpc" }
-reinhardt-cloud-telemetry = { path = "crates/reinhardt-cloud-telemetry" }
+reinhardt-cloud = { path = "crates/reinhardt-cloud", version = "0.1.0" }
+reinhardt-cloud-types = { path = "crates/reinhardt-cloud-types", version = "0.1.0" }
+reinhardt-cloud-core = { path = "crates/reinhardt-cloud-core", version = "0.1.0" }
+reinhardt-cloud-k8s = { path = "crates/reinhardt-cloud-k8s", version = "0.1.0" }
+reinhardt-cloud-proto = { path = "crates/reinhardt-cloud-proto", version = "0.1.0" }
+reinhardt-cloud-grpc = { path = "crates/reinhardt-cloud-grpc", version = "0.1.0" }
+reinhardt-cloud-telemetry = { path = "crates/reinhardt-cloud-telemetry", version = "0.1.0" }
 
 # Cryptography / encoding
 rand = "0.9"

--- a/crates/reinhardt-cloud-agent/Cargo.toml
+++ b/crates/reinhardt-cloud-agent/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-publish = false
+description = "In-cluster agent for Reinhardt Cloud workload operations"
 
 [[bin]]
 name = "reinhardt-cloud-agent"

--- a/crates/reinhardt-cloud-cli/Cargo.toml
+++ b/crates/reinhardt-cloud-cli/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-publish = false
+description = "Command-line interface for Reinhardt Cloud deployments"
 
 [[bin]]
 name = "reinhardt-cloud"

--- a/crates/reinhardt-cloud-core/Cargo.toml
+++ b/crates/reinhardt-cloud-core/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-publish = false
+description = "Core services and domain logic for Reinhardt Cloud"
 
 [dependencies]
 reinhardt-cloud-types = { workspace = true }

--- a/crates/reinhardt-cloud-grpc/Cargo.toml
+++ b/crates/reinhardt-cloud-grpc/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-publish = false
+description = "gRPC service implementations for Reinhardt Cloud"
 
 [dependencies]
 reinhardt-cloud-core = { workspace = true }

--- a/crates/reinhardt-cloud-k8s/Cargo.toml
+++ b/crates/reinhardt-cloud-k8s/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-publish = false
+description = "Kubernetes resource helpers for Reinhardt Cloud"
 
 [dependencies]
 kube = { workspace = true }

--- a/crates/reinhardt-cloud-operator/Cargo.toml
+++ b/crates/reinhardt-cloud-operator/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-publish = false
+description = "Kubernetes operator for Reinhardt Cloud"
 
 [dependencies]
 reinhardt-cloud-types = { workspace = true }

--- a/crates/reinhardt-cloud-proto/Cargo.toml
+++ b/crates/reinhardt-cloud-proto/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-publish = false
+description = "Protocol Buffer and gRPC type definitions for Reinhardt Cloud"
 
 [dependencies]
 tonic = "0.13"

--- a/crates/reinhardt-cloud-telemetry/Cargo.toml
+++ b/crates/reinhardt-cloud-telemetry/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-publish = false
+description = "Telemetry and log streaming integrations for Reinhardt Cloud"
 
 [dependencies]
 serde = { workspace = true }

--- a/crates/reinhardt-cloud-types/Cargo.toml
+++ b/crates/reinhardt-cloud-types/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-publish = false
+description = "Shared API, configuration, and Kubernetes types for Reinhardt Cloud"
 
 [dependencies]
 serde = { workspace = true }

--- a/crates/reinhardt-cloud/Cargo.toml
+++ b/crates/reinhardt-cloud/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-publish = false
+description = "Umbrella crate for Reinhardt Cloud control plane components"
 
 [dependencies]
 reinhardt-cloud-core = { workspace = true }

--- a/dashboard/Cargo.toml
+++ b/dashboard/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description = "Control plane dashboard application for Reinhardt Cloud"
 publish = false
 
 [lib]

--- a/instructions/COMMIT_GUIDELINE.md
+++ b/instructions/COMMIT_GUIDELINE.md
@@ -130,7 +130,7 @@ If unsure whether an artifact qualifies, default to excluding it and ask the use
 
 **Overview:**
 
-This project uses [release-plz](https://release-plz.ieni.dev/) for automated release management. Version bumps, CHANGELOG updates, GitHub Releases, and Git tags are handled automatically based on conventional commits and `release-plz.toml`.
+This project uses [release-plz](https://release-plz.ieni.dev/) for automated release management. Version bumps, CHANGELOG updates, crates.io publishing, GitHub Releases, and Git tags are handled automatically based on conventional commits and `release-plz.toml`.
 
 **How It Works:**
 
@@ -141,7 +141,7 @@ This project uses [release-plz](https://release-plz.ieni.dev/) for automated rel
    - Updated CHANGELOG.md files
    - Summary of changes
 4. Review and merge the Release PR
-5. release-plz creates GitHub Releases and Git tags for configured packages
+5. release-plz publishes configured crates to crates.io, creates GitHub Releases, and creates Git tags
 
 **Commit-to-Version Mapping:**
 
@@ -170,11 +170,13 @@ sequenceDiagram
     participant Dev as Developer
     participant Git as Git/GitHub
     participant RP as release-plz
+    participant Crates as crates.io
 
     Dev->>Git: Push conventional commits to main
     RP->>Git: Analyze commits since last release
     RP->>Git: Create Release PR (version bumps + CHANGELOG)
     Dev->>Git: Review and merge Release PR
+    RP->>Crates: Publish configured crates
     RP->>Git: Create GitHub Releases
     RP->>Git: Create git tags (package@vX.Y.Z)
 ```

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,8 +2,8 @@
 # Documentation: https://release-plz.ieni.dev/docs/config
 #
 # Crate structure:
-#   Library crates (publish = false): reinhardt-cloud-types, reinhardt-cloud-core, reinhardt-cloud-k8s
-#   Binary crates (GitHub Releases):  reinhardt-cloud-dashboard, reinhardt-cloud-operator, reinhardt-cloud-cli
+#   Published crates: library crates plus CLI/operator/agent binaries.
+#   Dashboard: versioned and released through GitHub/Docker assets, but not published to crates.io.
 
 [workspace]
 # Changelog settings
@@ -22,44 +22,64 @@ git_tag_name = "{{ package }}@v{{ version }}"
 git_release_type = "auto"
 
 # Publish settings
-# semver_check disabled at workspace level: library crates are internal (publish = false)
-# and binary crates are not published to crates.io.
-semver_check = false
+# Keep this aligned with the reinhardt-web release flow: release-plz creates
+# Release PRs on normal pushes, then publishes crates only after the Release PR
+# merge leaves local versions ahead of crates.io.
+semver_check = true
 publish_timeout = "10m"
 dependencies_update = true
 release_always = true
 publish_no_verify = true
 
-# ── Application crate ─────────────────────────────────────────────────────
-# Reinhardt startproject application. Distributed via Docker image / GitHub Releases.
+# Main crate. Only selected application/binary crates get GitHub Releases.
 
 [[package]]
 name = "reinhardt-cloud"
-publish = false
 git_release_enable = true
 version_group = "reinhardt-cloud"
 
-# ── Internal library crates ──────────────────────────────────────────────────
-# These crates are workspace-internal and not published to crates.io.
-# release-plz still manages their changelogs and tags for internal tracking.
+# Publishable crates.
 
 [[package]]
-name = "reinhardt-cloud-types"
-publish = false
+name = "reinhardt-cloud-agent"
+git_release_enable = true
+version_group = "reinhardt-cloud"
+
+[[package]]
+name = "reinhardt-cloud-cli"
+git_release_enable = true
 version_group = "reinhardt-cloud"
 
 [[package]]
 name = "reinhardt-cloud-core"
-publish = false
+version_group = "reinhardt-cloud"
+
+[[package]]
+name = "reinhardt-cloud-grpc"
 version_group = "reinhardt-cloud"
 
 [[package]]
 name = "reinhardt-cloud-k8s"
-publish = false
 version_group = "reinhardt-cloud"
 
-# ── Binary crates (GitHub Releases) ─────────────────────────────────────────
-# These crates are distributed as GitHub Releases (not crates.io).
+[[package]]
+name = "reinhardt-cloud-operator"
+git_release_enable = true
+version_group = "reinhardt-cloud"
+
+[[package]]
+name = "reinhardt-cloud-proto"
+version_group = "reinhardt-cloud"
+
+[[package]]
+name = "reinhardt-cloud-telemetry"
+version_group = "reinhardt-cloud"
+
+[[package]]
+name = "reinhardt-cloud-types"
+version_group = "reinhardt-cloud"
+
+# Dashboard remains an application release artifact, not a crates.io crate.
 
 [[package]]
 name = "reinhardt-cloud-dashboard"
@@ -67,17 +87,11 @@ publish = false
 git_release_enable = true
 version_group = "reinhardt-cloud"
 
+# Non-published test package.
 [[package]]
-name = "reinhardt-cloud-operator"
+name = "reinhardt-cloud-integration-tests"
+release = false
 publish = false
-git_release_enable = true
-version_group = "reinhardt-cloud"
-
-[[package]]
-name = "reinhardt-cloud-cli"
-publish = false
-git_release_enable = true
-version_group = "reinhardt-cloud"
 
 [changelog]
 protect_breaking_commits = true


### PR DESCRIPTION
## Summary

This PR addresses:

- Enables release-plz to publish non-dashboard Reinhardt Cloud crates to crates.io.
- Keeps `reinhardt-cloud-dashboard` as a GitHub/Docker release artifact instead of a crates.io package.
- Aligns the release workflow with the reinhardt-web Release PR merge publish path.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

`release-plz.toml` previously disabled publishing for every configured package, while project documentation and CLI usage already point users at published crates. This change enables crates.io publication only after a verified Release PR merge and passes `CARGO_REGISTRY_TOKEN` to release-plz.

Dashboard remains excluded because it is an operational application with server/WASM assets, migrations, settings, and `manage` binary behavior rather than a reusable crates.io library or CLI package.

Fixes: N/A

Related to: N/A

## How Was This Tested?

- `cargo metadata --no-deps --format-version 1`
- `cargo package --list --allow-dirty` for all publishable packages
- `cargo package --list -p reinhardt-cloud-dashboard --allow-dirty`
- `cargo publish --dry-run --allow-dirty --no-verify -p reinhardt-cloud-types`
- `cargo check --workspace --all --all-features`
- `cargo make fmt-check`
- `cargo make clippy-check`
- `semgrep scan --config p/supply-chain --error --metrics off`

`release-plz release --dry-run --allow-dirty --config release-plz.toml -o json` was also attempted, but the full initial multi-crate publish cannot complete locally because dry-run does not upload `reinhardt-cloud-types`; later dry-run package checks then cannot resolve it from the crates.io index.

## Performance Impact

No runtime performance impact.

## Breaking Changes

No breaking changes.

**Migration Guide:**

No migration required.

## Screenshots

Not applicable.

### Before

Not applicable.

### After

Not applicable.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

<!-- ⚠️ CI CONTROL CHECKBOX - DO NOT EDIT MANUALLY ⚠️
The following checkbox controls CI runner selection.
Checking this option triggers self-hosted runner usage,
which incurs infrastructure costs. Only the repository owner should enable this.
If this checkbox is missing or unchecked, CI defaults to GitHub-hosted runners.
Do NOT modify the checkbox text — CI parses it by exact pattern match. -->
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

None.

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [ ] `kubernetes` - Kubernetes resources, controllers, operators
- [ ] `deployment` - Application deployment logic
- [ ] `networking` - Ingress, services, network policies
- [ ] `storage` - Persistent volumes, storage classes
- [ ] `auth` - Authentication, authorization, RBAC
- [ ] `api` - REST API, serializers, handlers
- [ ] `cli` - Command-line interface
- [ ] `config` - Configuration management
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

`reinhardt-cloud-dashboard` remains non-publishable in both Cargo metadata and release-plz configuration.

🤖 Generated with [Codex](https://openai.com/codex)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow with improved verification checks before publishing
  * Expanded crates.io publishing to additional components, making them available as libraries
  * Updated dependencies to stable versioned releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->