### PR TITLE
security(types): restrict plugin wasm mount paths

### DIFF
--- a/crates/reinhardt-cloud-operator/src/error.rs
+++ b/crates/reinhardt-cloud-operator/src/error.rs
@@ -71,6 +71,11 @@ pub(crate) enum Error {
 	#[error("dentdelion plugin config render failed: {0}")]
 	PluginConfigRender(String),
 
+	/// Plugin configuration failed validation before Kubernetes resources
+	/// were materialized.
+	#[error("invalid plugin spec: {0}")]
+	InvalidPluginSpec(String),
+
 	/// `metadata.namespace` does not match the namespace computed from
 	/// `spec.tenant`. Set `metadata.namespace` to the value in `expected`,
 	/// or update `spec.tenant` so the computed namespace matches the
@@ -138,7 +143,8 @@ pub(crate) fn backoff_class(error: &Error) -> BackoffClass {
 		| Error::InvalidProbePeriod { .. }
 		| Error::TenantMismatch { .. }
 		| Error::InvalidTenant(_)
-		| Error::InvalidBudget(_) => BackoffClass::Permanent,
+		| Error::InvalidBudget(_)
+		| Error::InvalidPluginSpec(_) => BackoffClass::Permanent,
 		Error::Kube(kube_err) => kube_status_class(kube_err),
 		_ => BackoffClass::Transient,
 	}

--- a/crates/reinhardt-cloud-operator/src/resources/deployment.rs
+++ b/crates/reinhardt-cloud-operator/src/resources/deployment.rs
@@ -84,7 +84,7 @@ pub(crate) fn build_deployment(
 	// `production.toml` (made self-contained via ${VAR} interpolation in
 	// #588), so the application reads settings from its compile-time
 	// `CARGO_MANIFEST_DIR/settings` path.
-	let (plugin_volumes, plugin_mounts) = build_plugin_volumes(app);
+	let (plugin_volumes, plugin_mounts) = build_plugin_volumes(app)?;
 	let mut volumes: Vec<Volume> = plugin_volumes;
 	let volume_mounts: Vec<VolumeMount> = plugin_mounts;
 

--- a/crates/reinhardt-cloud-operator/src/resources/migration.rs
+++ b/crates/reinhardt-cloud-operator/src/resources/migration.rs
@@ -86,7 +86,7 @@ pub(crate) fn build_migration_job(
 		revision_key.to_string(),
 	)]);
 	let isolated = app.spec.isolation.is_some();
-	let (plugin_volumes, plugin_mounts) = build_plugin_volumes(app);
+	let (plugin_volumes, plugin_mounts) = build_plugin_volumes(app)?;
 	let resources = ResourceRequirements {
 		requests: Some(BTreeMap::from([
 			(
@@ -452,7 +452,7 @@ mod tests {
 		let mut app = test_app("my-app", "my-app:v1");
 		app.spec.plugins = Some(vec![PluginSpec {
 			name: "auth-filter".to_string(),
-			wasm_dir: "/plugins/auth".to_string(),
+			wasm_dir: "/var/lib/dentdelion/auth".to_string(),
 			plugin_type: PluginType::HttpMiddleware,
 			memory_limit_mb: None,
 			timeout_ms: None,
@@ -472,7 +472,7 @@ mod tests {
 			.expect("plugin volume mounts should be set");
 		assert_eq!(volumes.len(), 2);
 		assert_eq!(mounts.len(), 2);
-		assert_eq!(mounts[1].mount_path, "/plugins/auth");
+		assert_eq!(mounts[1].mount_path, "/var/lib/dentdelion/auth");
 	}
 
 	#[rstest]

--- a/crates/reinhardt-cloud-operator/src/resources/plugins.rs
+++ b/crates/reinhardt-cloud-operator/src/resources/plugins.rs
@@ -114,6 +114,26 @@ pub(crate) fn render_plugin_config(plugins: &[PluginSpec]) -> Result<String, Err
 	toml::to_string(&doc).map_err(|e| Error::PluginConfigRender(e.to_string()))
 }
 
+fn validate_plugin_specs(plugins: &[PluginSpec]) -> Result<(), Error> {
+	let messages: Vec<String> = plugins
+		.iter()
+		.enumerate()
+		.flat_map(|(idx, plugin)| {
+			plugin
+				.validate()
+				.err()
+				.unwrap_or_default()
+				.into_iter()
+				.map(move |error| format!("plugins[{idx}]: {}", error.message))
+		})
+		.collect();
+	if messages.is_empty() {
+		Ok(())
+	} else {
+		Err(Error::InvalidPluginSpec(messages.join("; ")))
+	}
+}
+
 /// Builds a `ConfigMap` carrying the rendered `dentdelion.toml` document.
 ///
 /// Returns `Ok(None)` when the spec declares no plugins; callers should
@@ -125,6 +145,7 @@ pub(crate) fn build_plugin_configmap(app: &Project) -> Result<Option<ConfigMap>,
 	if plugins.is_empty() {
 		return Ok(None);
 	}
+	validate_plugin_specs(plugins)?;
 
 	let labels = standard_labels(app, Component::Plugins);
 	let namespace = super::require_namespace(app)?;
@@ -150,13 +171,16 @@ pub(crate) fn build_plugin_configmap(app: &Project) -> Result<Option<ConfigMap>,
 /// to consume the declared plugins.
 ///
 /// The returned vectors are empty when the spec declares no plugins.
-pub(crate) fn build_plugin_volumes(app: &Project) -> (Vec<Volume>, Vec<VolumeMount>) {
+pub(crate) fn build_plugin_volumes(
+	app: &Project,
+) -> Result<(Vec<Volume>, Vec<VolumeMount>), Error> {
 	let Some(plugins) = app.spec.plugins.as_ref() else {
-		return (Vec::new(), Vec::new());
+		return Ok((Vec::new(), Vec::new()));
 	};
 	if plugins.is_empty() {
-		return (Vec::new(), Vec::new());
+		return Ok((Vec::new(), Vec::new()));
 	}
+	validate_plugin_specs(plugins)?;
 
 	// One Volume + VolumeMount for the ConfigMap-backed dentdelion.toml,
 	// plus one Volume + VolumeMount per plugin for the WASM artifact
@@ -194,7 +218,7 @@ pub(crate) fn build_plugin_volumes(app: &Project) -> (Vec<Volume>, Vec<VolumeMou
 		});
 	}
 
-	(volumes, mounts)
+	Ok((volumes, mounts))
 }
 
 #[cfg(test)]
@@ -241,7 +265,7 @@ mod tests {
 		let app = app_with_plugins(None);
 
 		// Act
-		let (volumes, mounts) = build_plugin_volumes(&app);
+		let (volumes, mounts) = build_plugin_volumes(&app).expect("plugin volumes should build");
 
 		// Assert
 		assert!(volumes.is_empty());
@@ -286,7 +310,7 @@ mod tests {
 		let plugins = vec![
 			PluginSpec {
 				name: "a".to_string(),
-				wasm_dir: "/p/a".to_string(),
+				wasm_dir: "/var/lib/dentdelion/a".to_string(),
 				plugin_type: PluginType::HttpMiddleware,
 				memory_limit_mb: None,
 				timeout_ms: None,
@@ -294,7 +318,7 @@ mod tests {
 			},
 			PluginSpec {
 				name: "b".to_string(),
-				wasm_dir: "/p/b".to_string(),
+				wasm_dir: "/var/lib/dentdelion/b".to_string(),
 				plugin_type: PluginType::GrpcInterceptor,
 				memory_limit_mb: None,
 				timeout_ms: None,
@@ -304,7 +328,7 @@ mod tests {
 		let app = app_with_plugins(Some(plugins));
 
 		// Act
-		let (volumes, mounts) = build_plugin_volumes(&app);
+		let (volumes, mounts) = build_plugin_volumes(&app).expect("plugin volumes should build");
 
 		// Assert
 		// 1 config ConfigMap volume + 2 plugin empty-dir volumes
@@ -312,8 +336,27 @@ mod tests {
 		assert_eq!(mounts.len(), 3);
 		assert_eq!(volumes[0].name, "dentdelion-config");
 		assert_eq!(mounts[0].mount_path, DENTDELION_CONFIG_MOUNT_DIR);
-		assert_eq!(mounts[1].mount_path, "/p/a");
-		assert_eq!(mounts[2].mount_path, "/p/b");
+		assert_eq!(mounts[1].mount_path, "/var/lib/dentdelion/a");
+		assert_eq!(mounts[2].mount_path, "/var/lib/dentdelion/b");
+	}
+
+	#[rstest]
+	fn test_build_plugin_volumes_rejects_invalid_wasm_dir() {
+		// Arrange
+		let app = app_with_plugins(Some(vec![PluginSpec {
+			name: "bad".to_string(),
+			wasm_dir: "/etc/passwd".to_string(),
+			plugin_type: PluginType::HttpMiddleware,
+			memory_limit_mb: None,
+			timeout_ms: None,
+			capabilities: Vec::new(),
+		}]));
+
+		// Act
+		let err = build_plugin_volumes(&app).expect_err("invalid plugin path should fail");
+
+		// Assert
+		assert!(matches!(err, Error::InvalidPluginSpec(_)));
 	}
 
 	#[rstest]
@@ -321,7 +364,7 @@ mod tests {
 		// Arrange
 		let plugin = PluginSpec {
 			name: "full".to_string(),
-			wasm_dir: "/p/full".to_string(),
+			wasm_dir: "/var/lib/dentdelion/full".to_string(),
 			plugin_type: PluginType::EventHandler,
 			memory_limit_mb: None,
 			timeout_ms: None,

--- a/crates/reinhardt-cloud-types/src/crd/plugins.rs
+++ b/crates/reinhardt-cloud-types/src/crd/plugins.rs
@@ -5,8 +5,6 @@
 //! `dentdelion.toml` `ConfigMap` and mounts the WASM artifacts into
 //! the application container via volume + volume mount pairs.
 
-use std::path::{Component, Path};
-
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -108,16 +106,13 @@ impl PluginSpec {
 		if trimmed_dir.is_empty() {
 			errors.push(ValidationError::new("plugins[].wasm_dir must be non-empty"));
 		} else {
-			let wasm_path = Path::new(trimmed_dir);
-			let is_absolute = wasm_path.is_absolute();
+			let is_absolute = trimmed_dir.starts_with('/');
 			if !is_absolute {
 				errors.push(ValidationError::new(
 					"plugins[].wasm_dir must be an absolute path (start with '/')",
 				));
 			}
-			let has_parent_dir = wasm_path
-				.components()
-				.any(|c| matches!(c, Component::ParentDir));
+			let has_parent_dir = trimmed_dir.split('/').any(|component| component == "..");
 			if has_parent_dir {
 				errors.push(ValidationError::new(
 					"plugins[].wasm_dir must not contain '..' path components",
@@ -125,8 +120,8 @@ impl PluginSpec {
 			}
 			if is_absolute
 				&& !has_parent_dir
-				&& (!wasm_path.starts_with(PLUGIN_WASM_DIR_PREFIX)
-					|| wasm_path == Path::new(PLUGIN_WASM_DIR_PREFIX))
+				&& (!trimmed_dir.starts_with(&format!("{PLUGIN_WASM_DIR_PREFIX}/"))
+					|| trimmed_dir.trim_end_matches('/') == PLUGIN_WASM_DIR_PREFIX)
 			{
 				errors.push(ValidationError::new(format!(
 					"plugins[].wasm_dir must be under {PLUGIN_WASM_DIR_PREFIX}/"
@@ -295,11 +290,15 @@ mod tests {
 	}
 
 	#[rstest]
-	fn plugin_spec_validate_rejects_unsafe_wasm_dir_prefix() {
+	#[case::outside_prefix("/app")]
+	#[case::prefix_sibling("/var/lib/dentdelionary/p")]
+	#[case::prefix_root("/var/lib/dentdelion")]
+	#[case::prefix_root_trailing_slash("/var/lib/dentdelion/")]
+	fn plugin_spec_validate_rejects_unsafe_wasm_dir_prefix(#[case] wasm_dir: &str) {
 		// Arrange
 		let spec = PluginSpec {
 			name: "p".to_string(),
-			wasm_dir: "/app".to_string(),
+			wasm_dir: wasm_dir.to_string(),
 			plugin_type: PluginType::HttpMiddleware,
 			memory_limit_mb: None,
 			timeout_ms: None,

--- a/crates/reinhardt-cloud-types/src/crd/plugins.rs
+++ b/crates/reinhardt-cloud-types/src/crd/plugins.rs
@@ -12,6 +12,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::validation::ValidationError;
 
+/// Safe in-container root for writable dentdelion WASM plugin mounts.
+pub const PLUGIN_WASM_DIR_PREFIX: &str = "/var/lib/dentdelion";
+
 /// Sanitizes a plugin name into the suffix used by the Kubernetes
 /// `Volume.name` (excluding any operator-side prefix).
 ///
@@ -90,10 +93,10 @@ impl PluginSpec {
 	/// Validates the plugin specification.
 	///
 	/// Checks that `name` and `wasm_dir` are non-empty, that `wasm_dir`
-	/// is an absolute path with no `..` components (path-traversal
-	/// guard, since `wasm_dir` flows directly into a Kubernetes
-	/// `VolumeMount.mount_path`), and that any optional numeric limits
-	/// are strictly positive when provided.
+	/// is an absolute path under [`PLUGIN_WASM_DIR_PREFIX`] with no `..`
+	/// components (path-traversal guard, since `wasm_dir` flows directly
+	/// into a Kubernetes `VolumeMount.mount_path`), and that any optional
+	/// numeric limits are strictly positive when provided.
 	pub fn validate(&self) -> Result<(), Vec<ValidationError>> {
 		let mut errors = Vec::new();
 
@@ -105,18 +108,29 @@ impl PluginSpec {
 		if trimmed_dir.is_empty() {
 			errors.push(ValidationError::new("plugins[].wasm_dir must be non-empty"));
 		} else {
-			if !trimmed_dir.starts_with('/') {
+			let wasm_path = Path::new(trimmed_dir);
+			let is_absolute = wasm_path.is_absolute();
+			if !is_absolute {
 				errors.push(ValidationError::new(
 					"plugins[].wasm_dir must be an absolute path (start with '/')",
 				));
 			}
-			if Path::new(trimmed_dir)
+			let has_parent_dir = wasm_path
 				.components()
-				.any(|c| matches!(c, Component::ParentDir))
-			{
+				.any(|c| matches!(c, Component::ParentDir));
+			if has_parent_dir {
 				errors.push(ValidationError::new(
 					"plugins[].wasm_dir must not contain '..' path components",
 				));
+			}
+			if is_absolute
+				&& !has_parent_dir
+				&& (!wasm_path.starts_with(PLUGIN_WASM_DIR_PREFIX)
+					|| wasm_path == Path::new(PLUGIN_WASM_DIR_PREFIX))
+			{
+				errors.push(ValidationError::new(format!(
+					"plugins[].wasm_dir must be under {PLUGIN_WASM_DIR_PREFIX}/"
+				)));
 			}
 		}
 
@@ -175,7 +189,8 @@ mod tests {
 	#[rstest]
 	fn plugin_spec_capabilities_defaults_empty() {
 		// Arrange
-		let json = r#"{"name":"p","wasm_dir":"/p","plugin_type":"GrpcInterceptor"}"#;
+		let json =
+			r#"{"name":"p","wasm_dir":"/var/lib/dentdelion/p","plugin_type":"GrpcInterceptor"}"#;
 
 		// Act
 		let parsed: PluginSpec = serde_json::from_str(json).expect("deserialize should succeed");
@@ -192,7 +207,7 @@ mod tests {
 		// Arrange
 		let spec = PluginSpec {
 			name: "p".to_string(),
-			wasm_dir: "/p".to_string(),
+			wasm_dir: "/var/lib/dentdelion/p".to_string(),
 			plugin_type: PluginType::EventHandler,
 			memory_limit_mb: None,
 			timeout_ms: None,
@@ -276,6 +291,31 @@ mod tests {
 		assert_eq!(
 			errors[0].message,
 			"plugins[].wasm_dir must not contain '..' path components"
+		);
+	}
+
+	#[rstest]
+	fn plugin_spec_validate_rejects_unsafe_wasm_dir_prefix() {
+		// Arrange
+		let spec = PluginSpec {
+			name: "p".to_string(),
+			wasm_dir: "/app".to_string(),
+			plugin_type: PluginType::HttpMiddleware,
+			memory_limit_mb: None,
+			timeout_ms: None,
+			capabilities: Vec::new(),
+		};
+
+		// Act
+		let errors = spec
+			.validate()
+			.expect_err("unsafe wasm_dir prefix should be rejected");
+
+		// Assert
+		assert_eq!(errors.len(), 1);
+		assert_eq!(
+			errors[0].message,
+			"plugins[].wasm_dir must be under /var/lib/dentdelion/"
 		);
 	}
 

--- a/crates/reinhardt-cloud-types/src/crd/spec.rs
+++ b/crates/reinhardt-cloud-types/src/crd/spec.rs
@@ -1,6 +1,7 @@
 //! Spec types for the `Project` custom resource.
 
 use std::collections::BTreeMap;
+use std::path::Path;
 
 use k8s_openapi::api::core::v1::LocalObjectReference;
 use kube::CustomResource;
@@ -463,10 +464,25 @@ impl ProjectSpec {
 					)));
 				}
 				let dir = plugin.wasm_dir.trim().to_string();
-				if !dir.is_empty() && !seen_dirs.insert(dir.clone()) {
+				if dir.is_empty() {
+					continue;
+				}
+				if !seen_dirs.insert(dir.clone()) {
 					errors.push(ValidationError::new(format!(
 						"spec.plugins contains entries with duplicate wasm_dir '{dir}'"
 					)));
+				}
+			}
+			let dirs: Vec<&str> = seen_dirs.iter().map(String::as_str).collect();
+			for (index, dir) in dirs.iter().enumerate() {
+				let dir_path = Path::new(dir);
+				for other in dirs.iter().skip(index + 1) {
+					let other_path = Path::new(other);
+					if dir_path.starts_with(other_path) || other_path.starts_with(dir_path) {
+						errors.push(ValidationError::new(format!(
+							"spec.plugins contains overlapping wasm_dir mount paths '{dir}' and '{other}'"
+						)));
+					}
 				}
 			}
 		}
@@ -1519,7 +1535,7 @@ mod tests {
 			image: "app:v1".to_string(),
 			plugins: Some(vec![PluginSpec {
 				name: String::new(),
-				wasm_dir: "/p".to_string(),
+				wasm_dir: "/var/lib/dentdelion/p".to_string(),
 				plugin_type: PluginType::HttpMiddleware,
 				memory_limit_mb: None,
 				timeout_ms: None,
@@ -1611,6 +1627,46 @@ mod tests {
 		assert!(errors.iter().any(|e| {
 			e.message
 				.contains("duplicate wasm_dir '/var/lib/dentdelion/shared'")
+		}));
+	}
+
+	#[rstest]
+	fn test_spec_validate_rejects_overlapping_plugin_wasm_dir() {
+		// Arrange
+		use crate::crd::plugins::{PluginSpec, PluginType};
+		let spec = ProjectSpec {
+			image: "app:v1".to_string(),
+			plugins: Some(vec![
+				PluginSpec {
+					name: "alpha".to_string(),
+					wasm_dir: "/var/lib/dentdelion/plugins".to_string(),
+					plugin_type: PluginType::HttpMiddleware,
+					memory_limit_mb: None,
+					timeout_ms: None,
+					capabilities: Vec::new(),
+				},
+				PluginSpec {
+					name: "beta".to_string(),
+					wasm_dir: "/var/lib/dentdelion/plugins/beta".to_string(),
+					plugin_type: PluginType::HttpMiddleware,
+					memory_limit_mb: None,
+					timeout_ms: None,
+					capabilities: Vec::new(),
+				},
+			]),
+			..Default::default()
+		};
+
+		// Act
+		let errors = spec
+			.validate()
+			.expect_err("overlapping wasm_dir values should be rejected");
+
+		// Assert
+		assert!(errors.iter().any(|e| {
+			e.message.contains(
+				"overlapping wasm_dir mount paths '/var/lib/dentdelion/plugins' and '/var/lib/dentdelion/plugins/beta'",
+			)
 		}));
 	}
 


### PR DESCRIPTION
### Motivation
- The operator previously mounted per-plugin `wasm_dir` values directly into pods, allowing a ReinhardtApp author to mount writable `emptyDir` volumes over arbitrary container paths and potentially mask application binaries, configuration, or secrets.
- This change tightens validation and disallows unsafe or overlapping plugin mount paths to prevent integrity and availability failures in workloads the operator manages.

### Description
- Add a `PLUGIN_WASM_DIR_PREFIX` constant (`/var/lib/dentdelion`) and require `PluginSpec.wasm_dir` to be absolute, traversal-free, and located under that prefix.
- Reject `wasm_dir` values that equal the prefix or contain `..`, and produce a clear validation error when the constraint is violated.
- Add cross-plugin validation in `ProjectSpec::validate` that rejects duplicate and overlapping `wasm_dir` mount paths.
- Update and add unit tests to cover unsafe prefix rejection and overlapping mount detection and adjust existing tests to use the safe prefix.

### Testing
- Ran `cargo test -p reinhardt-cloud-types plugin --lib`, with the plugin/spec unit test suite passing (18 passed, 0 failed).
- Ran `cargo fmt --check`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35f44f0e1c832789393b30ec75f9b8)