### PR TITLE
test(dashboard): add MSW-backed browser E2E

### DIFF
--- a/.github/workflows/wasm-build.yml
+++ b/.github/workflows/wasm-build.yml
@@ -57,9 +57,8 @@ jobs:
           tool: cargo-make
 
       - name: Install wasm-pack
-        uses: taiki-e/install-action@de6bbd1333b8f331563d54a051e542c7dfef81c3 # v2
-        with:
-          tool: wasm-pack
+        shell: bash
+        run: cargo install wasm-pack --locked
 
       - name: Build dashboard for wasm32-unknown-unknown
         working-directory: dashboard

--- a/.github/workflows/wasm-build.yml
+++ b/.github/workflows/wasm-build.yml
@@ -56,6 +56,15 @@ jobs:
         with:
           tool: cargo-make
 
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@de6bbd1333b8f331563d54a051e542c7dfef81c3 # v2
+        with:
+          tool: wasm-pack
+
       - name: Build dashboard for wasm32-unknown-unknown
         working-directory: dashboard
         run: cargo make wasm-compile-dev
+
+      - name: Run dashboard WASM browser tests
+        working-directory: dashboard
+        run: cargo make wasm-spa-test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6489,7 +6489,14 @@ name = "reinhardt-test"
 version = "0.2.0"
 source = "git+https://github.com/kent8192/reinhardt-web?branch=develop%2F0.3.0#13f9d36513796c88d4fbedad99f6e63c73505f1c"
 dependencies = [
+ "bytes",
  "cfg_aliases",
+ "gloo-timers",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "regex",
  "reinhardt-auth",
  "reinhardt-conf",
  "reinhardt-core",
@@ -6502,6 +6509,10 @@ dependencies = [
  "serde_json",
  "tokio",
  "uuid",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test",
+ "web-sys",
 ]
 
 [[package]]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -117,7 +117,11 @@ args = [
 # ============================================================================
 
 [tasks.test]
-description = "Run all tests with nextest"
+description = "Run all tests, including dashboard WASM browser E2E"
+dependencies = ["test-native", "dashboard-wasm-spa-test"]
+
+[tasks.test-native]
+description = "Run native tests with nextest"
 command = "cargo"
 args = [
 	"nextest",
@@ -127,6 +131,12 @@ args = [
 	"--all-features",
 	"--no-fail-fast",
 ]
+
+[tasks.dashboard-wasm-spa-test]
+description = "Run dashboard WASM browser E2E tests"
+cwd = "dashboard"
+command = "cargo"
+args = ["make", "wasm-spa-test"]
 
 [tasks.test-unit]
 description = "Run unit tests only"

--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ cargo check --workspace --all-features
 cargo build --workspace --all-features
 
 # Test
-cargo make test                                 # all tests
+cargo make test                                 # all tests, including dashboard WASM browser E2E
 cargo nextest run --workspace --all-features    # with nextest
 
 # Code quality

--- a/dashboard/Cargo.toml
+++ b/dashboard/Cargo.toml
@@ -21,10 +21,13 @@ path = "src/bin/manage.rs"
 # `ResolvedUrls::from_global()` in dashboard pages and layouts.
 default = ["client-router"]
 client-router = ["reinhardt/client-router"]
+msw = ["reinhardt/msw"]
 # Opts the `tests/wasm/` browser tests into the build. Off by default so
 # `cargo nextest run` (host-target) does not try to compile WASM-only
-# tests. Driven by `cargo make wasm-spa-test`. Refs #574.
-wasm-spa-test = []
+# tests. Driven by `cargo make wasm-spa-test`. The feature enables MSW so
+# browser tests can mock dashboard server functions without a live server.
+# Refs #574.
+wasm-spa-test = ["msw"]
 
 [dependencies]
 reinhardt = { workspace = true }

--- a/dashboard/Makefile.toml
+++ b/dashboard/Makefile.toml
@@ -64,7 +64,11 @@ args = ["run", "--bin", "manage", "shell"]
 # ============================================================================
 
 [tasks.test]
-description = "Run all tests"
+description = "Run all dashboard tests, including WASM browser E2E"
+dependencies = ["test-native", "wasm-spa-test"]
+
+[tasks.test-native]
+description = "Run native dashboard tests"
 command = "cargo"
 args = ["nextest", "run", "--all-features"]
 
@@ -184,6 +188,14 @@ script = '''
 cargo install wasm-bindgen-cli --version "0.2.118" --locked 2>/dev/null || true
 '''
 
+[tasks.wasm-install-test-tools]
+description = "Install WASM browser test tools"
+script = '''
+if ! command -v wasm-pack >/dev/null 2>&1; then
+	cargo install wasm-pack --locked
+fi
+'''
+
 [tasks.wasm-compile-dev]
 description = "Compile WASM library (debug)"
 command = "cargo"
@@ -271,7 +283,7 @@ args = [
 	"--features",
 	"wasm-spa-test",
 ]
-dependencies = ["wasm-install-tools"]
+dependencies = ["wasm-install-tools", "wasm-install-test-tools"]
 
 # Note: local infrastructure tasks (`infra-up` / `infra-down` /
 # `infra-reset`) live in the workspace-root `Makefile.toml` and delegate to

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -71,7 +71,7 @@ cargo make migrate          # Apply migrations
 ### Testing
 
 ```bash
-cargo make test             # Run all tests (uses cargo-nextest)
+cargo make test             # Run all tests (native nextest + WASM browser E2E)
 cargo make test-unit        # Run unit tests only
 cargo make test-integration # Run integration tests only
 cargo make test-watch       # Run tests with auto-reload (requires bacon)

--- a/dashboard/tests/wasm.rs
+++ b/dashboard/tests/wasm.rs
@@ -23,3 +23,6 @@ mod test_spa_navigation_smoke;
 
 #[path = "wasm/test_spa_route_paths.rs"]
 mod test_spa_route_paths;
+
+#[path = "wasm/test_frontend_msw_e2e.rs"]
+mod test_frontend_msw_e2e;

--- a/dashboard/tests/wasm/test_frontend_msw_e2e.rs
+++ b/dashboard/tests/wasm/test_frontend_msw_e2e.rs
@@ -139,6 +139,4 @@ async fn clusters_page_loads_and_submits_with_msw() {
 	worker
 		.calls_to_server_fn::<create_cluster_for_current_org::marker>()
 		.assert_count(1);
-
-	worker.stop().await;
 }

--- a/dashboard/tests/wasm/test_frontend_msw_e2e.rs
+++ b/dashboard/tests/wasm/test_frontend_msw_e2e.rs
@@ -1,0 +1,144 @@
+//! MSW-backed frontend E2E coverage for Dashboard browser flows.
+//!
+//! The test launches the real dashboard WASM client and intercepts
+//! server-function fetches with Reinhardt's `MockServiceWorker`. This keeps
+//! the test fast and deterministic while exercising the browser-rendered form
+//! and `server_fn` request path.
+
+use std::cell::Cell;
+use std::rc::Rc;
+
+use reinhardt::pages::ClientLauncher;
+use reinhardt::test::fixtures::wasm::{msw_worker, screen, wasm_test_env};
+use reinhardt::test::wasm::{UserEvent, wait_for};
+use reinhardt_cloud_dashboard::apps::clusters::server_fn::{
+	ClusterInfo, ClusterTokenInfo, create_cluster_for_current_org, list_clusters_for_current_org,
+};
+use reinhardt_cloud_dashboard::client::router::init_router;
+use reinhardt_cloud_dashboard::shared::client::state;
+use wasm_bindgen::JsCast;
+use wasm_bindgen::JsValue;
+use wasm_bindgen_test::*;
+use web_sys::HtmlInputElement;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+fn prepare_mount_point() {
+	let window = web_sys::window().expect("window");
+	let document = window.document().expect("document");
+	let body = document.body().expect("body");
+
+	if let Some(existing) = document.get_element_by_id("app") {
+		existing.remove();
+	}
+	let app_div = document.create_element("div").expect("create #app div");
+	app_div.set_id("app");
+	body.append_child(&app_div).expect("append #app to body");
+}
+
+fn push_test_path(path: &str) {
+	let window = web_sys::window().expect("window");
+	window
+		.history()
+		.expect("history")
+		.push_state_with_url(&JsValue::NULL, "", Some(path))
+		.expect("push test path");
+}
+
+fn launch_dashboard_at(path: &str) {
+	prepare_mount_point();
+	push_test_path(path);
+	ClientLauncher::new("#app")
+		.before_launch(state::init_app_state)
+		.router_client(init_router)
+		.launch()
+		.expect("ClientLauncher::launch must succeed");
+}
+
+fn cluster_fixture() -> ClusterInfo {
+	ClusterInfo {
+		id: 42,
+		name: "prod-us-east".to_string(),
+		api_url: "https://kubernetes.example.com:6443".to_string(),
+		is_active: true,
+		token_last_rotated_at: Some("2026-06-21T00:00:00Z".to_string()),
+	}
+}
+
+#[wasm_bindgen_test]
+async fn clusters_page_loads_and_submits_with_msw() {
+	// Arrange
+	let _env = wasm_test_env();
+	let worker = msw_worker().await;
+	let create_call_count = Rc::new(Cell::new(0));
+	let create_call_count_for_handler = Rc::clone(&create_call_count);
+
+	worker.handle_server_fn::<list_clusters_for_current_org::marker>(|_args| {
+		Ok(vec![cluster_fixture()])
+	});
+	worker.handle_server_fn::<create_cluster_for_current_org::marker>(move |args| {
+		create_call_count_for_handler.set(create_call_count_for_handler.get() + 1);
+		assert_eq!(args.name, "staging-eu");
+		assert_eq!(args.api_url, "https://staging.example.com:6443");
+		Ok(ClusterTokenInfo {
+			cluster: ClusterInfo {
+				id: 43,
+				name: args.name,
+				api_url: args.api_url,
+				is_active: true,
+				token_last_rotated_at: Some("2026-06-21T00:01:00Z".to_string()),
+			},
+			auth_token: "rc-agent-token-e2e".to_string(),
+		})
+	});
+
+	// Act
+	launch_dashboard_at("/clusters");
+	let screen = screen();
+
+	// Assert
+	let screen_for_inventory_wait = screen.clone();
+	wait_for(move || {
+		screen_for_inventory_wait
+			.get_by_text("prod-us-east")
+			.query()
+			.is_some()
+	})
+	.with_description("cluster inventory rendered from MSW data")
+	.await
+	.expect("cluster inventory should render");
+	worker
+		.calls_to_server_fn::<list_clusters_for_current_org::marker>()
+		.assert_called();
+
+	let name_input: HtmlInputElement = screen
+		.get_by_placeholder_text("prod-us-east")
+		.get()
+		.dyn_into()
+		.expect("cluster name input");
+	let api_url_input: HtmlInputElement = screen
+		.get_by_placeholder_text("https://kubernetes.example.com:6443")
+		.get()
+		.dyn_into()
+		.expect("cluster API URL input");
+	let submit = screen
+		.get_by_role_with_name("button", "Create cluster")
+		.get();
+
+	// Act
+	UserEvent::type_text(&name_input, "staging-eu");
+	UserEvent::type_text(&api_url_input, "https://staging.example.com:6443");
+	UserEvent::click(&submit);
+
+	// Assert
+	let create_call_count_for_wait = Rc::clone(&create_call_count);
+	wait_for(move || create_call_count_for_wait.get() == 1)
+		.with_description("create cluster server_fn handled by MSW")
+		.await
+		.expect("create cluster server_fn should be called");
+	worker
+		.calls_to_server_fn::<create_cluster_for_current_org::marker>()
+		.assert_count(1);
+
+	worker.stop().await;
+}

--- a/docs/development/LOCAL_E2E_TESTING.md
+++ b/docs/development/LOCAL_E2E_TESTING.md
@@ -39,6 +39,27 @@ kubectl version --client
 cargo --version
 ```
 
+## Fast Dashboard frontend E2E
+
+The default test command includes the Dashboard's headless Chrome WASM browser
+tests:
+
+```bash
+cargo make test
+```
+
+Those tests launch the real Dashboard WASM client in the browser and use
+Reinhardt's `MockServiceWorker` to intercept server-function fetches. For a
+Dashboard-only run, use:
+
+```bash
+cd dashboard
+cargo make test
+```
+
+The `test` tasks declare both the native suite and the WASM browser suite as
+`cargo-make` dependencies, so a successful `cargo make test` run includes both.
+
 ## Automated Dashboard self-deploy harness
 
 For the Dashboard dogfood path, prefer the first-class harness before walking

--- a/docs/development/LOCAL_E2E_TESTING.md
+++ b/docs/development/LOCAL_E2E_TESTING.md
@@ -54,7 +54,7 @@ Dashboard-only run, use:
 
 ```bash
 cd dashboard
-cargo make test
+cargo make wasm-spa-test
 ```
 
 The `test` tasks declare both the native suite and the WASM browser suite as


### PR DESCRIPTION
<!-- Thank you for contributing to Reinhardt Cloud! Please fill out the information below. -->

## Summary

This PR addresses:

- Adds a Dashboard WASM browser E2E test for the clusters page using Reinhardt's `wasm` fixtures and `MockServiceWorker` server-function handlers.
- Wires the Dashboard WASM browser suite into `cargo make test` through `cargo-make` dependencies at both workspace root and dashboard crate level.
- Extends the `wasm-build` workflow to install `wasm-pack` and run the Dashboard browser tests in CI.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

Dashboard SPA browser coverage previously exercised routing smoke tests but did not exercise real page UI with MSW-backed server-function traffic. This adds deterministic frontend E2E coverage for a cluster creation flow without requiring a live Dashboard server.

## How Was This Tested?

- `cargo make fmt-check` from `dashboard/`
- `cargo make wasm-spa-test` from `dashboard/`
- `git diff --check`

A full local `cargo make test` was attempted before PR creation, but native Dashboard tests require `REINHARDT_CORE__SECRET_KEY` and failed in the local shell before reaching the WASM dependency. CI native test workflows already provide this environment variable.

## Performance Impact

No runtime performance impact. CI and local `cargo make test` now include the Dashboard headless Chrome WASM browser suite.

## Breaking Changes

None.

## Screenshots

Not applicable; this is test and CI coverage only.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings in the verified commands
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

<!-- CI runner selection. Do not modify this checkbox text. -->
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Refs #574

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [ ] `kubernetes` - Kubernetes resources, controllers, operators
- [ ] `deployment` - Application deployment logic
- [ ] `networking` - Ingress, services, network policies
- [ ] `storage` - Persistent volumes, storage classes
- [ ] `auth` - Authentication, authorization, RBAC
- [ ] `api` - REST API, serializers, handlers
- [ ] `cli` - Command-line interface
- [ ] `config` - Configuration management
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The E2E test uses the upstream Reinhardt testing fixtures for browser setup, DOM querying, user events, wait helpers, and MSW server-function interception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added Dashboard browser-based end-to-end coverage for the “clusters” flow, using API mocking to validate list and create operations.
  - Included the Dashboard WASM browser suite in the standard `cargo make test` run alongside native tests.
  - Updated the CI build/test workflow to run the browser WASM checks in addition to existing WASM build steps.

- **Documentation**
  - Expanded local development instructions with a “Fast Dashboard frontend E2E” guide, including how to run the Dashboard subset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->