### PR TITLE
ci(release): fall back for release-plz PR token

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -23,16 +23,24 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      RELEASE_PLZ_APP_CONFIGURED: ${{ secrets.RELEASE_PLZ_APP_ID != '' && secrets.RELEASE_PLZ_APP_PRIVATE_KEY != '' }}
     concurrency:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
     steps:
       - name: Generate GitHub token
+        if: env.RELEASE_PLZ_APP_CONFIGURED == 'true'
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         id: generate-token
         with:
           app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
           private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
+
+      - name: Warn about fallback GitHub token
+        if: env.RELEASE_PLZ_APP_CONFIGURED != 'true'
+        run: |
+          echo "::warning title=Release-plz GitHub App credentials missing::RELEASE_PLZ_APP_ID and RELEASE_PLZ_APP_PRIVATE_KEY are not both configured. Falling back to GITHUB_TOKEN for the Release PR update; release PR checks may require a manual workflow run until the App secrets are configured."
 
       - name: Free Disk Space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
@@ -58,7 +66,7 @@ jobs:
         with:
           command: release-pr
         env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token || github.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   release-plz-release:
@@ -83,11 +91,28 @@ jobs:
       )
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      RELEASE_PLZ_APP_CONFIGURED: ${{ secrets.RELEASE_PLZ_APP_ID != '' && secrets.RELEASE_PLZ_APP_PRIVATE_KEY != '' }}
+      CARGO_REGISTRY_TOKEN_CONFIGURED: ${{ secrets.CARGO_REGISTRY_TOKEN != '' }}
     concurrency:
       group: release-plz-release-${{ github.ref }}
       cancel-in-progress: false
     steps:
+      - name: Validate release credentials
+        run: |
+          missing=0
+          if [ "$RELEASE_PLZ_APP_CONFIGURED" != "true" ]; then
+            echo "::error title=Release-plz GitHub App credentials missing::RELEASE_PLZ_APP_ID and RELEASE_PLZ_APP_PRIVATE_KEY must be configured before publishing releases so release-created and tag-push workflows can run."
+            missing=1
+          fi
+          if [ "$CARGO_REGISTRY_TOKEN_CONFIGURED" != "true" ]; then
+            echo "::error title=Cargo registry token missing::CARGO_REGISTRY_TOKEN must be configured before publishing crates."
+            missing=1
+          fi
+          exit "$missing"
+
       - name: Generate GitHub token
+        if: env.RELEASE_PLZ_APP_CONFIGURED == 'true'
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         id: generate-token
         with:


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds a `GITHUB_TOKEN` fallback for Release PR updates when the release-plz GitHub App secrets are not configured.
- Keeps the publish path strict by validating the GitHub App and Cargo registry credentials before releasing.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

The `Release-plz` workflow currently fails on routine `main` pushes before release-plz runs because `actions/create-github-app-token` receives empty App credentials.

The fallback lets Release PR updates proceed while still making real release publishing fail early with actionable credential errors.

Related to: #777

## How Was This Tested?

- `actionlint .github/workflows/release-plz.yml`
- `git diff --check`

Full `actionlint` was also run, but it reports pre-existing unrelated shellcheck warnings in `develop-leak-guard.yml` and `public-api-diff.yml`.

## Performance Impact

Not applicable.

## Breaking Changes

None.

## Screenshots

Not applicable.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Refs #777
- Failed run: https://github.com/kent8192/reinhardt-cloud/actions/runs/27889208859/job/82529643004

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [ ] `kubernetes` - Kubernetes resources, controllers, operators
- [ ] `deployment` - Application deployment logic
- [ ] `networking` - Ingress, services, network policies
- [ ] `storage` - Persistent volumes, storage classes
- [ ] `auth` - Authentication, authorization, RBAC
- [ ] `api` - REST API, serializers, handlers
- [ ] `cli` - Command-line interface
- [ ] `config` - Configuration management
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

Release-plz documents that the default `GITHUB_TOKEN` can update the release PR, but follow-up workflows may not trigger from changes made by that token. The dedicated GitHub App credentials remain the desired configuration for full automation.

🤖 Generated with [Codex](https://openai.com/codex)
