### PR TITLE
security(terraform): enable GKE Dataplane V2 by default

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -183,7 +183,7 @@ On-premise support (k3s/kubeadm, local Postgres, self-hosted Harbor) is planned 
 ## Security Notes
 
 - **No credentials are hardcoded.** All sensitive values (database passwords, service account keys) are passed via Terraform variables or retrieved from the provider's secret manager.
-- **GKE clusters** can opt in to Dataplane V2 (`ADVANCED_DATAPATH`) with `enable_dataplane_v2 = true` during planned cluster creation or migration. The option is disabled by default because enabling Dataplane V2 on an existing cluster can require replacement.
+- **GKE clusters** enable Dataplane V2 (`ADVANCED_DATAPATH`) by default so Kubernetes `NetworkPolicy` resources used for tenant isolation are enforced. Because Dataplane V2 is create-time-only and enabling it on an existing cluster can require replacement, set `enable_dataplane_v2 = false` only during a planned migration that preserves equivalent NetworkPolicy enforcement by other means.
 - **EKS API server** is private-endpoint-only (`endpoint_public_access = false`). Access via VPN or AWS Systems Manager Session Manager.
 - **EKS managed nodes** use a launch template that requires IMDSv2 and limits metadata response hops to `1`, preventing tenant pods from reaching node-role credentials through the instance metadata service.
 - **RDS and Cloud SQL** are deployed with private IP only; no public endpoint.

--- a/terraform/examples/gcp-minimal/main.tf
+++ b/terraform/examples/gcp-minimal/main.tf
@@ -16,6 +16,7 @@ module "gke" {
   subnet_id           = module.network.subnet_id
   pods_range_name     = module.network.pods_range_name
   services_range_name = module.network.services_range_name
+  enable_dataplane_v2 = var.enable_dataplane_v2
   labels              = var.labels
 }
 

--- a/terraform/examples/gcp-minimal/variables.tf
+++ b/terraform/examples/gcp-minimal/variables.tf
@@ -21,6 +21,12 @@ variable "name_prefix" {
   default     = "reinhardt"
 }
 
+variable "enable_dataplane_v2" {
+  description = "Enable GKE Dataplane V2 for NetworkPolicy enforcement in the example cluster."
+  type        = bool
+  default     = true
+}
+
 variable "labels" {
   description = "Labels applied to all resources."
   type        = map(string)

--- a/terraform/modules/gcp/gke/main.tf
+++ b/terraform/modules/gcp/gke/main.tf
@@ -39,8 +39,9 @@ resource "google_container_cluster" "primary" {
     services_secondary_range_name = var.services_range_name
   }
 
-  # Dataplane V2 is create-time-only for GKE clusters, so keep it opt-in
-  # to avoid replacing existing clusters during security patch rollouts.
+  # Dataplane V2 enforces Kubernetes NetworkPolicy for tenant isolation.
+  # It is create-time-only for GKE clusters, so existing clusters can opt out
+  # during planned migrations to avoid replacement.
   datapath_provider = var.enable_dataplane_v2 ? "ADVANCED_DATAPATH" : null
 
   private_cluster_config {

--- a/terraform/modules/gcp/gke/variables.tf
+++ b/terraform/modules/gcp/gke/variables.tf
@@ -57,9 +57,9 @@ variable "disk_size_gb" {
 }
 
 variable "enable_dataplane_v2" {
-  description = "Enable GKE Dataplane V2 for NetworkPolicy enforcement. Enabling this on an existing cluster can force replacement; use only during planned cluster creation or migration."
+  description = "Enable GKE Dataplane V2 for NetworkPolicy enforcement. Keep enabled for new clusters so tenant isolation NetworkPolicies are enforced; set to false only for planned migrations of existing clusters where enabling Dataplane V2 would force replacement."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "labels" {


### PR DESCRIPTION
### Motivation

- A previous change made GKE Dataplane V2 opt-in (default=false), which left new Terraform-provisioned GKE clusters without a NetworkPolicy-capable dataplane while the operator still reconciles NetworkPolicy objects, weakening tenant isolation.
- Restore a secure default for new clusters so NetworkPolicy objects the operator creates are actually enforced, while keeping an explicit opt-out for planned existing-cluster migrations.

### Description

- Change `terraform/modules/gcp/gke/variables.tf` to set `enable_dataplane_v2` default to `true` and clarify the variable description to recommend disabling only for planned migrations where replacement would be handled.
- Keep the `datapath_provider = var.enable_dataplane_v2 ? "ADVANCED_DATAPATH" : null` conditional in `terraform/modules/gcp/gke/main.tf` and update the comment to explain Dataplane V2 enforces Kubernetes `NetworkPolicy` for tenant isolation.
- Wire the `terraform/examples/gcp-minimal` example to expose the `enable_dataplane_v2` variable and pass it into the GKE module, with the example's variable defaulted to `true`.
- Update `terraform/README.md` security notes to state that Dataplane V2 is enabled by default and should be disabled only during planned migrations that preserve equivalent NetworkPolicy enforcement.

### Testing

- Ran a targeted validation script that checked the module default, example variable, example wiring, datapath conditional presence, and README update; all checks passed.
- Ran `git diff --check` style validation; no problems reported.
- `terraform fmt` could not be executed in the environment because the `terraform` executable is not available; formatting should be verified in CI or locally with Terraform installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f7c94c6d483278727761a25e2a314)