### PR TITLE
security(dashboard): coalesce health probe refreshes

### DIFF
--- a/dashboard/src/apps/health/server_urls.rs
+++ b/dashboard/src/apps/health/server_urls.rs
@@ -115,11 +115,8 @@ fn status_str(ok: bool) -> String {
 }
 
 async fn cached_probe_results(grpc_channel: &GrpcChannelSingleton) -> CachedHealth {
-	let cached = {
-		let cache = health_cache().lock().await;
-		cache.filter(|cached| cached.checked_at.elapsed() < PROBE_CACHE_TTL)
-	};
-	if let Some(cached) = cached {
+	let mut cache = health_cache().lock().await;
+	if let Some(cached) = cache.filter(|cached| cached.checked_at.elapsed() < PROBE_CACHE_TTL) {
 		return cached;
 	}
 
@@ -130,7 +127,6 @@ async fn cached_probe_results(grpc_channel: &GrpcChannelSingleton) -> CachedHeal
 		db_ok,
 		grpc_ok,
 	};
-	let mut cache = health_cache().lock().await;
 	*cache = Some(cached);
 	cached
 }


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated `/api/healthz/` cache-stampede where concurrent expired-cache requests each run expensive backend probes, reducing the risk of amplified load or denial-of-service against the database and gRPC service.

### Description
- Keep the health-cache mutex held while refreshing an expired probe result so concurrent cache misses coalesce behind a single in-flight DB and gRPC probe, while preserving the existing constant-time `SELECT 1` database ping.

### Testing
- Ran `cargo fmt --all` and `git diff --check` which passed; attempted `cargo test -p reinhardt-cloud-dashboard healthz --no-run` but the build was blocked by missing protobuf well-known includes (`google/protobuf/timestamp.proto`) in the local environment so tests could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f842f3f688327b4bc8a6b5b787478)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved health check consistency under concurrent load, reducing the chance of overlapping checks and stale cached results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->