### PR TITLE
refactor(dashboard): register page routes from components

### DIFF
--- a/dashboard/src/apps/auth/urls.rs
+++ b/dashboard/src/apps/auth/urls.rs
@@ -22,9 +22,9 @@ pub fn url_patterns() -> UnifiedRouter {
 			s
 		})
 		.client(|c| {
-			c.page("account_page", "/account", account_page)
-				.page("login_page", "/login", login_page)
-				.page("register_page", "/register", register_page)
+			c.component(account_page)
+				.component(login_page)
+				.component(register_page)
 		})
 }
 
@@ -76,9 +76,25 @@ mod tests {
 			.into_client();
 
 		// Act
-		let account = router.reverse("account_page", &[]);
+		let account = router.reverse("auth:account_page", &[]);
 
 		// Assert
 		assert_eq!(account, Ok("/account".to_string()));
+	}
+
+	#[rstest]
+	fn login_and_register_page_routes_are_registered_from_component_metadata() {
+		// Arrange
+		let router = UnifiedRouter::new()
+			.mount_unified("/", super::url_patterns())
+			.into_client();
+
+		// Act
+		let login = router.reverse("auth:login_page", &[]);
+		let register = router.reverse("auth:register_page", &[]);
+
+		// Assert
+		assert_eq!(login, Ok("/login".to_string()));
+		assert_eq!(register, Ok("/register".to_string()));
 	}
 }

--- a/dashboard/src/apps/clusters/urls.rs
+++ b/dashboard/src/apps/clusters/urls.rs
@@ -10,5 +10,25 @@ use crate::apps::clusters::client::pages::clusters_list_page;
 pub fn url_patterns() -> UnifiedRouter {
 	UnifiedRouter::new()
 		.server(|s| s)
-		.client(|c| c.page("list", "/clusters", clusters_list_page))
+		.client(|c| c.component(clusters_list_page))
+}
+
+#[cfg(all(test, native))]
+mod tests {
+	use reinhardt::urls::prelude::UnifiedRouter;
+	use rstest::rstest;
+
+	#[rstest]
+	fn clusters_page_route_is_registered_from_component_metadata() {
+		// Arrange
+		let router = UnifiedRouter::new()
+			.mount_unified("/", super::url_patterns())
+			.into_client();
+
+		// Act
+		let route = router.reverse("clusters:list", &[]);
+
+		// Assert
+		assert_eq!(route, Ok("/clusters".to_string()));
+	}
 }

--- a/dashboard/src/apps/dashboard/urls.rs
+++ b/dashboard/src/apps/dashboard/urls.rs
@@ -1,10 +1,9 @@
 //! URL configuration for the dashboard app.
 //!
 //! Declares the project-level SPA `home` route reachable from the
-//! top-level navigation. Server-side reverse URL resolution uses
-//! `UrlReverser::from_global()` and SPA navigation uses hardcoded paths.
-//! Per-section routes (`clusters:list`, `deployments:list`) are owned by
-//! their respective apps' `url_patterns`.
+//! top-level navigation. The page component owns its route path and name
+//! through `#[component(...)]`; this module only mounts that component into
+//! the unified router.
 
 pub mod ws_urls;
 
@@ -16,5 +15,25 @@ use crate::apps::dashboard::client::layout::dashboard_shell;
 pub fn url_patterns() -> UnifiedRouter {
 	UnifiedRouter::new()
 		.server(|s| s)
-		.client(|c| c.page("home", "/", dashboard_shell))
+		.client(|c| c.component(dashboard_shell))
+}
+
+#[cfg(all(test, native))]
+mod tests {
+	use reinhardt::urls::prelude::UnifiedRouter;
+	use rstest::rstest;
+
+	#[rstest]
+	fn dashboard_home_route_is_registered_from_component_metadata() {
+		// Arrange
+		let router = UnifiedRouter::new()
+			.mount_unified("/", super::url_patterns())
+			.into_client();
+
+		// Act
+		let route = router.reverse("dashboard:home", &[]);
+
+		// Assert
+		assert_eq!(route, Ok("/".to_string()));
+	}
 }

--- a/dashboard/src/apps/deployments/urls.rs
+++ b/dashboard/src/apps/deployments/urls.rs
@@ -16,7 +16,7 @@ pub fn url_patterns() -> UnifiedRouter {
 			let s = s.endpoint(server_urls::cli_deploy);
 			s
 		})
-		.client(|c| c.page("list", "/deployments", deployments_list_page))
+		.client(|c| c.component(deployments_list_page))
 }
 
 #[cfg(all(test, native))]
@@ -37,5 +37,19 @@ mod tests {
 
 		// Assert
 		assert_eq!(url, Some("/api/deployments/cli/".to_string()));
+	}
+
+	#[rstest]
+	fn deployments_page_route_is_registered_from_component_metadata() {
+		// Arrange
+		let router = UnifiedRouter::new()
+			.mount_unified("/", super::url_patterns())
+			.into_client();
+
+		// Act
+		let route = router.reverse("deployments:list", &[]);
+
+		// Assert
+		assert_eq!(route, Ok("/deployments".to_string()));
 	}
 }

--- a/dashboard/src/apps/github/urls.rs
+++ b/dashboard/src/apps/github/urls.rs
@@ -2,16 +2,19 @@
 
 use reinhardt::urls::prelude::UnifiedRouter;
 
+use crate::apps::github::client::pages::github_repositories_page;
 #[cfg(native)]
 use crate::apps::github::server_urls;
 
 pub fn url_patterns() -> UnifiedRouter {
-	UnifiedRouter::new().server(|s| {
-		#[cfg(native)]
-		let s = s.endpoint(server_urls::github_setup)
-			.endpoint(server_urls::github_webhook);
-		s
-	})
+	UnifiedRouter::new()
+		.server(|s| {
+			#[cfg(native)]
+			let s = s.endpoint(server_urls::github_setup)
+				.endpoint(server_urls::github_webhook);
+			s
+		})
+		.client(|c| c.component(github_repositories_page))
 }
 
 #[cfg(all(test, native))]
@@ -47,5 +50,19 @@ mod tests {
 
 		// Assert
 		assert_eq!(url, Some("/api/github/setup/".to_string()));
+	}
+
+	#[rstest]
+	fn github_repositories_page_route_is_registered_from_component_metadata() {
+		// Arrange
+		let router = UnifiedRouter::new()
+			.mount_unified("/", super::url_patterns())
+			.into_client();
+
+		// Act
+		let route = router.reverse("github:repositories", &[]);
+
+		// Assert
+		assert_eq!(route, Ok("/github".to_string()));
 	}
 }

--- a/dashboard/src/client/router.rs
+++ b/dashboard/src/client/router.rs
@@ -1,6 +1,6 @@
 //! SPA router configuration for the Reinhardt Cloud WASM client.
 //!
-//! Routes are declared in [`init_router`], which builds a
+//! Routes are composed in [`init_router`], which builds a
 //! [`reinhardt::urls::prelude::ClientRouter`] through
 //! [`reinhardt::urls::prelude::UnifiedRouter`] and installs it globally
 //! as a side effect. The terminating
@@ -16,8 +16,8 @@
 //!
 //! # Route names
 //!
-//! Every SPA route is registered from route-backed component metadata
-//! via `ClientRouter::component`, so the path and name live with the
+//! Every SPA route is registered from route-backed component metadata in
+//! each app's `url_patterns()` function, so the path and name live with the
 //! page component declaration. Names follow the `<app>:<name>` namespace
 //! convention used by server-side view macros. SPA names use a `_page`
 //! suffix where a server-side route already owns the unsuffixed name
@@ -29,11 +29,7 @@
 
 use reinhardt::urls::prelude::{ClientRouter, UnifiedRouter};
 
-use crate::apps::auth::client::pages::{account_page, login_page, register_page};
-use crate::apps::clusters::client::pages::clusters_list_page;
-use crate::apps::dashboard::client::layout::dashboard_shell;
-use crate::apps::deployments::client::pages::deployments_list_page;
-use crate::apps::github::client::pages::github_repositories_page;
+use crate::apps::{auth, clusters, dashboard, deployments, github};
 use crate::shared::client::pages::not_found::not_found_page;
 
 /// Build the SPA router and register the client URL reverser globally.
@@ -44,15 +40,11 @@ use crate::shared::client::pages::not_found::not_found_page;
 /// WASM client.
 pub fn init_router() -> ClientRouter {
 	UnifiedRouter::new()
-		.client(|c| {
-			c.component(dashboard_shell)
-				.component(account_page)
-				.component(login_page)
-				.component(register_page)
-				.component(clusters_list_page)
-				.component(deployments_list_page)
-				.component(github_repositories_page)
-				.not_found(not_found_page)
-		})
+		.client(|c| c.not_found(not_found_page))
+		.mount_unified("/", dashboard::urls::url_patterns())
+		.mount_unified("/auth/", auth::urls::url_patterns())
+		.mount_unified("/clusters/", clusters::urls::url_patterns())
+		.mount_unified("/deployments/", deployments::urls::url_patterns())
+		.mount_unified("/github/", github::urls::url_patterns())
 		.register_globally()
 }


### PR DESCRIPTION
## Summary

This PR addresses:

- Registers dashboard SPA routes through `ClientRouter::component(...)` so `#[component(...)]` metadata owns each page path and name.
- Composes the WASM router from each app-level `url_patterns()` implementation instead of duplicating page registrations in `client/router.rs`.
- Adds route metadata regression tests for the dashboard, auth, clusters, deployments, and GitHub pages.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

- Route path/name metadata already lives on each page component via `#[component(...)]`. Keeping separate `.page(name, path, handler)` calls in app routers duplicated that source of truth and could drift.

Fixes: N/A

Related to: N/A

## How Was This Tested?

- `cargo make fmt-check`
- `git diff --check`
- `cd dashboard && cargo check --all-features`
- `cd dashboard && cargo test --all-features route_is_registered`
- `cd dashboard && cargo test --all-features login_and_register_page_routes_are_registered_from_component_metadata`
- `cd dashboard && cargo make wasm-compile-dev`
- `cargo make clippy-check`

## Performance Impact

- None expected. This only changes route registration composition and metadata tests.

## Breaking Changes

- None.

**Migration Guide:**

- Not applicable.

## Screenshots

Not applicable. This is a route registration refactor with no visible UI changes.

### Before

- Not applicable.

### After

- Not applicable.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- N/A

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [x] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [ ] `kubernetes` - Kubernetes resources, controllers, operators
- [ ] `deployment` - Application deployment logic
- [ ] `networking` - Ingress, services, network policies
- [ ] `storage` - Persistent volumes, storage classes
- [ ] `auth` - Authentication, authorization, RBAC
- [ ] `api` - REST API, serializers, handlers
- [ ] `cli` - Command-line interface
- [ ] `config` - Configuration management
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

- The PR keeps the 404 fallback as a router-level `not_found` handler because it does not carry route metadata.

Generated with Codex