### PR TITLE
ci(release): add manual publish recovery

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -9,6 +9,16 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      publish_existing_release:
+        description: 'Publish already-merged release metadata from main.'
+        required: true
+        type: boolean
+        default: false
+      expected_version:
+        description: 'Expected release version to publish, for example 0.1.0-alpha.1.'
+        required: true
+        type: string
 
 jobs:
   # Native two-step release workflow:
@@ -75,19 +85,28 @@ jobs:
     # still runs on every main push so routine feature merges keep the next
     # Release PR up to date without entering the publish path.
     #
+    # Manual dispatch is a recovery path for already-merged release metadata
+    # after release credentials or workflow checks have been fixed on main.
+    #
     # Accepted Release PR merge shapes:
     # - merge commit from a release-plz-* branch
     # - squash commit titled "chore: release (#N)"
     if: |
-      github.event_name == 'push' && (
-        (
-          startsWith(github.event.head_commit.message, 'Merge pull request #') &&
-          contains(github.event.head_commit.message, format(' from {0}/release-plz-', github.repository_owner))
-        ) ||
-        (
-          startsWith(github.event.head_commit.message, 'chore: release ') &&
-          contains(github.event.head_commit.message, '(#')
+      (
+        github.event_name == 'push' && (
+          (
+            startsWith(github.event.head_commit.message, 'Merge pull request #') &&
+            contains(github.event.head_commit.message, format(' from {0}/release-plz-', github.repository_owner))
+          ) ||
+          (
+            startsWith(github.event.head_commit.message, 'chore: release ') &&
+            contains(github.event.head_commit.message, '(#')
+          )
         )
+      ) ||
+      (
+        github.event_name == 'workflow_dispatch' &&
+        inputs.publish_existing_release == true
       )
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -110,6 +129,21 @@ jobs:
             missing=1
           fi
           exit "$missing"
+
+      - name: Validate manual release dispatch
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          EXPECTED_VERSION: ${{ inputs.expected_version }}
+        run: |
+          if [ "$REF_NAME" != "main" ]; then
+            echo "::error::Manual release publish must run from the main branch, not '$REF_NAME'."
+            exit 1
+          fi
+          if [[ ! "$EXPECTED_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+            echo "::error::Expected version '$EXPECTED_VERSION' is not a SemVer version."
+            exit 1
+          fi
 
       - name: Generate GitHub token
         if: env.RELEASE_PLZ_APP_CONFIGURED == 'true'
@@ -138,8 +172,33 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
+      - name: Verify manual release version
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          EXPECTED_VERSION: ${{ inputs.expected_version }}
+        run: |
+          mapfile -t versions < <(
+            cargo metadata --locked --no-deps --format-version=1 \
+              | jq -r '
+                .packages[]
+                | select(.name | startswith("reinhardt-cloud"))
+                | select(.publish != [])
+                | .version
+              ' \
+              | sort -u
+          )
+
+          if [ "${#versions[@]}" -ne 1 ]; then
+            printf '::error::Expected one publishable workspace version, found: %s\n' "${versions[*]}"
+            exit 1
+          fi
+          if [ "${versions[0]}" != "$EXPECTED_VERSION" ]; then
+            echo "::error::Expected version '$EXPECTED_VERSION' does not match workspace version '${versions[0]}'."
+            exit 1
+          fi
+
       - name: Verify release branch name
-        if: "startsWith(github.event.head_commit.message, 'Merge pull request #')"
+        if: "github.event_name == 'push' && startsWith(github.event.head_commit.message, 'Merge pull request #')"
         env:
           COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
@@ -163,7 +222,7 @@ jobs:
           esac
 
       - name: Verify release PR label
-        if: "startsWith(github.event.head_commit.message, 'Merge pull request #') || (startsWith(github.event.head_commit.message, 'chore: release ') && contains(github.event.head_commit.message, '(#'))"
+        if: "github.event_name == 'push' && (startsWith(github.event.head_commit.message, 'Merge pull request #') || (startsWith(github.event.head_commit.message, 'chore: release ') && contains(github.event.head_commit.message, '(#')))"
         env:
           COMMIT_MSG: ${{ github.event.head_commit.message }}
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds a guarded manual `workflow_dispatch` path for publishing already-merged release metadata from `main`.
- Requires an explicit publish checkbox, `main` ref, and an expected workspace version before running `release-plz release` manually.
- Keeps release PR branch and label verification on normal push-triggered publishes.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

The `Release-plz / Release PR` job for run `27921649473` returned `release_pr_output: {"prs":[]}` because the `0.1.0-alpha.1` version metadata had already been merged, leaving no new Release PR diff to create. The matching publish job was skipped because the triggering commit was a normal PR merge rather than a `release-plz-*` Release PR merge.

This change adds an explicit recovery path for that state: after the workflow fix is on `main`, operators can manually dispatch the Release-plz workflow from `main`, check `publish_existing_release`, and set `expected_version` to `0.1.0-alpha.1`.

Fixes: N/A

Related to: #781, #782, #783

## How Was This Tested?

- `actionlint .github/workflows/release-plz.yml`
- Local validation of the manual publish version check against workspace version `0.1.0-alpha.1`
- Confirmed `release-plz release --dry-run` reaches the publish sequence but cannot fully validate dependent workspace crates because dry-run skips uploading the first same-release crate to crates.io.

## Performance Impact

N/A

## Breaking Changes

N/A

## Screenshots

N/A

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #781
- #782
- #783

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [ ] `kubernetes` - Kubernetes resources, controllers, operators
- [ ] `deployment` - Application deployment logic
- [ ] `networking` - Ingress, services, network policies
- [ ] `storage` - Persistent volumes, storage classes
- [ ] `auth` - Authentication, authorization, RBAC
- [ ] `api` - REST API, serializers, handlers
- [ ] `cli` - Command-line interface
- [ ] `config` - Configuration management
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

This PR only adds the recovery path. It does not run the publish workflow, create release tags, or publish crates.

🤖 Generated with [Codex](https://openai.com/codex)