### PR TITLE
security(operator): require owner reference for git credential cleanup

### DIFF
--- a/crates/reinhardt-cloud-operator/src/reconciler.rs
+++ b/crates/reinhardt-cloud-operator/src/reconciler.rs
@@ -284,8 +284,28 @@ fn git_credentials_cleanup_names(app: &Project, project_name: &str) -> Vec<Strin
 	names
 }
 
-fn git_credentials_secret_is_managed(secret: &Secret, app: &Project) -> bool {
-	resource_is_controlled_by_project(secret, app)
+fn git_credentials_secret_has_dashboard_labels(secret: &Secret) -> bool {
+	let Some(labels) = secret.metadata.labels.as_ref() else {
+		return false;
+	};
+	labels
+		.get("reinhardt.dev/credential-type")
+		.map(String::as_str)
+		== Some("git")
+		&& labels.get("reinhardt.dev/provider").map(String::as_str) == Some("github")
+}
+
+fn git_credentials_secret_is_managed(
+	secret: &Secret,
+	app: &Project,
+	project_name: &str,
+	secret_name: &str,
+) -> bool {
+	if resource_is_controlled_by_project(secret, app) {
+		return true;
+	}
+	secret_name == managed_github_credentials_secret_name(project_name)
+		&& git_credentials_secret_has_dashboard_labels(secret)
 }
 
 async fn delete_git_credentials_secret_if_managed(
@@ -298,7 +318,7 @@ async fn delete_git_credentials_secret_if_managed(
 	let Some(existing) = secret_api.get_opt(secret_name).await.map_err(Error::Kube)? else {
 		return Ok(());
 	};
-	if git_credentials_secret_is_managed(&existing, app) {
+	if git_credentials_secret_is_managed(&existing, app, project_name, secret_name) {
 		let _ = secret_api
 			.delete(secret_name, &DeleteParams::default())
 			.await;
@@ -4280,7 +4300,7 @@ mod tests {
 	}
 
 	#[rstest]
-	fn git_credentials_secret_rejects_dashboard_applied_secret_labels_without_owner() {
+	fn git_credentials_secret_accepts_dashboard_applied_project_scoped_secret() {
 		// Arrange
 		let app = make_test_app("private-app");
 		let secret = Secret {
@@ -4298,10 +4318,15 @@ mod tests {
 		};
 
 		// Act
-		let is_managed = git_credentials_secret_is_managed(&secret, &app);
+		let is_managed = git_credentials_secret_is_managed(
+			&secret,
+			&app,
+			"private-app",
+			"private-app-github-git-credentials",
+		);
 
 		// Assert
-		assert!(!is_managed);
+		assert!(is_managed);
 	}
 
 	#[rstest]
@@ -4326,7 +4351,12 @@ mod tests {
 		};
 
 		// Act
-		let is_managed = git_credentials_secret_is_managed(&secret, &app);
+		let is_managed = git_credentials_secret_is_managed(
+			&secret,
+			&app,
+			"private-app",
+			"shared-git-credentials",
+		);
 
 		// Assert
 		assert!(is_managed);
@@ -4351,7 +4381,12 @@ mod tests {
 		};
 
 		// Act
-		let is_managed = git_credentials_secret_is_managed(&secret, &app);
+		let is_managed = git_credentials_secret_is_managed(
+			&secret,
+			&app,
+			"private-app",
+			"shared-git-credentials",
+		);
 
 		// Assert
 		assert!(!is_managed);

--- a/crates/reinhardt-cloud-operator/src/reconciler.rs
+++ b/crates/reinhardt-cloud-operator/src/reconciler.rs
@@ -284,29 +284,8 @@ fn git_credentials_cleanup_names(app: &Project, project_name: &str) -> Vec<Strin
 	names
 }
 
-fn git_credentials_secret_is_managed(
-	secret: &Secret,
-	app: &Project,
-	project_name: &str,
-	secret_name: &str,
-) -> bool {
-	if resource_is_controlled_by_project(secret, app) {
-		return true;
-	}
-
-	let project_scoped = secret_name == managed_git_credentials_secret_name(project_name)
-		|| secret_name == managed_github_credentials_secret_name(project_name);
-	if !project_scoped {
-		return false;
-	}
-
-	secret.metadata.labels.as_ref().is_some_and(|labels| {
-		labels
-			.get("reinhardt.dev/credential-type")
-			.map(String::as_str)
-			== Some("git")
-			&& labels.get("reinhardt.dev/provider").map(String::as_str) == Some("github")
-	})
+fn git_credentials_secret_is_managed(secret: &Secret, app: &Project) -> bool {
+	resource_is_controlled_by_project(secret, app)
 }
 
 async fn delete_git_credentials_secret_if_managed(
@@ -319,7 +298,7 @@ async fn delete_git_credentials_secret_if_managed(
 	let Some(existing) = secret_api.get_opt(secret_name).await.map_err(Error::Kube)? else {
 		return Ok(());
 	};
-	if git_credentials_secret_is_managed(&existing, app, project_name, secret_name) {
+	if git_credentials_secret_is_managed(&existing, app) {
 		let _ = secret_api
 			.delete(secret_name, &DeleteParams::default())
 			.await;
@@ -4301,7 +4280,7 @@ mod tests {
 	}
 
 	#[rstest]
-	fn git_credentials_secret_accepts_dashboard_applied_secret_labels() {
+	fn git_credentials_secret_rejects_dashboard_applied_secret_labels_without_owner() {
 		// Arrange
 		let app = make_test_app("private-app");
 		let secret = Secret {
@@ -4319,12 +4298,35 @@ mod tests {
 		};
 
 		// Act
-		let is_managed = git_credentials_secret_is_managed(
-			&secret,
-			&app,
-			"private-app",
-			"private-app-github-git-credentials",
-		);
+		let is_managed = git_credentials_secret_is_managed(&secret, &app);
+
+		// Assert
+		assert!(!is_managed);
+	}
+
+	#[rstest]
+	fn git_credentials_secret_accepts_project_owner_reference() {
+		// Arrange
+		let app = make_test_app("private-app");
+		let secret = Secret {
+			metadata: kube::api::ObjectMeta {
+				owner_references: Some(vec![
+					k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference {
+						api_version: "paas.reinhardt-cloud.dev/v1alpha2".to_string(),
+						kind: "Project".to_string(),
+						name: "private-app".to_string(),
+						uid: "test-uid-12345".to_string(),
+						controller: Some(true),
+						block_owner_deletion: Some(true),
+					},
+				]),
+				..Default::default()
+			},
+			..Default::default()
+		};
+
+		// Act
+		let is_managed = git_credentials_secret_is_managed(&secret, &app);
 
 		// Assert
 		assert!(is_managed);
@@ -4349,12 +4351,7 @@ mod tests {
 		};
 
 		// Act
-		let is_managed = git_credentials_secret_is_managed(
-			&secret,
-			&app,
-			"private-app",
-			"shared-git-credentials",
-		);
+		let is_managed = git_credentials_secret_is_managed(&secret, &app);
 
 		// Assert
 		assert!(!is_managed);


### PR DESCRIPTION
### Motivation
- A cleanup path treated deterministic names plus generic `reinhardt.dev` labels as sufficient proof of ownership, allowing a tenant with Project create/delete rights to cause the operator to delete arbitrary same-namespace Secrets (confused-deputy risk). 
- The operator needs a stronger ownership guard so it only deletes Secrets that are actually controlled by the `Project` resource.

### Description
- Replace the weak predicate with a strict ownerReference-based check by changing `git_credentials_secret_is_managed` to only return true when `resource_is_controlled_by_project(secret, app)` is true, removing the label-based fallback. 
- Update the call site in `delete_git_credentials_secret_if_managed` to use the new two-argument signature of `git_credentials_secret_is_managed`. 
- Adjust unit tests to assert that generic dashboard-applied GitHub labels alone are rejected and to add coverage that a Secret with a Project controller `ownerReference` is accepted as managed. 
- Preserve the existing cleanup candidate name list (`<project>-git-credentials` and `<project>-github-git-credentials`) while ensuring deletion requires the ownerReference guard.

### Testing
- Ran code formatting check with `cargo fmt --all -- --check`, which succeeded. 
- Ran `git diff --check` to ensure no whitespace/patch issues, which succeeded. 
- Attempted unit test run `cargo test -p reinhardt-cloud-operator git_credentials_secret -- --nocapture`, but the workspace build failed before those tests due to an unrelated `protoc`/`google/protobuf/timestamp.proto` include error while building `crates/reinhardt-cloud-proto`, so the modified reconciler tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f8322894c832799a74c99f2a8eb1c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Git credential Secrets so Dashboard-applied labels are recognized more consistently for GitHub-managed credentials.
  * Tightened which Secret names can be treated as Dashboard-managed, reducing accidental acceptance of unrelated credentials.
  * Secrets linked to a Project via ownership are now correctly recognized as managed, even when using the shared credentials name.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->