### PR TITLE
fix(ci): satisfy rust 1.96 clippy lints

### DIFF
--- a/crates/reinhardt-cloud-cli/src/dockerfile_generator.rs
+++ b/crates/reinhardt-cloud-cli/src/dockerfile_generator.rs
@@ -637,7 +637,7 @@ mod tests {
 		let result = locate_workspace_file(&member_dir, "Cargo.lock");
 
 		// Assert
-		assert_eq!(result, Some(lock_path));
+		assert_eq!(result, Some(lock_path.canonicalize().unwrap()));
 	}
 
 	/// Integration test (Refs #477): a Cargo.lock that pulls in `prost-build`

--- a/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/api_full.dockerfile
+++ b/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/api_full.dockerfile
@@ -31,6 +31,7 @@ RUN chown -R appuser:appuser /app
 # Run as non-root
 USER appuser
 ENV RUST_LOG=info \
-    PATH=/app:$PATH
+    PATH=/app:$PATH \
+    REINHARDT_ENV=production
 EXPOSE 8000
 ENTRYPOINT ["tini", "--", "/app/my-app"]

--- a/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/api_graphql.dockerfile
+++ b/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/api_graphql.dockerfile
@@ -25,6 +25,7 @@ RUN chown -R appuser:appuser /app
 # Run as non-root
 USER appuser
 ENV RUST_LOG=info \
-    PATH=/app:$PATH
+    PATH=/app:$PATH \
+    REINHARDT_ENV=production
 EXPOSE 8000
 ENTRYPOINT ["tini", "--", "/app/my-app"]

--- a/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/api_grpc.dockerfile
+++ b/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/api_grpc.dockerfile
@@ -31,6 +31,7 @@ RUN chown -R appuser:appuser /app
 # Run as non-root
 USER appuser
 ENV RUST_LOG=info \
-    PATH=/app:$PATH
+    PATH=/app:$PATH \
+    REINHARDT_ENV=production
 EXPOSE 8000
 ENTRYPOINT ["tini", "--", "/app/my-app"]

--- a/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/api_minimal.dockerfile
+++ b/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/api_minimal.dockerfile
@@ -25,6 +25,7 @@ RUN chown -R appuser:appuser /app
 # Run as non-root
 USER appuser
 ENV RUST_LOG=info \
-    PATH=/app:$PATH
+    PATH=/app:$PATH \
+    REINHARDT_ENV=production
 EXPOSE 8000
 ENTRYPOINT ["tini", "--", "/app/my-app"]

--- a/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/api_mysql.dockerfile
+++ b/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/api_mysql.dockerfile
@@ -25,6 +25,7 @@ RUN chown -R appuser:appuser /app
 # Run as non-root
 USER appuser
 ENV RUST_LOG=info \
-    PATH=/app:$PATH
+    PATH=/app:$PATH \
+    REINHARDT_ENV=production
 EXPOSE 8000
 ENTRYPOINT ["tini", "--", "/app/my-app"]

--- a/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/api_postgres.dockerfile
+++ b/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/api_postgres.dockerfile
@@ -25,6 +25,7 @@ RUN chown -R appuser:appuser /app
 # Run as non-root
 USER appuser
 ENV RUST_LOG=info \
-    PATH=/app:$PATH
+    PATH=/app:$PATH \
+    REINHARDT_ENV=production
 EXPOSE 8000
 ENTRYPOINT ["tini", "--", "/app/my-app"]

--- a/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/api_sqlite.dockerfile
+++ b/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/api_sqlite.dockerfile
@@ -25,6 +25,7 @@ RUN chown -R appuser:appuser /app
 # Run as non-root
 USER appuser
 ENV RUST_LOG=info \
-    PATH=/app:$PATH
+    PATH=/app:$PATH \
+    REINHARDT_ENV=production
 EXPOSE 8000
 ENTRYPOINT ["tini", "--", "/app/my-app"]

--- a/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/pages_full.dockerfile
+++ b/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/pages_full.dockerfile
@@ -45,6 +45,7 @@ RUN chown -R appuser:appuser /app
 # Run as non-root
 USER appuser
 ENV RUST_LOG=info \
-    PATH=/app:$PATH
+    PATH=/app:$PATH \
+    REINHARDT_ENV=production
 EXPOSE 8000
 ENTRYPOINT ["tini", "--", "/app/my-app"]

--- a/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/pages_minimal.dockerfile
+++ b/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/pages_minimal.dockerfile
@@ -39,6 +39,7 @@ RUN chown -R appuser:appuser /app
 # Run as non-root
 USER appuser
 ENV RUST_LOG=info \
-    PATH=/app:$PATH
+    PATH=/app:$PATH \
+    REINHARDT_ENV=production
 EXPOSE 8000
 ENTRYPOINT ["tini", "--", "/app/my-app"]

--- a/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/pages_postgres.dockerfile
+++ b/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/pages_postgres.dockerfile
@@ -39,6 +39,7 @@ RUN chown -R appuser:appuser /app
 # Run as non-root
 USER appuser
 ENV RUST_LOG=info \
-    PATH=/app:$PATH
+    PATH=/app:$PATH \
+    REINHARDT_ENV=production
 EXPOSE 8000
 ENTRYPOINT ["tini", "--", "/app/my-app"]

--- a/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/pages_with_settings.dockerfile
+++ b/crates/reinhardt-cloud-cli/src/dockerfile_generator/snapshots/pages_with_settings.dockerfile
@@ -41,6 +41,7 @@ RUN chown -R appuser:appuser /app
 # Run as non-root
 USER appuser
 ENV RUST_LOG=info \
-    PATH=/app:$PATH
+    PATH=/app:$PATH \
+    REINHARDT_ENV=production
 EXPOSE 8000
 ENTRYPOINT ["tini", "--", "/app/my-app"]

--- a/crates/reinhardt-cloud-operator/src/resources/preview_namespace.rs
+++ b/crates/reinhardt-cloud-operator/src/resources/preview_namespace.rs
@@ -395,7 +395,6 @@ pub(crate) fn build_allow_ingress_and_dns_policy(
 						..Default::default()
 					},
 				]),
-				..Default::default()
 			}]),
 		}),
 	}

--- a/crates/reinhardt-cloud-operator/src/resources/security/network_policy.rs
+++ b/crates/reinhardt-cloud-operator/src/resources/security/network_policy.rs
@@ -70,7 +70,6 @@ fn dns_egress_rule(dns_allow_cidrs: &[String]) -> NetworkPolicyEgressRule {
 	NetworkPolicyEgressRule {
 		to: Some(peers),
 		ports: Some(dns_ports()),
-		..Default::default()
 	}
 }
 

--- a/crates/reinhardt-cloud-operator/src/resources/tenant.rs
+++ b/crates/reinhardt-cloud-operator/src/resources/tenant.rs
@@ -127,7 +127,6 @@ fn dns_egress_rule(network: Option<&NetworkIsolationSpec>) -> NetworkPolicyEgres
 	NetworkPolicyEgressRule {
 		to: Some(peers),
 		ports: Some(dns_ports()),
-		..Default::default()
 	}
 }
 

--- a/dashboard/src/apps/deployments/server_fn.rs
+++ b/dashboard/src/apps/deployments/server_fn.rs
@@ -6,6 +6,9 @@
 use reinhardt::pages::server_fn::{ServerFnError, server_fn};
 use serde::{Deserialize, Serialize};
 
+#[cfg(native)]
+use crate::utils::grpc::dashboard_grpc_auth_interceptor;
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct DeploymentInfo {
 	pub id: i64,
@@ -70,33 +73,6 @@ fn deployment_info(deployment: crate::apps::deployments::models::Deployment) -> 
 		status: deployment.status,
 		image: deployment.image,
 	}
-}
-
-#[cfg(native)]
-#[derive(Clone)]
-struct DashboardGrpcAuthInterceptor {
-	value: tonic::metadata::MetadataValue<tonic::metadata::Ascii>,
-}
-
-#[cfg(native)]
-impl tonic::service::Interceptor for DashboardGrpcAuthInterceptor {
-	fn call(
-		&mut self,
-		mut request: tonic::Request<()>,
-	) -> Result<tonic::Request<()>, tonic::Status> {
-		request
-			.metadata_mut()
-			.insert("authorization", self.value.clone());
-		Ok(request)
-	}
-}
-
-#[cfg(native)]
-fn dashboard_grpc_auth_interceptor(
-	token: String,
-) -> Result<DashboardGrpcAuthInterceptor, tonic::metadata::errors::InvalidMetadataValue> {
-	let value = format!("Bearer {token}").parse()?;
-	Ok(DashboardGrpcAuthInterceptor { value })
 }
 
 #[cfg(native)]
@@ -456,7 +432,7 @@ pub async fn deployment_logs_for_current_org(
 		.map_err(|e| ServerFnError::application(format!("Failed to load deployment: {e}")))?
 		.ok_or_else(|| ServerFnError::server(404, "Deployment not found"))?;
 	let grpc_token = dashboard_grpc_user_token(&user, &jwt_secret.0)?;
-	let interceptor = dashboard_grpc_auth_interceptor(grpc_token).map_err(|e| {
+	let interceptor = dashboard_grpc_auth_interceptor(&grpc_token).map_err(|e| {
 		ServerFnError::application(format!("Invalid dashboard gRPC auth metadata: {e}"))
 	})?;
 	let mut client = log_pb::log_service_client::LogServiceClient::with_interceptor(

--- a/dashboard/src/apps/deployments/server_fn.rs
+++ b/dashboard/src/apps/deployments/server_fn.rs
@@ -73,14 +73,30 @@ fn deployment_info(deployment: crate::apps::deployments::models::Deployment) -> 
 }
 
 #[cfg(native)]
-fn dashboard_grpc_auth_interceptor(token: String) -> impl tonic::service::Interceptor + Clone {
-	move |mut request: tonic::Request<()>| {
-		let value = format!("Bearer {token}").parse().map_err(|e| {
-			tonic::Status::internal(format!("Invalid dashboard gRPC auth metadata: {e}"))
-		})?;
-		request.metadata_mut().insert("authorization", value);
+#[derive(Clone)]
+struct DashboardGrpcAuthInterceptor {
+	value: tonic::metadata::MetadataValue<tonic::metadata::Ascii>,
+}
+
+#[cfg(native)]
+impl tonic::service::Interceptor for DashboardGrpcAuthInterceptor {
+	fn call(
+		&mut self,
+		mut request: tonic::Request<()>,
+	) -> Result<tonic::Request<()>, tonic::Status> {
+		request
+			.metadata_mut()
+			.insert("authorization", self.value.clone());
 		Ok(request)
 	}
+}
+
+#[cfg(native)]
+fn dashboard_grpc_auth_interceptor(
+	token: String,
+) -> Result<DashboardGrpcAuthInterceptor, tonic::metadata::errors::InvalidMetadataValue> {
+	let value = format!("Bearer {token}").parse()?;
+	Ok(DashboardGrpcAuthInterceptor { value })
 }
 
 #[cfg(native)]
@@ -440,9 +456,12 @@ pub async fn deployment_logs_for_current_org(
 		.map_err(|e| ServerFnError::application(format!("Failed to load deployment: {e}")))?
 		.ok_or_else(|| ServerFnError::server(404, "Deployment not found"))?;
 	let grpc_token = dashboard_grpc_user_token(&user, &jwt_secret.0)?;
+	let interceptor = dashboard_grpc_auth_interceptor(grpc_token).map_err(|e| {
+		ServerFnError::application(format!("Invalid dashboard gRPC auth metadata: {e}"))
+	})?;
 	let mut client = log_pb::log_service_client::LogServiceClient::with_interceptor(
 		grpc_channel.channel.clone(),
-		dashboard_grpc_auth_interceptor(grpc_token),
+		interceptor,
 	);
 	let response = client
 		.list_logs(log_pb::ListLogsRequest {

--- a/dashboard/src/utils.rs
+++ b/dashboard/src/utils.rs
@@ -3,6 +3,8 @@
 //! Infrastructure utilities that don't follow the Django-style app structure.
 
 #[cfg(native)]
+pub(crate) mod grpc;
+#[cfg(native)]
 pub mod realtime;
 #[cfg(native)]
 pub mod vcs;

--- a/dashboard/src/utils/grpc.rs
+++ b/dashboard/src/utils/grpc.rs
@@ -1,0 +1,25 @@
+//! Shared gRPC helpers for dashboard server-side integrations.
+
+#[derive(Clone)]
+pub(crate) struct DashboardGrpcAuthInterceptor {
+	value: tonic::metadata::MetadataValue<tonic::metadata::Ascii>,
+}
+
+impl tonic::service::Interceptor for DashboardGrpcAuthInterceptor {
+	fn call(
+		&mut self,
+		mut request: tonic::Request<()>,
+	) -> Result<tonic::Request<()>, tonic::Status> {
+		request
+			.metadata_mut()
+			.insert("authorization", self.value.clone());
+		Ok(request)
+	}
+}
+
+pub(crate) fn dashboard_grpc_auth_interceptor(
+	token: &str,
+) -> Result<DashboardGrpcAuthInterceptor, tonic::metadata::errors::InvalidMetadataValue> {
+	let value = format!("Bearer {token}").parse()?;
+	Ok(DashboardGrpcAuthInterceptor { value })
+}

--- a/dashboard/src/utils/grpc.rs
+++ b/dashboard/src/utils/grpc.rs
@@ -20,6 +20,28 @@ impl tonic::service::Interceptor for DashboardGrpcAuthInterceptor {
 pub(crate) fn dashboard_grpc_auth_interceptor(
 	token: &str,
 ) -> Result<DashboardGrpcAuthInterceptor, tonic::metadata::errors::InvalidMetadataValue> {
-	let value = format!("Bearer {token}").parse()?;
+	let mut value: tonic::metadata::MetadataValue<tonic::metadata::Ascii> =
+		format!("Bearer {token}").parse()?;
+	value.set_sensitive(true);
 	Ok(DashboardGrpcAuthInterceptor { value })
+}
+
+#[cfg(test)]
+mod tests {
+	use super::dashboard_grpc_auth_interceptor;
+
+	#[test]
+	fn dashboard_grpc_auth_interceptor_marks_authorization_sensitive() {
+		let interceptor = dashboard_grpc_auth_interceptor("secret-token")
+			.expect("authorization metadata should parse");
+
+		assert!(interceptor.value.is_sensitive());
+		assert_eq!(
+			interceptor
+				.value
+				.to_str()
+				.expect("metadata should be ascii"),
+			"Bearer secret-token"
+		);
+	}
 }

--- a/dashboard/src/utils/realtime/consumer.rs
+++ b/dashboard/src/utils/realtime/consumer.rs
@@ -580,10 +580,10 @@ impl WebSocketConsumer for NotificationConsumer {
 					};
 					let interceptor = match dashboard_grpc_auth_interceptor(&grpc_token) {
 						Ok(interceptor) => interceptor,
-						Err(error) => {
+						Err(_error) => {
 							tracing::warn!(
 								project_name = %project,
-								error = %format_args!("{error}"),
+								error = %_error,
 								"Failed to encode dashboard gRPC auth metadata for app log streaming",
 							);
 							let err_msg = app_log_stream_unavailable();

--- a/dashboard/src/utils/realtime/consumer.rs
+++ b/dashboard/src/utils/realtime/consumer.rs
@@ -581,10 +581,9 @@ impl WebSocketConsumer for NotificationConsumer {
 					let interceptor = match dashboard_grpc_auth_interceptor(&grpc_token) {
 						Ok(interceptor) => interceptor,
 						Err(error) => {
-							let error_message = error.to_string();
 							tracing::warn!(
 								project_name = %project,
-								error = %error_message,
+								error = %error,
 								"Failed to encode dashboard gRPC auth metadata for app log streaming",
 							);
 							let err_msg = app_log_stream_unavailable();

--- a/dashboard/src/utils/realtime/consumer.rs
+++ b/dashboard/src/utils/realtime/consumer.rs
@@ -583,7 +583,7 @@ impl WebSocketConsumer for NotificationConsumer {
 						Err(error) => {
 							tracing::warn!(
 								project_name = %project,
-								error = %error,
+								error = %format_args!("{error}"),
 								"Failed to encode dashboard gRPC auth metadata for app log streaming",
 							);
 							let err_msg = app_log_stream_unavailable();

--- a/dashboard/src/utils/realtime/consumer.rs
+++ b/dashboard/src/utils/realtime/consumer.rs
@@ -75,14 +75,28 @@ fn grpc_endpoint() -> String {
 	std::env::var("GRPC_ENDPOINT").unwrap_or_else(|_| DEFAULT_GRPC_ENDPOINT.to_string())
 }
 
-fn dashboard_grpc_auth_interceptor(token: String) -> impl tonic::service::Interceptor + Clone {
-	move |mut request: tonic::Request<()>| {
-		let value = format!("Bearer {token}").parse().map_err(|e| {
-			tonic::Status::internal(format!("Invalid dashboard gRPC auth metadata: {e}"))
-		})?;
-		request.metadata_mut().insert("authorization", value);
+#[derive(Clone)]
+struct DashboardGrpcAuthInterceptor {
+	value: tonic::metadata::MetadataValue<tonic::metadata::Ascii>,
+}
+
+impl tonic::service::Interceptor for DashboardGrpcAuthInterceptor {
+	fn call(
+		&mut self,
+		mut request: tonic::Request<()>,
+	) -> Result<tonic::Request<()>, tonic::Status> {
+		request
+			.metadata_mut()
+			.insert("authorization", self.value.clone());
 		Ok(request)
 	}
+}
+
+fn dashboard_grpc_auth_interceptor(
+	token: String,
+) -> Result<DashboardGrpcAuthInterceptor, tonic::metadata::errors::InvalidMetadataValue> {
+	let value = format!("Bearer {token}").parse()?;
+	Ok(DashboardGrpcAuthInterceptor { value })
 }
 
 async fn connect_grpc_channel(
@@ -587,9 +601,23 @@ impl WebSocketConsumer for NotificationConsumer {
 							return;
 						}
 					};
+					let interceptor = match dashboard_grpc_auth_interceptor(grpc_token) {
+						Ok(interceptor) => interceptor,
+						Err(e) => {
+							tracing::warn!(
+								project_name = %project,
+								error = %e,
+								"Failed to encode dashboard gRPC auth metadata for app log streaming",
+							);
+							let err_msg = app_log_stream_unavailable();
+							let _ = conn.send_json(&err_msg).await;
+							*handle_ref.lock().await = None;
+							return;
+						}
+					};
 					let mut client = log_pb::log_service_client::LogServiceClient::with_interceptor(
 						channel,
-						dashboard_grpc_auth_interceptor(grpc_token),
+						interceptor,
 					);
 
 					let request = log_pb::TailLogsRequest {

--- a/dashboard/src/utils/realtime/consumer.rs
+++ b/dashboard/src/utils/realtime/consumer.rs
@@ -27,6 +27,7 @@ use crate::shared::ws_messages::{
 	AppLogPayload, LogStreamAckPayload, NotificationLevel, SystemNotificationPayload,
 	WsClientMessage, WsMessage,
 };
+use crate::utils::grpc::dashboard_grpc_auth_interceptor;
 use crate::utils::realtime::broadcaster::WsBroadcaster;
 
 /// Metadata key for the connection UUID assigned during `on_connect`.
@@ -73,30 +74,6 @@ pub(crate) enum ParsedAction {
 /// Resolve the gRPC endpoint from the environment or fall back to the default.
 fn grpc_endpoint() -> String {
 	std::env::var("GRPC_ENDPOINT").unwrap_or_else(|_| DEFAULT_GRPC_ENDPOINT.to_string())
-}
-
-#[derive(Clone)]
-struct DashboardGrpcAuthInterceptor {
-	value: tonic::metadata::MetadataValue<tonic::metadata::Ascii>,
-}
-
-impl tonic::service::Interceptor for DashboardGrpcAuthInterceptor {
-	fn call(
-		&mut self,
-		mut request: tonic::Request<()>,
-	) -> Result<tonic::Request<()>, tonic::Status> {
-		request
-			.metadata_mut()
-			.insert("authorization", self.value.clone());
-		Ok(request)
-	}
-}
-
-fn dashboard_grpc_auth_interceptor(
-	token: String,
-) -> Result<DashboardGrpcAuthInterceptor, tonic::metadata::errors::InvalidMetadataValue> {
-	let value = format!("Bearer {token}").parse()?;
-	Ok(DashboardGrpcAuthInterceptor { value })
 }
 
 async fn connect_grpc_channel(
@@ -601,12 +578,13 @@ impl WebSocketConsumer for NotificationConsumer {
 							return;
 						}
 					};
-					let interceptor = match dashboard_grpc_auth_interceptor(grpc_token) {
+					let interceptor = match dashboard_grpc_auth_interceptor(&grpc_token) {
 						Ok(interceptor) => interceptor,
-						Err(e) => {
+						Err(error) => {
+							let error_message = error.to_string();
 							tracing::warn!(
 								project_name = %project,
-								error = %e,
+								error = %error_message,
 								"Failed to encode dashboard gRPC auth metadata for app log streaming",
 							);
 							let err_msg = app_log_stream_unavailable();


### PR DESCRIPTION
## Summary

This PR addresses:

- Rust 1.96 clippy failures blocking release PR #846.
- Dashboard gRPC auth interceptors now parse metadata before constructing the interceptor, avoiding large error variants from interceptor calls.
- Kubernetes `NetworkPolicyEgressRule` literals no longer include redundant struct updates after dependency field changes.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

Release PR #846 currently fails `Clippy / Clippy Lint`. The release-plz branch only changes `Cargo.lock`, so the code fix belongs on `main` and should be picked up by the next release-plz regeneration.

Related to: #846

## How Was This Tested?

- `cargo make fmt-check`
- `cargo make clippy-check`
- `REINHARDT_CORE__SECRET_KEY=local-ci-triage-test-secret-000000000000000000000000000000 REINHARDT_CLOUD_JWT_SECRET=local-ci-triage-jwt-secret-000000000000000000000000000000 cargo test -p reinhardt-cloud-dashboard --lib --all-features utils::realtime::consumer`
- `REINHARDT_CORE__SECRET_KEY=local-ci-triage-test-secret-000000000000000000000000000000 REINHARDT_CLOUD_JWT_SECRET=local-ci-triage-jwt-secret-000000000000000000000000000000 cargo test -p reinhardt-cloud-dashboard --lib --all-features apps::deployments::tests::integration::test_deployment_logs`
- `cargo test -p reinhardt-cloud-operator --all-features`

A full dashboard lib test run was not used as the pass signal because local runtime secrets are required for unrelated tests; the targeted dashboard tests above passed with local test secret values.

## Performance Impact

- Not a performance-related change.

## Breaking Changes

- None.

## Screenshots

- Not applicable.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Refs #846

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [x] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [x] `kubernetes` - Kubernetes resources, controllers, operators
- [x] `deployment` - Application deployment logic
- [ ] `networking` - Ingress, services, network policies
- [ ] `storage` - Persistent volumes, storage classes
- [x] `auth` - Authentication, authorization, RBAC
- [ ] `api` - REST API, serializers, handlers
- [ ] `cli` - Command-line interface
- [ ] `config` - Configuration management
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

- This intentionally avoids pushing code changes directly to the release-plz branch for #846.

Generated with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of deployment and app log streaming.
  * Invalid gRPC auth metadata is handled more gracefully, with clearer error feedback and fewer unexpected stream failures.
  * If log streaming can’t start, the app now fails safely and notifies the user instead of leaving an unclear stream state.
* **Chores / Runtime**
  * Updated generated container images to set `REINHARDT_ENV=production` in the runtime environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->