### PR TITLE
ci(release): add publish dry-run check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,15 @@ jobs:
       runner: ${{ needs.determine-runner.outputs.runner }}
       cargo-build-jobs: ${{ needs.determine-runner.outputs.cargo-build-jobs }}
 
+  publish-check:
+    name: Publish Check
+    needs: [determine-runner, check-branch-status]
+    if: needs.check-branch-status.outputs.has-conflicts != 'true'
+    uses: ./.github/workflows/publish-check.yml
+    with:
+      runner: ${{ needs.determine-runner.outputs.runner }}
+      cargo-build-jobs: ${{ needs.determine-runner.outputs.cargo-build-jobs }}
+
   bruno-tests:
     name: Bruno API Tests
     needs: [fmt, clippy, determine-runner, check-branch-status]
@@ -254,6 +263,7 @@ jobs:
       - terraform-check
       - cross-platform-check
       - public-api-diff
+      - publish-check
     steps:
       - name: Verify all required checks passed
         env:
@@ -270,6 +280,7 @@ jobs:
           TERRAFORM_CHECK_RESULT: ${{ needs.terraform-check.result }}
           CROSS_PLATFORM_RESULT: ${{ needs.cross-platform-check.result }}
           PUBLIC_API_DIFF_RESULT: ${{ needs.public-api-diff.result }}
+          PUBLISH_CHECK_RESULT: ${{ needs.publish-check.result }}
         run: |
           # If PR has merge conflicts, all jobs are expected to be skipped
           if [[ "$HAS_CONFLICTS" == "true" ]]; then
@@ -289,6 +300,7 @@ jobs:
             "bruno-tests:$BRUNO_TESTS_RESULT"
             "security-audit:$SECURITY_AUDIT_RESULT"
             "todo-check:$TODO_CHECK_RESULT"
+            "publish-check:$PUBLISH_CHECK_RESULT"
           )
           for entry in "${always_required[@]}"; do
             name="${entry%%:*}"

--- a/.github/workflows/publish-check.yml
+++ b/.github/workflows/publish-check.yml
@@ -1,0 +1,92 @@
+name: Publish Check
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        description: 'Runner label JSON. Use "\"ubuntu-latest\"" for GitHub-hosted or "[\"self-hosted\",\"linux\",\"arm64\",\"reinhardt-cloud-ci\"]" for self-hosted.'
+        type: string
+        default: '"ubuntu-latest"'
+      cargo-build-jobs:
+        description: "Parallel cargo build jobs (1=GitHub-hosted OOM safe, 8=self-hosted)"
+        type: string
+        default: "1"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  CARGO_TARGET_DIR: /tmp/cargo_target
+  CARGO_INCREMENTAL: 0
+  CARGO_BUILD_JOBS: ${{ inputs.cargo-build-jobs || '1' }}
+
+jobs:
+  publish-check:
+    name: Publish Dry-Run Check
+    runs-on: ${{ fromJSON(inputs.runner || '"ubuntu-latest"') }}
+    timeout-minutes: 60
+    steps:
+      - name: Free Disk Space (Ubuntu)
+        if: ${{ !contains(inputs.runner || '', 'self-hosted') }}
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Package publishable workspace crates
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mapfile -t non_publishable < <(
+            cargo metadata --locked --no-deps --format-version=1 \
+              | jq -r '.packages[] | select(.publish == []) | .name'
+          )
+
+          package_args=(--locked --workspace --no-verify --allow-dirty)
+          for crate in "${non_publishable[@]}"; do
+            package_args+=(--exclude "$crate")
+          done
+
+          cargo package "${package_args[@]}"
+
+      - name: Cargo publish dry-run for registry-independent release crates
+        if: ${{ startsWith(github.head_ref || github.ref_name, 'release-plz-') }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mapfile -t publish_roots < <(
+            cargo metadata --locked --no-deps --format-version=1 \
+              | jq -r '
+                .packages[]
+                | select(.publish == null or (.publish | index("crates-io")))
+                | select(([.dependencies[] | select(.source == null and (.name | startswith("reinhardt-cloud")))] | length) == 0)
+                | .name
+              '
+          )
+
+          if [[ "${#publish_roots[@]}" -eq 0 ]]; then
+            echo "No registry-independent publishable crates found."
+            exit 0
+          fi
+
+          for crate in "${publish_roots[@]}"; do
+            cargo publish --locked --package "$crate" --dry-run --allow-dirty --no-verify
+          done


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds a reusable `Publish Check` workflow based on the `reinhardt-web` publish-check pattern.
- Packages all publishable workspace crates while excluding `publish = false` packages from Cargo metadata.
- Runs real `cargo publish --dry-run` on release-plz branches for registry-independent crates (`reinhardt-cloud-types` and `reinhardt-cloud-proto` today), so crates.io-side manifest validation is exercised before release PR merge.
- Wires the new publish check into the main CI aggregate gate.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

The release publish path recently failed after a release PR merged because crates.io rejected publish metadata during upload. This adds a CI gate that catches publish-form packaging issues broadly and runs real crates.io dry-run validation where workspace dependency ordering allows it.

Related to: #781, #782

## How Was This Tested?

- `actionlint -shellcheck= .github/workflows/ci.yml .github/workflows/publish-check.yml`
- `cargo package --locked --workspace --no-verify --allow-dirty --exclude reinhardt-cloud-dashboard --exclude reinhardt-cloud-integration-tests`
- `cargo publish --locked --package reinhardt-cloud-types --dry-run --allow-dirty --no-verify`
- `cargo publish --locked --package reinhardt-cloud-proto --dry-run --allow-dirty --no-verify`
- `git diff --check`

## Performance Impact

Adds one CI job. It uses GitHub-hosted OOM-safe cargo settings by default and respects the existing self-hosted runner selection.

## Breaking Changes

None.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Related to #781
- Related to #782

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [ ] `kubernetes` - Kubernetes resources, controllers, operators
- [ ] `deployment` - Application deployment logic
- [ ] `networking` - Ingress, services, network policies
- [ ] `storage` - Persistent volumes, storage classes
- [ ] `auth` - Authentication, authorization, RBAC
- [ ] `api` - REST API, serializers, handlers
- [ ] `cli` - Command-line interface
- [ ] `config` - Configuration management
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The real `cargo publish --dry-run` step is limited to release-plz branches and registry-independent crates because dependent workspace crates cannot resolve same-release siblings from crates.io until a real release publishes them.

🤖 Generated with [Codex](https://openai.com/codex)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline with additional publish validation checks to ensure packages meet publishing requirements before deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->