### PR TITLE
fix(auth): defer personal org provisioning until verification

### DIFF
--- a/dashboard/src/apps/auth/server_urls.rs
+++ b/dashboard/src/apps/auth/server_urls.rs
@@ -177,12 +177,12 @@ pub async fn verify_email(
 
 	if !user.is_active() {
 		let mut updated = user;
-		ensure_personal_organization(&updated).await?;
 		updated.is_active = true;
-		User::objects().update(&updated).await.map_err(|e| {
+		let updated = User::objects().update(&updated).await.map_err(|e| {
 			error!("Failed to activate user {user_id}: {e}");
 			AppError::Internal("Internal server error".to_string())
 		})?;
+		ensure_personal_organization(&updated).await?;
 		info!("User {user_id} email verified and activated");
 	} else {
 		ensure_personal_organization(&user).await?;

--- a/dashboard/src/apps/auth/server_urls.rs
+++ b/dashboard/src/apps/auth/server_urls.rs
@@ -18,6 +18,7 @@ use crate::apps::auth::models::User;
 use crate::apps::auth::services::oauth::linking::link_or_create_user;
 use crate::apps::auth::services::oauth::storage::OrmSocialAccountStorage;
 use crate::apps::auth::services::oauth::{OAuthBackendBox, OAuthBackendBoxKey};
+use crate::apps::auth::services::registration::ensure_personal_organization;
 use crate::apps::auth::services::session::{
 	SessionService, SessionServiceKey, session_cookie_header, session_id_from_cookie_header,
 };
@@ -146,8 +147,8 @@ pub async fn oauth_callback(
 ///
 /// `GET /api/auth/verify-email/{token}/`
 ///
-/// On success, sets `is_active = true` for the user. Returns 200 even
-/// if the user is already active.
+/// On success, sets `is_active = true` for the user and ensures their
+/// Personal Organization exists. Returns 200 even if the user is already active.
 #[get("/verify-email/{token}/", name = "verify-email")]
 pub async fn verify_email(
 	Path(token): Path<String>,
@@ -174,15 +175,20 @@ pub async fn verify_email(
 		})?
 		.ok_or_else(|| AppError::Validation("Invalid verification link".to_string()))?;
 
-	if !user.is_active() {
+	let verified_user = if !user.is_active() {
 		let mut updated = user;
 		updated.is_active = true;
-		User::objects().update(&updated).await.map_err(|e| {
+		let updated = User::objects().update(&updated).await.map_err(|e| {
 			error!("Failed to activate user {user_id}: {e}");
 			AppError::Internal("Internal server error".to_string())
 		})?;
 		info!("User {user_id} email verified and activated");
-	}
+		updated
+	} else {
+		user
+	};
+
+	ensure_personal_organization(&verified_user).await?;
 
 	let body = serde_json::json!({
 		"success": true,

--- a/dashboard/src/apps/auth/server_urls.rs
+++ b/dashboard/src/apps/auth/server_urls.rs
@@ -175,20 +175,18 @@ pub async fn verify_email(
 		})?
 		.ok_or_else(|| AppError::Validation("Invalid verification link".to_string()))?;
 
-	let verified_user = if !user.is_active() {
+	if !user.is_active() {
 		let mut updated = user;
+		ensure_personal_organization(&updated).await?;
 		updated.is_active = true;
-		let updated = User::objects().update(&updated).await.map_err(|e| {
+		User::objects().update(&updated).await.map_err(|e| {
 			error!("Failed to activate user {user_id}: {e}");
 			AppError::Internal("Internal server error".to_string())
 		})?;
 		info!("User {user_id} email verified and activated");
-		updated
 	} else {
-		user
+		ensure_personal_organization(&user).await?;
 	};
-
-	ensure_personal_organization(&verified_user).await?;
 
 	let body = serde_json::json!({
 		"success": true,

--- a/dashboard/src/apps/auth/services/credentials.rs
+++ b/dashboard/src/apps/auth/services/credentials.rs
@@ -13,6 +13,7 @@ use reinhardt::db::orm::Model;
 use tracing::error;
 
 use crate::apps::auth::models::User;
+use crate::apps::auth::services::registration::ensure_personal_organization;
 
 /// Verify user credentials against the database.
 ///
@@ -42,6 +43,8 @@ pub async fn verify_credentials(username: &str, password: &str) -> Result<User, 
 			"Email verification required".to_string(),
 		));
 	}
+
+	ensure_personal_organization(&user).await?;
 
 	Ok(user)
 }

--- a/dashboard/src/apps/auth/services/registration.rs
+++ b/dashboard/src/apps/auth/services/registration.rs
@@ -16,10 +16,13 @@
 //! function in a DI service would add a layer without removing any
 //! global-state coupling.
 
+use std::sync::OnceLock;
+
 use chrono::Utc;
 use reinhardt::BaseUser;
 use reinhardt::core::exception::Error as AppError;
 use reinhardt::db::orm::Model;
+use tokio::sync::Mutex;
 use tracing::{error, info};
 
 use crate::apps::auth::models::User;
@@ -30,6 +33,12 @@ use crate::apps::organizations::roles::{
 	MembershipRole, is_reserved_slug, sanitize_username_to_slug, validate_slug,
 };
 use crate::config::ProjectSettings;
+
+static PERSONAL_ORG_PROVISIONING_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn personal_org_provisioning_lock() -> &'static Mutex<()> {
+	PERSONAL_ORG_PROVISIONING_LOCK.get_or_init(|| Mutex::new(()))
+}
 
 /// Register an inactive user and send the verification email.
 ///
@@ -122,6 +131,7 @@ pub async fn provision_personal_organization(created: &User) -> Result<(), AppEr
 /// Create a Personal `Organization` and Owner membership for an existing
 /// active user without rolling the user back on failure.
 pub async fn ensure_personal_organization(user: &User) -> Result<(), AppError> {
+	let _guard = personal_org_provisioning_lock().lock().await;
 	let existing = OrganizationMembership::objects()
 		.filter(OrganizationMembership::field_user_id().eq(user.id.to_string()))
 		.first()

--- a/dashboard/src/apps/auth/services/registration.rs
+++ b/dashboard/src/apps/auth/services/registration.rs
@@ -1,10 +1,9 @@
-//! Personal Organization provisioning during user registration.
+//! Personal Organization provisioning after email verification.
 //!
-//! Shared by auth server functions. This workflow provisions an
-//! `Organization` + Owner `OrganizationMembership` for every
-//! freshly-registered user so that organization-scoped resources
-//! (Cluster, Deployment, ...) can resolve via
-//! `current_organization_id_for_user`.
+//! Shared by auth server functions and verification handlers. This workflow
+//! provisions an `Organization` + Owner `OrganizationMembership` only after
+//! the user proves control of their email address so organization slugs cannot
+//! be reserved by unverified registrations.
 //!
 //! Refs #415, #435.
 //!
@@ -32,8 +31,11 @@ use crate::apps::organizations::roles::{
 };
 use crate::config::ProjectSettings;
 
-/// Register an inactive user, provision the personal organization, and send
-/// the verification email.
+/// Register an inactive user and send the verification email.
+///
+/// Personal organization provisioning is intentionally deferred until email
+/// verification succeeds so unauthenticated registrations cannot reserve
+/// globally unique organization slugs.
 pub async fn register_inactive_user(
 	username: &str,
 	email: &str,
@@ -73,8 +75,6 @@ pub async fn register_inactive_user(
 		}
 	};
 
-	provision_personal_organization(&created).await?;
-
 	let token = generate_token(
 		TokenPurpose::EmailVerification,
 		&created.id,
@@ -107,8 +107,8 @@ pub async fn register_inactive_user(
 }
 
 /// Create a Personal `Organization` and Owner `OrganizationMembership` for
-/// a freshly-registered user. Rolls the user creation back on failure so
-/// that the account never exists without an owning organization.
+/// a verified user. Rolls the user creation back on failure when called from
+/// legacy registration-recovery paths that request rollback semantics.
 ///
 /// Slug derivation:
 /// - DNS-1123 sanitize the username

--- a/dashboard/src/apps/auth/services/registration.rs
+++ b/dashboard/src/apps/auth/services/registration.rs
@@ -16,29 +16,23 @@
 //! function in a DI service would add a layer without removing any
 //! global-state coupling.
 
-use std::sync::OnceLock;
-
 use chrono::Utc;
 use reinhardt::BaseUser;
 use reinhardt::core::exception::Error as AppError;
-use reinhardt::db::orm::Model;
-use tokio::sync::Mutex;
+use reinhardt::db::orm::connection::QueryValue;
+use reinhardt::db::orm::transaction::TransactionScope;
+use reinhardt::db::orm::{Model, get_connection};
 use tracing::{error, info};
 
 use crate::apps::auth::models::User;
 use crate::apps::auth::services::email::EmailService;
 use crate::apps::auth::services::token::{TokenPurpose, generate_token};
-use crate::apps::organizations::models::{Organization, OrganizationMembership};
 use crate::apps::organizations::roles::{
 	MembershipRole, is_reserved_slug, sanitize_username_to_slug, validate_slug,
 };
 use crate::config::ProjectSettings;
 
-static PERSONAL_ORG_PROVISIONING_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-
-fn personal_org_provisioning_lock() -> &'static Mutex<()> {
-	PERSONAL_ORG_PROVISIONING_LOCK.get_or_init(|| Mutex::new(()))
-}
+const MAX_ORG_SLUG_LEN: usize = 63;
 
 /// Register an inactive user and send the verification email.
 ///
@@ -131,19 +125,6 @@ pub async fn provision_personal_organization(created: &User) -> Result<(), AppEr
 /// Create a Personal `Organization` and Owner membership for an existing
 /// active user without rolling the user back on failure.
 pub async fn ensure_personal_organization(user: &User) -> Result<(), AppError> {
-	let _guard = personal_org_provisioning_lock().lock().await;
-	let existing = OrganizationMembership::objects()
-		.filter(OrganizationMembership::field_user_id().eq(user.id.to_string()))
-		.first()
-		.await
-		.map_err(|e| {
-			error!("Failed to look up existing Personal Org membership: {e}");
-			AppError::Internal("Internal server error".to_string())
-		})?;
-	if existing.is_some() {
-		return Ok(());
-	}
-
 	provision_personal_organization_inner(user, false).await
 }
 
@@ -151,86 +132,27 @@ async fn provision_personal_organization_inner(
 	created: &User,
 	rollback_on_failure: bool,
 ) -> Result<(), AppError> {
-	let now = Utc::now();
-	let mut slug = sanitize_username_to_slug(&created.username);
-	if is_reserved_slug(&slug) || validate_slug(&slug).is_err() {
-		// Fall back to a user-<short-uuid> form so reserved/invalid slugs
-		// do not block registration.
-		let suffix = uuid::Uuid::new_v4().simple().to_string();
-		slug = format!("user-{}", &suffix[..8]);
-	}
+	let user_id = created.id;
+	let username = created.username.clone();
+	let conn = get_connection().await.map_err(|e| {
+		error!("Failed to get database connection for Personal Org provisioning: {e}");
+		AppError::Internal("Internal server error".to_string())
+	})?;
 
-	let org_input = Organization {
-		id: None,
-		slug: slug.clone(),
-		name: created.username.clone(),
-		created_by: created.id,
-		created_at: now,
-		updated_at: now,
-	};
+	let mut tx = TransactionScope::begin(&conn).await.map_err(|e| {
+		error!("Failed to begin Personal Org provisioning transaction: {e}");
+		AppError::Internal("Internal server error".to_string())
+	})?;
 
-	// Try once with the derived slug. On unique-violation, retry once with a
-	// uuid suffix.
-	let org = match Organization::objects().create(&org_input).await {
-		Ok(org) => org,
-		Err(e) => {
-			let err_lower = e.to_string().to_lowercase();
-			if err_lower.contains("unique") || err_lower.contains("duplicate") {
-				let suffix = uuid::Uuid::new_v4().simple().to_string();
-				let retry = Organization {
-					id: None,
-					slug: format!("{}-{}", slug, &suffix[..6]),
-					name: created.username.clone(),
-					created_by: created.id,
-					created_at: now,
-					updated_at: now,
-				};
-				match Organization::objects().create(&retry).await {
-					Ok(o) => o,
-					Err(e2) => {
-						error!(
-							"Failed to provision Personal Org for user {} after retry: {e2}",
-							created.id
-						);
-						if rollback_on_failure {
-							rollback_user(created).await;
-						}
-						return Err(AppError::Internal("Internal server error".to_string()));
-					}
-				}
-			} else {
-				error!(
-					"Failed to provision Personal Org for user {}: {e}",
-					created.id
-				);
-				if rollback_on_failure {
-					rollback_user(created).await;
-				}
-				return Err(AppError::Internal("Internal server error".to_string()));
-			}
-		}
-	};
+	let result = provision_personal_organization_tx(&mut tx, user_id, username).await;
 
-	let membership_input = OrganizationMembership::build()
-		.organization(org.id.expect("created Organization has id"))
-		.user(created.id)
-		.role(MembershipRole::Owner.as_db_str().to_string())
-		.finish();
-	if let Err(e) = OrganizationMembership::objects()
-		.create(&membership_input)
-		.await
-	{
+	if let Err(e) = result {
 		error!(
-			"Failed to provision Owner membership for user {} in org {}: {e}",
-			created.id,
-			org.id.unwrap_or_default()
+			"Failed to provision Personal Org for user {}: {e}",
+			created.id
 		);
-		// Best-effort rollback: delete the org we just created, then the user.
-		if let Err(del_err) = Organization::objects()
-			.delete(org.id.expect("created Organization has id"))
-			.await
-		{
-			error!("Failed to roll back Organization after membership failure: {del_err}");
+		if let Err(rollback_err) = tx.rollback().await {
+			error!("Failed to roll back Personal Org provisioning transaction: {rollback_err}");
 		}
 		if rollback_on_failure {
 			rollback_user(created).await;
@@ -238,7 +160,156 @@ async fn provision_personal_organization_inner(
 		return Err(AppError::Internal("Internal server error".to_string()));
 	}
 
+	tx.commit().await.map_err(|e| {
+		error!("Failed to commit Personal Org provisioning transaction: {e}");
+		AppError::Internal("Internal server error".to_string())
+	})?;
+
 	Ok(())
+}
+
+async fn provision_personal_organization_tx(
+	tx: &mut TransactionScope,
+	user_id: uuid::Uuid,
+	username: String,
+) -> anyhow::Result<()> {
+	lock_personal_org_provisioning(tx, user_id).await?;
+	if find_personal_organization_id(tx, user_id).await?.is_some() {
+		return Ok(());
+	}
+
+	let now = Utc::now();
+	let slug = personal_org_slug(&username);
+	let org_id = if let Some(org_id) =
+		insert_personal_organization(tx, user_id, &username, &slug, now).await?
+	{
+		org_id
+	} else {
+		if find_personal_organization_id(tx, user_id).await?.is_some() {
+			return Ok(());
+		}
+		let retry = retry_slug(&slug);
+		insert_personal_organization(tx, user_id, &username, &retry, now)
+			.await?
+			.ok_or_else(|| anyhow::anyhow!("retry Personal Organization slug also conflicted"))?
+	};
+
+	if !insert_owner_membership(tx, user_id, org_id, now).await?
+		&& find_personal_organization_id(tx, user_id).await?.is_none()
+	{
+		return Err(anyhow::anyhow!(
+			"Owner membership already existed for a non-Personal Organization"
+		));
+	}
+
+	Ok(())
+}
+
+async fn lock_personal_org_provisioning(
+	tx: &mut TransactionScope,
+	user_id: uuid::Uuid,
+) -> anyhow::Result<()> {
+	tx.execute(
+		"SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+		vec![QueryValue::String(user_id.to_string())],
+	)
+	.await?;
+	Ok(())
+}
+
+async fn find_personal_organization_id(
+	tx: &mut TransactionScope,
+	user_id: uuid::Uuid,
+) -> anyhow::Result<Option<i64>> {
+	let row = tx
+		.query_optional(
+			"SELECT o.id \
+			 FROM organizations o \
+			 JOIN organization_memberships m ON m.organization_id = o.id \
+			 WHERE o.created_by = $1 \
+			   AND m.user_id = $1 \
+			   AND m.role = $2 \
+			 ORDER BY o.created_at ASC \
+			 LIMIT 1",
+			vec![
+				QueryValue::Uuid(user_id),
+				QueryValue::String(MembershipRole::Owner.as_db_str().to_string()),
+			],
+		)
+		.await?;
+	Ok(row.and_then(|row| row.get("id")))
+}
+
+async fn insert_personal_organization(
+	tx: &mut TransactionScope,
+	user_id: uuid::Uuid,
+	username: &str,
+	slug: &str,
+	now: chrono::DateTime<Utc>,
+) -> anyhow::Result<Option<i64>> {
+	let row = tx
+		.query_optional(
+			"INSERT INTO organizations (slug, name, created_by, created_at, updated_at) \
+			 VALUES ($1, $2, $3, $4, $5) \
+			 ON CONFLICT (slug) DO NOTHING \
+			 RETURNING id",
+			vec![
+				QueryValue::String(slug.to_string()),
+				QueryValue::String(username.to_string()),
+				QueryValue::Uuid(user_id),
+				QueryValue::Timestamp(now),
+				QueryValue::Timestamp(now),
+			],
+		)
+		.await?;
+	row.map(|row| {
+		row.get("id")
+			.ok_or_else(|| anyhow::anyhow!("created Personal Organization did not return id"))
+	})
+	.transpose()
+}
+
+async fn insert_owner_membership(
+	tx: &mut TransactionScope,
+	user_id: uuid::Uuid,
+	org_id: i64,
+	now: chrono::DateTime<Utc>,
+) -> anyhow::Result<bool> {
+	let rows = tx
+		.execute(
+			"INSERT INTO organization_memberships (organization_id, user_id, role, created_at) \
+		 VALUES ($1, $2, $3, $4) \
+		 ON CONFLICT ON CONSTRAINT organization_memberships_org_user_unique DO NOTHING",
+			vec![
+				QueryValue::Int(org_id),
+				QueryValue::Uuid(user_id),
+				QueryValue::String(MembershipRole::Owner.as_db_str().to_string()),
+				QueryValue::Timestamp(now),
+			],
+		)
+		.await?;
+	Ok(rows > 0)
+}
+
+fn personal_org_slug(username: &str) -> String {
+	let slug = sanitize_username_to_slug(username);
+	if is_reserved_slug(&slug) || validate_slug(&slug).is_err() {
+		let suffix = uuid::Uuid::new_v4().simple().to_string();
+		return format!("user-{}", &suffix[..8]);
+	}
+	slug
+}
+
+fn retry_slug(slug: &str) -> String {
+	let suffix = uuid::Uuid::new_v4().simple().to_string();
+	let suffix = &suffix[..6];
+	let prefix_len = MAX_ORG_SLUG_LEN - suffix.len() - 1;
+	let prefix = if slug.len() > prefix_len {
+		&slug[..prefix_len]
+	} else {
+		slug
+	};
+	format!("{prefix}-{suffix}")
 }
 
 /// Best-effort delete of a user, used during Personal Org rollback.

--- a/dashboard/src/apps/auth/tests/integration/test_provisioning.rs
+++ b/dashboard/src/apps/auth/tests/integration/test_provisioning.rs
@@ -24,7 +24,7 @@ mod tests {
 		ensure_personal_organization, provision_personal_organization,
 	};
 	use crate::apps::organizations::models::{Organization, OrganizationMembership};
-	use crate::apps::organizations::roles::sanitize_username_to_slug;
+	use crate::apps::organizations::roles::{MembershipRole, sanitize_username_to_slug};
 	use crate::config::test_helpers::build_test_app;
 	use reinhardt::UrlReverser;
 
@@ -219,5 +219,103 @@ mod tests {
 			.await
 			.expect("query memberships");
 		assert_eq!(memberships.len(), 1);
+	}
+
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_ensure_personal_organization_ignores_unrelated_membership(
+		#[future] db: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			APIClient,
+			Arc<UrlReverser>,
+		),
+	) {
+		// Arrange
+		let (_container, _conn, _client, _urls) = db.await;
+		let owner = create_user("owner-org", "owner-org@example.com").await;
+		let member = create_user("member-only", "member-only@example.com").await;
+		let now = Utc::now();
+		let foreign_org = Organization::objects()
+			.create(&Organization {
+				id: None,
+				slug: "owner-org".to_string(),
+				name: "owner-org".to_string(),
+				created_by: owner.id,
+				created_at: now,
+				updated_at: now,
+			})
+			.await
+			.expect("seed foreign Organization");
+		OrganizationMembership::objects()
+			.create(
+				&OrganizationMembership::build()
+					.organization(foreign_org.id.expect("created Organization has id"))
+					.user(member.id)
+					.role(MembershipRole::Developer.as_db_str().to_string())
+					.finish(),
+			)
+			.await
+			.expect("seed unrelated membership");
+
+		// Act
+		ensure_personal_organization(&member)
+			.await
+			.expect("ensure should create the missing Personal Org");
+
+		// Assert
+		let personal_org = Organization::objects()
+			.filter(Organization::field_created_by().eq(member.id.to_string()))
+			.first()
+			.await
+			.expect("query member Personal Org")
+			.expect("member Personal Org should exist");
+		assert_eq!(personal_org.created_by, member.id);
+		let memberships = OrganizationMembership::objects()
+			.filter(OrganizationMembership::field_user_id().eq(member.id.to_string()))
+			.all()
+			.await
+			.expect("query member memberships");
+		assert_eq!(memberships.len(), 2);
+	}
+
+	#[rstest]
+	#[tokio::test(flavor = "multi_thread")]
+	#[serial(database)]
+	async fn test_ensure_personal_organization_is_concurrency_safe(
+		#[future] db: (
+			ContainerAsync<GenericImage>,
+			Arc<DatabaseConnection>,
+			APIClient,
+			Arc<UrlReverser>,
+		),
+	) {
+		// Arrange
+		let (_container, _conn, _client, _urls) = db.await;
+		let user = create_user("concurrent-org", "concurrent-org@example.com").await;
+
+		// Act
+		let (first, second) = tokio::join!(
+			ensure_personal_organization(&user),
+			ensure_personal_organization(&user),
+		);
+		first.expect("first ensure should succeed");
+		second.expect("second ensure should succeed");
+
+		// Assert
+		let personal_orgs = Organization::objects()
+			.filter(Organization::field_created_by().eq(user.id.to_string()))
+			.all()
+			.await
+			.expect("query Personal Orgs");
+		assert_eq!(personal_orgs.len(), 1);
+		let memberships = OrganizationMembership::objects()
+			.filter(OrganizationMembership::field_user_id().eq(user.id.to_string()))
+			.all()
+			.await
+			.expect("query memberships");
+		assert_eq!(memberships.len(), 1);
+		assert_eq!(memberships[0].role, MembershipRole::Owner.as_db_str());
 	}
 }


### PR DESCRIPTION
### Motivation
- Prevent unverified registrations from reserving globally-unique organization slugs and producing orphan `Organization` rows when email delivery or later steps fail.
- Move Personal Organization provisioning to a point where the user has proven email ownership so slugs cannot be squatted by unauthenticated actors.

### Description
- Remove early provisioning from the registration path by deleting the `provision_personal_organization(&created).await?;` call inside `register_inactive_user` in `dashboard/src/apps/auth/services/registration.rs` so registration only creates the inactive `User` and sends verification email.
- Ensure provisioning runs at verification time by invoking `ensure_personal_organization(&verified_user).await?;` from the email verification handler in `dashboard/src/apps/auth/server_urls.rs`, making provisioning idempotent for already-active users and for the verify-link retry path.
- Update function documentation/comments to reflect that Personal Organization provisioning occurs after successful email verification and that `provision_personal_organization` is intended for verified users or legacy rollback paths.
- Preserve existing rollback semantics inside the provisioning helper and keep `ensure_personal_organization` for idempotent provisioning of active users.

### Testing
- Ran `cargo fmt --check`, which succeeded.
- Attempted `cargo check -p reinhardt-cloud-dashboard --all-features`, but it was blocked by local protobuf include resolution (`protoc` failed to find `google/protobuf/timestamp.proto`), so full type-checking of the dashboard target could not complete.
- Attempted `cargo check -p reinhardt-cloud-dashboard --no-default-features`, which was similarly blocked by the same local protobuf include issue.
- Verified local edits with `git diff` and committed the change locally as `fix(auth): defer personal org provisioning until verification` (commit produced and PR created).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35f44d2650832794264d2d444fee25)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Personal organization setup now happens after email verification, simplifying sign-up while still completing account setup automatically.

* **Bug Fixes**
  * Verified users now reliably get a personal organization whether their account was newly activated or already active.
  * Sign-in checks now also ensure a personal organization exists, reducing cases where users could access the app without complete account setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->