### PR TITLE
security: bound explicit database provisioning

### DIFF
--- a/charts/reinhardt-cloud-operator/crds/project-crd.yaml
+++ b/charts/reinhardt-cloud-operator/crds/project-crd.yaml
@@ -85,16 +85,6 @@ spec:
                     description: |-
                       Instance class (platform-specific, e.g., "db.t3.micro").
                       Defaults to platform profile value if unset.
-                    enum:
-                    - db.t3.micro
-                    - db.t3.small
-                    - db.t3.medium
-                    - db.t3.large
-                    - db.r5.large
-                    - db-f1-micro
-                    - db-g1-small
-                    - db-custom-1-3840
-                    - db-custom-2-8192
                     nullable: true
                     type: string
                   storage_gb:

--- a/charts/reinhardt-cloud-operator/crds/project-crd.yaml
+++ b/charts/reinhardt-cloud-operator/crds/project-crd.yaml
@@ -85,11 +85,23 @@ spec:
                     description: |-
                       Instance class (platform-specific, e.g., "db.t3.micro").
                       Defaults to platform profile value if unset.
+                    enum:
+                    - db.t3.micro
+                    - db.t3.small
+                    - db.t3.medium
+                    - db.t3.large
+                    - db.r5.large
+                    - db-f1-micro
+                    - db-g1-small
+                    - db-custom-1-3840
+                    - db-custom-2-8192
                     nullable: true
                     type: string
                   storage_gb:
-                    description: Storage size in GB. Must be > 0.
+                    description: Storage size in GB. Must be between 1 and 100.
                     format: int32
+                    maximum: 100
+                    minimum: 1
                     nullable: true
                     type: integer
                   version:

--- a/crates/reinhardt-cloud-operator/src/error.rs
+++ b/crates/reinhardt-cloud-operator/src/error.rs
@@ -136,6 +136,7 @@ pub(crate) fn backoff_class(error: &Error) -> BackoffClass {
 		Error::MissingField(_)
 		| Error::InvalidPort { .. }
 		| Error::InvalidProbePeriod { .. }
+		| Error::DatabaseProvisioning(_)
 		| Error::TenantMismatch { .. }
 		| Error::InvalidTenant(_)
 		| Error::InvalidBudget(_) => BackoffClass::Permanent,
@@ -209,6 +210,18 @@ mod tests {
 	fn invalid_tenant_is_permanent() {
 		// Arrange
 		let err = Error::InvalidTenant("tenant.organization must not be empty".to_string());
+
+		// Act
+		let class = backoff_class(&err);
+
+		// Assert
+		assert_eq!(class, BackoffClass::Permanent);
+	}
+
+	#[rstest]
+	fn database_provisioning_is_permanent() {
+		// Arrange
+		let err = Error::DatabaseProvisioning("database.storage_gb must be <= 100".to_string());
 
 		// Act
 		let class = backoff_class(&err);

--- a/crates/reinhardt-cloud-operator/src/inference/database.rs
+++ b/crates/reinhardt-cloud-operator/src/inference/database.rs
@@ -133,6 +133,9 @@ pub(crate) fn infer_database_resources(
 		Some(db) => db,
 		None => return vec![],
 	};
+	if db.validate().is_err() {
+		return vec![];
+	}
 
 	let namespace = match app.namespace() {
 		Some(ns) => ns,
@@ -570,6 +573,25 @@ mod tests {
 		// Arrange
 		let app = make_app_without_db("myapp");
 		let platform = PlatformConfig::onprem_defaults();
+
+		// Act
+		let resources = infer_database_resources(&app, &platform);
+
+		// Assert
+		assert!(resources.is_empty());
+	}
+
+	#[rstest]
+	fn invalid_database_spec_returns_empty() {
+		// Arrange
+		let db_spec = DatabaseSpec {
+			engine: DatabaseEngine::Postgresql,
+			instance_class: Some("db.r7i.48xlarge".to_string()),
+			storage_gb: Some(2_000_000_000),
+			version: None,
+		};
+		let app = make_app_with_db("myapp", db_spec);
+		let platform = PlatformConfig::aws_defaults();
 
 		// Act
 		let resources = infer_database_resources(&app, &platform);

--- a/crates/reinhardt-cloud-operator/src/inference/database.rs
+++ b/crates/reinhardt-cloud-operator/src/inference/database.rs
@@ -26,6 +26,22 @@ use reinhardt_cloud_types::crd::{DatabaseEngine, DatabaseSpec, Project};
 
 use super::platform::{Platform, PlatformConfig};
 use super::secrets::{build_db_credentials_secret, generate_random_password};
+use crate::error::Error;
+
+const AWS_DATABASE_INSTANCE_CLASSES: &[&str] = &[
+	"db.t3.micro",
+	"db.t3.small",
+	"db.t3.medium",
+	"db.t3.large",
+	"db.r5.large",
+];
+
+const GCP_DATABASE_INSTANCE_CLASSES: &[&str] = &[
+	"db-f1-micro",
+	"db-g1-small",
+	"db-custom-1-3840",
+	"db-custom-2-8192",
+];
 
 /// Map a `DatabaseEngine` variant to the lowercase engine name used by AWS RDS.
 ///
@@ -128,28 +144,55 @@ pub(crate) enum DatabaseResource {
 pub(crate) fn infer_database_resources(
 	app: &Project,
 	platform: &PlatformConfig,
-) -> Vec<DatabaseResource> {
+) -> Result<Vec<DatabaseResource>, Error> {
 	let db = match &app.spec.database {
 		Some(db) => db,
-		None => return vec![],
+		None => return Ok(vec![]),
 	};
-	if db.validate().is_err() {
-		return vec![];
-	}
+	validate_database_for_platform(db, platform)?;
 
 	let namespace = match app.namespace() {
 		Some(ns) => ns,
-		None => return vec![], // namespace required for database resources
+		None => return Ok(vec![]), // namespace required for database resources
 	};
 	let project_name = app.name_any();
 	let storage_gb = db
 		.storage_gb
 		.unwrap_or(platform.defaults.database.storage_gb);
 
-	match platform.platform {
+	let resources = match platform.platform {
 		Platform::Onpremise => build_onprem_postgres(&project_name, &namespace, db, storage_gb),
 		Platform::Aws => build_aws_rds(&project_name, &namespace, db, platform),
 		Platform::Gcp => build_gcp_cloud_sql(&project_name, &namespace, db, storage_gb, platform),
+	};
+	Ok(resources)
+}
+
+fn validate_database_for_platform(
+	db: &DatabaseSpec,
+	platform: &PlatformConfig,
+) -> Result<(), Error> {
+	db.validate().map_err(Error::DatabaseProvisioning)?;
+	let Some(instance_class) = db.instance_class.as_deref() else {
+		return Ok(());
+	};
+	let allowed = match platform.platform {
+		Platform::Aws => AWS_DATABASE_INSTANCE_CLASSES,
+		Platform::Gcp => GCP_DATABASE_INSTANCE_CLASSES,
+		Platform::Onpremise => {
+			return Err(Error::DatabaseProvisioning(
+				"database.instance_class is not supported for onpremise databases".to_string(),
+			));
+		}
+	};
+	if allowed.contains(&instance_class) {
+		Ok(())
+	} else {
+		Err(Error::DatabaseProvisioning(format!(
+			"database.instance_class '{instance_class}' is not allowed for {:?}; allowed values: {}",
+			platform.platform,
+			allowed.join(", ")
+		)))
 	}
 }
 
@@ -575,14 +618,15 @@ mod tests {
 		let platform = PlatformConfig::onprem_defaults();
 
 		// Act
-		let resources = infer_database_resources(&app, &platform);
+		let resources =
+			infer_database_resources(&app, &platform).expect("database resources should infer");
 
 		// Assert
 		assert!(resources.is_empty());
 	}
 
 	#[rstest]
-	fn invalid_database_spec_returns_empty() {
+	fn invalid_database_spec_returns_error() {
 		// Arrange
 		let db_spec = DatabaseSpec {
 			engine: DatabaseEngine::Postgresql,
@@ -594,10 +638,29 @@ mod tests {
 		let platform = PlatformConfig::aws_defaults();
 
 		// Act
-		let resources = infer_database_resources(&app, &platform);
+		let result = infer_database_resources(&app, &platform);
 
 		// Assert
-		assert!(resources.is_empty());
+		assert!(matches!(result, Err(Error::DatabaseProvisioning(_))));
+	}
+
+	#[rstest]
+	fn database_instance_class_must_match_target_platform() {
+		// Arrange
+		let db_spec = DatabaseSpec {
+			engine: DatabaseEngine::Postgresql,
+			instance_class: Some("db-custom-2-8192".to_string()),
+			storage_gb: Some(20),
+			version: None,
+		};
+		let app = make_app_with_db("myapp", db_spec);
+		let platform = PlatformConfig::aws_defaults();
+
+		// Act
+		let result = infer_database_resources(&app, &platform);
+
+		// Assert
+		assert!(matches!(result, Err(Error::DatabaseProvisioning(_))));
 	}
 
 	#[rstest]
@@ -613,7 +676,8 @@ mod tests {
 		let platform = PlatformConfig::onprem_defaults();
 
 		// Act
-		let resources = infer_database_resources(&app, &platform);
+		let resources =
+			infer_database_resources(&app, &platform).expect("database resources should infer");
 
 		// Assert
 		assert_eq!(resources.len(), 5);
@@ -637,7 +701,8 @@ mod tests {
 		let platform = PlatformConfig::onprem_defaults();
 
 		// Act
-		let resources = infer_database_resources(&app, &platform);
+		let resources =
+			infer_database_resources(&app, &platform).expect("database resources should infer");
 
 		// Assert
 		if let DatabaseResource::StatefulSet(ss) = &resources[0] {
@@ -669,7 +734,8 @@ mod tests {
 		let platform = PlatformConfig::onprem_defaults();
 
 		// Act
-		let resources = infer_database_resources(&app, &platform);
+		let resources =
+			infer_database_resources(&app, &platform).expect("database resources should infer");
 
 		// Assert
 		let DatabaseResource::StatefulSet(ss) = &resources[0] else {
@@ -706,7 +772,8 @@ mod tests {
 		let platform = PlatformConfig::onprem_defaults();
 
 		// Act
-		let resources = infer_database_resources(&app, &platform);
+		let resources =
+			infer_database_resources(&app, &platform).expect("database resources should infer");
 
 		// Assert
 		let DatabaseResource::StatefulSet(ss) = &resources[0] else {
@@ -735,7 +802,8 @@ mod tests {
 		let platform = PlatformConfig::onprem_defaults();
 
 		// Act
-		let resources = infer_database_resources(&app, &platform);
+		let resources =
+			infer_database_resources(&app, &platform).expect("database resources should infer");
 
 		// Assert
 		if let DatabaseResource::Pvc(pvc) = &resources[1] {
@@ -768,7 +836,8 @@ mod tests {
 		let platform = PlatformConfig::onprem_defaults();
 
 		// Act
-		let resources = infer_database_resources(&app, &platform);
+		let resources =
+			infer_database_resources(&app, &platform).expect("database resources should infer");
 
 		// Assert
 		if let DatabaseResource::Pvc(pvc) = &resources[1] {
@@ -801,7 +870,8 @@ mod tests {
 		let platform = PlatformConfig::aws_defaults();
 
 		// Act
-		let resources = infer_database_resources(&app, &platform);
+		let resources =
+			infer_database_resources(&app, &platform).expect("database resources should infer");
 
 		// Assert
 		assert_eq!(resources.len(), 2);
@@ -822,7 +892,8 @@ mod tests {
 		let platform = PlatformConfig::aws_defaults();
 
 		// Act
-		let resources = infer_database_resources(&app, &platform);
+		let resources =
+			infer_database_resources(&app, &platform).expect("database resources should infer");
 
 		// Assert
 		if let DatabaseResource::Dynamic(obj) = &resources[0] {
@@ -849,7 +920,8 @@ mod tests {
 		let platform = PlatformConfig::gcp_defaults();
 
 		// Act
-		let resources = infer_database_resources(&app, &platform);
+		let resources =
+			infer_database_resources(&app, &platform).expect("database resources should infer");
 
 		// Assert
 		assert_eq!(resources.len(), 4);
@@ -872,7 +944,8 @@ mod tests {
 		let platform = PlatformConfig::gcp_defaults();
 
 		// Act
-		let resources = infer_database_resources(&app, &platform);
+		let resources =
+			infer_database_resources(&app, &platform).expect("database resources should infer");
 
 		// Assert
 		if let DatabaseResource::Dynamic(obj) = &resources[0] {
@@ -922,7 +995,8 @@ mod tests {
 		let platform = PlatformConfig::onprem_defaults();
 
 		// Act
-		let resources = infer_database_resources(&app, &platform);
+		let resources =
+			infer_database_resources(&app, &platform).expect("database resources should infer");
 
 		// Assert
 		if let DatabaseResource::Pvc(pvc) = &resources[1] {
@@ -955,7 +1029,8 @@ mod tests {
 		let platform = PlatformConfig::onprem_defaults();
 
 		// Act
-		let resources = infer_database_resources(&app, &platform);
+		let resources =
+			infer_database_resources(&app, &platform).expect("database resources should infer");
 
 		// Assert
 		if let DatabaseResource::Service(svc) = &resources[2] {
@@ -987,7 +1062,8 @@ mod tests {
 		let platform = PlatformConfig::onprem_defaults();
 
 		// Act
-		let resources = infer_database_resources(&app, &platform);
+		let resources =
+			infer_database_resources(&app, &platform).expect("database resources should infer");
 
 		// Assert
 		if let DatabaseResource::StatefulSet(ss) = &resources[0] {
@@ -1056,7 +1132,8 @@ mod tests {
 		let platform = PlatformConfig::aws_defaults();
 
 		// Act
-		let resources = infer_database_resources(&app, &platform);
+		let resources =
+			infer_database_resources(&app, &platform).expect("database resources should infer");
 
 		// Assert
 		if let DatabaseResource::Dynamic(obj) = &resources[0] {
@@ -1083,7 +1160,8 @@ mod tests {
 		let platform = PlatformConfig::aws_defaults();
 
 		// Act
-		let resources = infer_database_resources(&app, &platform);
+		let resources =
+			infer_database_resources(&app, &platform).expect("database resources should infer");
 
 		// Assert
 		if let DatabaseResource::Dynamic(obj) = &resources[0] {
@@ -1108,7 +1186,8 @@ mod tests {
 		let platform = PlatformConfig::aws_defaults();
 
 		// Act
-		let resources = infer_database_resources(&app, &platform);
+		let resources =
+			infer_database_resources(&app, &platform).expect("database resources should infer");
 
 		// Assert
 		if let DatabaseResource::Dynamic(obj) = &resources[0] {
@@ -1133,7 +1212,8 @@ mod tests {
 		let platform = PlatformConfig::aws_defaults();
 
 		// Act
-		let resources = infer_database_resources(&app, &platform);
+		let resources =
+			infer_database_resources(&app, &platform).expect("database resources should infer");
 
 		// Assert — values should come from platform.defaults.database
 		if let DatabaseResource::Dynamic(obj) = &resources[0] {
@@ -1165,7 +1245,8 @@ mod tests {
 		let platform = PlatformConfig::aws_defaults();
 
 		// Act
-		let resources = infer_database_resources(&app, &platform);
+		let resources =
+			infer_database_resources(&app, &platform).expect("database resources should infer");
 
 		// Assert
 		if let DatabaseResource::Dynamic(obj) = &resources[0] {
@@ -1193,7 +1274,8 @@ mod tests {
 		let platform = PlatformConfig::gcp_defaults();
 
 		// Act
-		let resources = infer_database_resources(&app, &platform);
+		let resources =
+			infer_database_resources(&app, &platform).expect("database resources should infer");
 
 		// Assert
 		if let DatabaseResource::Dynamic(obj) = &resources[0] {
@@ -1221,7 +1303,8 @@ mod tests {
 		let platform = PlatformConfig::gcp_defaults();
 
 		// Act
-		let resources = infer_database_resources(&app, &platform);
+		let resources =
+			infer_database_resources(&app, &platform).expect("database resources should infer");
 
 		// Assert
 		if let DatabaseResource::Dynamic(obj) = &resources[0] {
@@ -1244,7 +1327,8 @@ mod tests {
 		let platform = PlatformConfig::gcp_defaults();
 
 		// Act
-		let resources = infer_database_resources(&app, &platform);
+		let resources =
+			infer_database_resources(&app, &platform).expect("database resources should infer");
 
 		// Assert
 		if let DatabaseResource::Dynamic(obj) = &resources[0] {
@@ -1269,7 +1353,8 @@ mod tests {
 		let platform = PlatformConfig::gcp_defaults();
 
 		// Act
-		let resources = infer_database_resources(&app, &platform);
+		let resources =
+			infer_database_resources(&app, &platform).expect("database resources should infer");
 
 		// Assert
 		if let DatabaseResource::Dynamic(obj) = &resources[0] {
@@ -1292,7 +1377,8 @@ mod tests {
 		let platform = PlatformConfig::gcp_defaults();
 
 		// Act
-		let resources = infer_database_resources(&app, &platform);
+		let resources =
+			infer_database_resources(&app, &platform).expect("database resources should infer");
 
 		// Assert
 		if let DatabaseResource::Dynamic(obj) = &resources[1] {
@@ -1318,7 +1404,8 @@ mod tests {
 		let platform = PlatformConfig::gcp_defaults();
 
 		// Act
-		let resources = infer_database_resources(&app, &platform);
+		let resources =
+			infer_database_resources(&app, &platform).expect("database resources should infer");
 
 		// Assert
 		if let DatabaseResource::Dynamic(obj) = &resources[2] {
@@ -1347,7 +1434,8 @@ mod tests {
 		let platform = PlatformConfig::aws_defaults();
 
 		// Act
-		let resources = infer_database_resources(&app, &platform);
+		let resources =
+			infer_database_resources(&app, &platform).expect("database resources should infer");
 
 		// Assert
 		assert!(resources.is_empty());
@@ -1366,7 +1454,8 @@ mod tests {
 		let platform = PlatformConfig::gcp_defaults();
 
 		// Act
-		let resources = infer_database_resources(&app, &platform);
+		let resources =
+			infer_database_resources(&app, &platform).expect("database resources should infer");
 
 		// Assert
 		assert!(resources.is_empty());
@@ -1426,7 +1515,8 @@ mod tests {
 		let platform = PlatformConfig::gcp_defaults();
 
 		// Act
-		let resources = infer_database_resources(&app, &platform);
+		let resources =
+			infer_database_resources(&app, &platform).expect("database resources should infer");
 
 		// Assert
 		if let DatabaseResource::Dynamic(obj) = &resources[0] {

--- a/crates/reinhardt-cloud-operator/src/reconciler.rs
+++ b/crates/reinhardt-cloud-operator/src/reconciler.rs
@@ -453,7 +453,7 @@ async fn apply(app: Arc<Project>, ctx: &Context, namespace: &str) -> Result<Acti
 		// set of platform-appropriate resources (on-prem StatefulSet/PVC,
 		// AWS ACK DBInstance, or GCP Config Connector SQL resources) and
 		// apply them via server-side apply.
-		let resources = infer_database_resources(&app, &ctx.platform);
+		let resources = infer_database_resources(&app, &ctx.platform)?;
 		for resource in resources {
 			match resource {
 				DatabaseResource::StatefulSet(ss) => {
@@ -3401,7 +3401,8 @@ mod tests {
 		// function. A non-empty result proves the wiring is reachable;
 		// the previous code path (introspect-only) would have ignored
 		// the explicit spec entirely.
-		let resources = infer_database_resources(&app, &platform);
+		let resources =
+			infer_database_resources(&app, &platform).expect("database resources should infer");
 
 		// Assert
 		assert_eq!(

--- a/crates/reinhardt-cloud-types/src/crd/database.rs
+++ b/crates/reinhardt-cloud-types/src/crd/database.rs
@@ -1,14 +1,32 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+/// Maximum database storage tenants may request through `spec.database`.
+pub const MAX_DATABASE_STORAGE_GB: i32 = 100;
+
+/// Safe database instance classes accepted for managed cloud databases.
+pub const ALLOWED_DATABASE_INSTANCE_CLASSES: &[&str] = &[
+	"db.t3.micro",
+	"db.t3.small",
+	"db.t3.medium",
+	"db.t3.large",
+	"db.r5.large",
+	"db-f1-micro",
+	"db-g1-small",
+	"db-custom-1-3840",
+	"db-custom-2-8192",
+];
+
 /// Database infrastructure specification
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct DatabaseSpec {
 	pub engine: DatabaseEngine,
 	/// Instance class (platform-specific, e.g., "db.t3.micro").
 	/// Defaults to platform profile value if unset.
+	///
+	/// Explicit values must be one of `ALLOWED_DATABASE_INSTANCE_CLASSES`.
 	pub instance_class: Option<String>,
-	/// Storage size in GB. Must be > 0.
+	/// Storage size in GB. Must be between 1 and `MAX_DATABASE_STORAGE_GB`.
 	pub storage_gb: Option<i32>,
 	/// Engine version (e.g., "16" for PostgreSQL).
 	pub version: Option<String>,
@@ -49,11 +67,26 @@ pub enum ResourcePhase {
 impl DatabaseSpec {
 	/// Validates the database specification
 	pub fn validate(&self) -> Result<(), String> {
-		if let Some(gb) = self.storage_gb
-			&& gb <= 0
-		{
-			return Err("database.storage_gb must be > 0".to_string());
+		if let Some(gb) = self.storage_gb {
+			if gb <= 0 {
+				return Err("database.storage_gb must be > 0".to_string());
+			}
+			if gb > MAX_DATABASE_STORAGE_GB {
+				return Err(format!(
+					"database.storage_gb must be <= {MAX_DATABASE_STORAGE_GB}"
+				));
+			}
 		}
+
+		if let Some(instance_class) = self.instance_class.as_deref()
+			&& !ALLOWED_DATABASE_INSTANCE_CLASSES.contains(&instance_class)
+		{
+			return Err(format!(
+				"database.instance_class must be one of: {}",
+				ALLOWED_DATABASE_INSTANCE_CLASSES.join(", ")
+			));
+		}
+
 		Ok(())
 	}
 }
@@ -106,6 +139,51 @@ mod tests {
 		let result = spec.validate();
 		// Assert
 		assert!(result.is_err());
+	}
+
+	#[rstest]
+	fn test_database_spec_rejects_excessive_storage() {
+		// Arrange
+		let spec = DatabaseSpec {
+			engine: DatabaseEngine::Postgresql,
+			instance_class: None,
+			storage_gb: Some(MAX_DATABASE_STORAGE_GB + 1),
+			version: None,
+		};
+
+		// Act
+		let result = spec.validate();
+
+		// Assert
+		assert_eq!(
+			result,
+			Err(format!(
+				"database.storage_gb must be <= {MAX_DATABASE_STORAGE_GB}"
+			))
+		);
+	}
+
+	#[rstest]
+	fn test_database_spec_rejects_unsafe_instance_class() {
+		// Arrange
+		let spec = DatabaseSpec {
+			engine: DatabaseEngine::Postgresql,
+			instance_class: Some("db.r7i.48xlarge".to_string()),
+			storage_gb: Some(20),
+			version: None,
+		};
+
+		// Act
+		let result = spec.validate();
+
+		// Assert
+		assert_eq!(
+			result,
+			Err(format!(
+				"database.instance_class must be one of: {}",
+				ALLOWED_DATABASE_INSTANCE_CLASSES.join(", ")
+			))
+		);
 	}
 
 	#[rstest]

--- a/crates/reinhardt-cloud-types/src/crd/database.rs
+++ b/crates/reinhardt-cloud-types/src/crd/database.rs
@@ -4,29 +4,15 @@ use serde::{Deserialize, Serialize};
 /// Maximum database storage tenants may request through `spec.database`.
 pub const MAX_DATABASE_STORAGE_GB: i32 = 100;
 
-/// Safe database instance classes accepted for managed cloud databases.
-pub const ALLOWED_DATABASE_INSTANCE_CLASSES: &[&str] = &[
-	"db.t3.micro",
-	"db.t3.small",
-	"db.t3.medium",
-	"db.t3.large",
-	"db.r5.large",
-	"db-f1-micro",
-	"db-g1-small",
-	"db-custom-1-3840",
-	"db-custom-2-8192",
-];
-
 /// Database infrastructure specification
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct DatabaseSpec {
 	pub engine: DatabaseEngine,
 	/// Instance class (platform-specific, e.g., "db.t3.micro").
 	/// Defaults to platform profile value if unset.
-	///
-	/// Explicit values must be one of `ALLOWED_DATABASE_INSTANCE_CLASSES`.
 	pub instance_class: Option<String>,
 	/// Storage size in GB. Must be between 1 and `MAX_DATABASE_STORAGE_GB`.
+	#[schemars(range(min = 1, max = 100))]
 	pub storage_gb: Option<i32>,
 	/// Engine version (e.g., "16" for PostgreSQL).
 	pub version: Option<String>,
@@ -76,15 +62,6 @@ impl DatabaseSpec {
 					"database.storage_gb must be <= {MAX_DATABASE_STORAGE_GB}"
 				));
 			}
-		}
-
-		if let Some(instance_class) = self.instance_class.as_deref()
-			&& !ALLOWED_DATABASE_INSTANCE_CLASSES.contains(&instance_class)
-		{
-			return Err(format!(
-				"database.instance_class must be one of: {}",
-				ALLOWED_DATABASE_INSTANCE_CLASSES.join(", ")
-			));
 		}
 
 		Ok(())
@@ -159,29 +136,6 @@ mod tests {
 			result,
 			Err(format!(
 				"database.storage_gb must be <= {MAX_DATABASE_STORAGE_GB}"
-			))
-		);
-	}
-
-	#[rstest]
-	fn test_database_spec_rejects_unsafe_instance_class() {
-		// Arrange
-		let spec = DatabaseSpec {
-			engine: DatabaseEngine::Postgresql,
-			instance_class: Some("db.r7i.48xlarge".to_string()),
-			storage_gb: Some(20),
-			version: None,
-		};
-
-		// Act
-		let result = spec.validate();
-
-		// Assert
-		assert_eq!(
-			result,
-			Err(format!(
-				"database.instance_class must be one of: {}",
-				ALLOWED_DATABASE_INSTANCE_CLASSES.join(", ")
 			))
 		);
 	}


### PR DESCRIPTION
### Motivation

- A tenant-controlled `spec.database` could request unbounded `storage_gb` or arbitrary managed instance classes which the operator would provision with its privileges, enabling resource exhaustion or cloud-cost abuse. 
- The change introduces server- and admission-time guardrails so explicit database specs cannot trigger excessive PVC sizes or unsafe managed classes.

### Description

- Add `MAX_DATABASE_STORAGE_GB` and `ALLOWED_DATABASE_INSTANCE_CLASSES` and enforce them in `DatabaseSpec::validate()` so storage and instance-class values are bounded and allowlisted. 
- Short-circuit inference by calling `db.validate()` in `infer_database_resources()` so invalid explicit specs do not emit PVCs or cloud-provider DynamicObjects. 
- Update the Project CRD (`charts/reinhardt-cloud-operator/crds/project-crd.yaml`) to include `storage_gb` `minimum`/`maximum` and an `instance_class` `enum` to provide admission-time validation. 
- Add unit tests: validation tests in `crates/reinhardt-cloud-types/src/crd/database.rs` and an operator-level regression test in `crates/reinhardt-cloud-operator/src/inference/database.rs` that ensures invalid specs produce no inferred resources. 

### Testing

- Ran `cargo test -p reinhardt-cloud-types crd::database -- --nocapture`, and all added and existing unit tests passed. 
- Ran the operator test target `inference::database::tests::invalid_database_spec_returns_empty`; the test is present but the full operator test run was blocked by missing protobuf well-known types (`google/protobuf/timestamp.proto`) in the environment so the workspace-level run could not complete to that target. 
- Ran `cargo fmt --check` and `git diff --check` to ensure formatting and no whitespace errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35f44f8080832781c8a83ab483048b)