### PR TITLE
fix(operator): type project status merge patches

### DIFF
--- a/crates/reinhardt-cloud-operator/src/reconciler.rs
+++ b/crates/reinhardt-cloud-operator/src/reconciler.rs
@@ -19,6 +19,7 @@ use kube::runtime::controller::{Action, Controller};
 use kube::runtime::finalizer::{Event as FinalizerEvent, finalizer};
 use kube::runtime::watcher;
 use kube::{Client, Resource, ResourceExt};
+use serde::Serialize;
 use tracing::{Instrument, error, info, warn};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use uuid::Uuid;
@@ -54,7 +55,8 @@ use reinhardt_cloud_types::crd::database::{DatabaseStatus, ResourcePhase};
 use reinhardt_cloud_types::crd::policy::DeletionPolicy;
 use reinhardt_cloud_types::crd::spec::ScaleMetric;
 use reinhardt_cloud_types::crd::{
-	BuildStatus, BuildTargetKind, Project, ProjectCondition, ProjectPhase, ProjectStatus,
+	BuildStatus, BuildTargetKind, PreviewStatus, Project, ProjectCondition, ProjectPhase,
+	ProjectStatus,
 };
 use reinhardt_cloud_types::{ConditionStatus, ConditionType};
 
@@ -77,6 +79,25 @@ fn managed_github_credentials_secret_name(project_name: &str) -> String {
 const TRACEPARENT_ANNOTATION: &str = "reinhardt.io/traceparent";
 /// Comma-separated list of DNS suffixes that tenant-supplied Ingress hosts may use.
 const INGRESS_HOST_SUFFIXES_ENV: &str = "REINHARDT_CLOUD_INGRESS_HOST_SUFFIXES";
+
+#[derive(Debug, Clone, Serialize)]
+struct StatusSubresourcePatch<T> {
+	status: T,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PreviewStatusMergePatch {
+	previews: Vec<PreviewStatus>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DegradedStatusMergePatch {
+	phase: ProjectPhase,
+	observed_generation: Option<i64>,
+	conditions: Vec<ProjectCondition>,
+}
 
 /// Platform-level preview environment configuration read from the environment.
 ///
@@ -2377,18 +2398,26 @@ async fn reconcile_preview_status(
 	Ok(())
 }
 
-fn build_preview_status_patch(preview_projects: &[Project]) -> serde_json::Value {
+fn build_preview_status_patch(
+	preview_projects: &[Project],
+) -> StatusSubresourcePatch<PreviewStatusMergePatch> {
 	let previews = resources::preview_status::build_preview_status_list(preview_projects, "https");
-	serde_json::json!({ "status": { "previews": previews } })
+	StatusSubresourcePatch {
+		status: PreviewStatusMergePatch { previews },
+	}
 }
 
 /// Builds a `Degraded`-condition status patch payload for the given
 /// reason and message.
 ///
 /// Pure function so it is exercised by unit tests without spinning up a
-/// kube client. The returned JSON value is shaped to merge into the
+/// kube client. The returned typed value is shaped to merge into the
 /// `status` sub-resource via `Patch::Merge`.
-fn build_degraded_status_patch(app: &Project, reason: &str, message: &str) -> serde_json::Value {
+fn build_degraded_status_patch(
+	app: &Project,
+	reason: &str,
+	message: &str,
+) -> StatusSubresourcePatch<DegradedStatusMergePatch> {
 	let condition = ProjectCondition {
 		type_: ConditionType::Degraded,
 		status: ConditionStatus::True,
@@ -2398,13 +2427,13 @@ fn build_degraded_status_patch(app: &Project, reason: &str, message: &str) -> se
 		observed_generation: app.metadata.generation,
 	};
 
-	serde_json::json!({
-		"status": {
-			"phase": ProjectPhase::Failed,
-			"observedGeneration": app.metadata.generation,
-			"conditions": [condition],
-		}
-	})
+	StatusSubresourcePatch {
+		status: DegradedStatusMergePatch {
+			phase: ProjectPhase::Failed,
+			observed_generation: app.metadata.generation,
+			conditions: vec![condition],
+		},
+	}
 }
 
 /// Best-effort: write a `Degraded` condition to the app's status
@@ -2426,7 +2455,7 @@ async fn record_degraded_condition(
 		.patch_status(
 			&app.name_any(),
 			&PatchParams::default(),
-			&Patch::Merge(payload),
+			&Patch::Merge(&payload),
 		)
 		.await
 	{
@@ -2848,12 +2877,14 @@ async fn update_status(
 	);
 
 	let phase_label_for_gauge = typed_status.phase.as_ref().map(phase_label);
-	let status = serde_json::json!({ "status": typed_status });
+	let status = StatusSubresourcePatch {
+		status: typed_status,
+	};
 
 	api.patch_status(
 		&app.name_any(),
 		&PatchParams::default(),
-		&Patch::Merge(status),
+		&Patch::Merge(&status),
 	)
 	.await
 	.map_err(Error::Kube)?;
@@ -3104,6 +3135,10 @@ mod tests {
 			},
 			status: None,
 		}
+	}
+
+	fn status_patch_value<T: Serialize>(patch: &StatusSubresourcePatch<T>) -> serde_json::Value {
+		serde_json::to_value(patch).expect("status patch should serialize")
 	}
 
 	fn service_account_with_owner(uid: Option<&str>) -> ServiceAccount {
@@ -3473,7 +3508,7 @@ mod tests {
 		};
 
 		// Act
-		let patch = build_preview_status_patch(&[preview]);
+		let patch = status_patch_value(&build_preview_status_patch(&[preview]));
 
 		// Assert
 		assert_eq!(patch["status"]["previews"][0]["name"], "ready-app-pr-42");
@@ -5352,11 +5387,11 @@ mod tests {
 		let app = make_test_app("acme-app");
 
 		// Act
-		let payload = build_degraded_status_patch(
+		let payload = status_patch_value(&build_degraded_status_patch(
 			&app,
 			"TenantMismatch",
 			"namespace 'default' does not match expected 'tenant-acme'",
-		);
+		));
 
 		// Assert — the emitted JSON must drive the CR into `Failed`
 		// phase and carry a single Degraded=True condition with the
@@ -5384,7 +5419,7 @@ mod tests {
 		app.metadata.generation = Some(7);
 
 		// Act
-		let payload = build_degraded_status_patch(&app, "Reason", "msg");
+		let payload = status_patch_value(&build_degraded_status_patch(&app, "Reason", "msg"));
 
 		// Assert
 		let status = &payload["status"];
@@ -5401,7 +5436,7 @@ mod tests {
 		let app = make_test_app("ts-app");
 
 		// Act
-		let payload = build_degraded_status_patch(&app, "Reason", "msg");
+		let payload = status_patch_value(&build_degraded_status_patch(&app, "Reason", "msg"));
 
 		// Assert — `lastTransitionTime` must be a non-empty RFC-3339 string.
 		let ts = payload["status"]["conditions"][0]["lastTransitionTime"]


### PR DESCRIPTION
## Summary

This PR addresses:

- Replaces raw reconciler status merge-patch wrappers with typed `StatusSubresourcePatch` payloads.
- Keeps preview and degraded status patch serialization covered by focused operator tests.
- Groups the remaining #36-#40 follow-up in one branch; #36-#39 are already covered on `main` by organization-scoped models, filtered reads, and database constraints.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Motivation and Context

The operator still had status subresource patches that wrapped typed data in raw `serde_json::json!({ "status": ... })` objects. That kept field names outside compile-time checking in the reconciler status write path.

Fixes #40

Related to: #36, #37, #38, #39

## How Was This Tested?

- [x] `cargo fmt --all --check`
- [x] `cargo test -p reinhardt-cloud-operator build_degraded_status_patch`
- [x] `cargo test -p reinhardt-cloud-operator preview_status_patch`
- [x] `cargo clippy -p reinhardt-cloud-operator --all-targets -- -D warnings`

## Performance Impact

No runtime performance impact expected. This changes the Rust-side patch construction type shape while preserving the serialized Kubernetes merge-patch payload.

## Breaking Changes

None.

## Screenshots

Not applicable; no UI changes.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #36
- #37
- #38
- #39
- #40

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements
- [ ] `breaking-change` - Breaking change (also select in "Type of Change" above)

### Scope Label (select all that apply)
- [x] `kubernetes` - Kubernetes resources, controllers, operators
- [ ] `deployment` - Application deployment logic
- [ ] `networking` - Ingress, services, network policies
- [ ] `storage` - Persistent volumes, storage classes
- [ ] `auth` - Authentication, authorization, RBAC
- [ ] `api` - REST API, serializers, handlers
- [ ] `cli` - Command-line interface
- [ ] `config` - Configuration management
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The branch intentionally keeps #36-#40 in one review unit. Current `main` already contains organization ownership fields, organization-scoped list/mutation queries, `deployments.cluster_id` FK migration, and auth email uniqueness migration. The remaining concrete change here is the typed status patch gap from #40.

🤖 Generated with [Codex](https://openai.com/codex)
