### PR TITLE
security(terraform): enable GKE Dataplane V2 by default

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -183,7 +183,7 @@ On-premise support (k3s/kubeadm, local Postgres, self-hosted Harbor) is planned 
 ## Security Notes
 
 - **No credentials are hardcoded.** All sensitive values (database passwords, service account keys) are passed via Terraform variables or retrieved from the provider's secret manager.
-- **GKE clusters** can opt in to Dataplane V2 (`ADVANCED_DATAPATH`) with `enable_dataplane_v2 = true` so Kubernetes `NetworkPolicy` resources used for tenant isolation are enforced. The reusable module defaults to `false` to avoid replacement-only datapath changes during routine upgrades of existing clusters; the `gcp-minimal` example enables it for new clusters and should be set to `false` only for planned migrations after validating equivalent NetworkPolicy enforcement.
+- **GKE clusters** enable Dataplane V2 (`ADVANCED_DATAPATH`) by default with `enable_dataplane_v2 = true` so Kubernetes `NetworkPolicy` resources used for tenant isolation are enforced. Changing this setting on an existing cluster is replacement-only; set it to `false` only for planned migrations after validating equivalent NetworkPolicy enforcement is provided separately.
 - **EKS API server** is private-endpoint-only (`endpoint_public_access = false`). Access via VPN or AWS Systems Manager Session Manager.
 - **EKS managed nodes** use a launch template that requires IMDSv2 and limits metadata response hops to `1`, preventing tenant pods from reaching node-role credentials through the instance metadata service.
 - **RDS and Cloud SQL** are deployed with private IP only; no public endpoint.

--- a/terraform/modules/gcp/gke/main.tf
+++ b/terraform/modules/gcp/gke/main.tf
@@ -40,8 +40,8 @@ resource "google_container_cluster" "primary" {
   }
 
   # Dataplane V2 enforces Kubernetes NetworkPolicy for tenant isolation.
-  # It is replacement-only for existing GKE clusters, so the reusable module
-  # keeps it explicit while new-cluster examples opt in.
+  # It is replacement-only for existing GKE clusters; disable it only when
+  # equivalent NetworkPolicy enforcement is provided separately.
   datapath_provider = var.enable_dataplane_v2 ? "ADVANCED_DATAPATH" : null
 
   private_cluster_config {

--- a/terraform/modules/gcp/gke/variables.tf
+++ b/terraform/modules/gcp/gke/variables.tf
@@ -57,9 +57,9 @@ variable "disk_size_gb" {
 }
 
 variable "enable_dataplane_v2" {
-  description = "Enable GKE Dataplane V2 for NetworkPolicy enforcement. Defaults to false because enabling it on an existing cluster is replacement-only; set true only for new clusters or planned replacements after validating NetworkPolicy allowances."
+  description = "Enable GKE Dataplane V2 for NetworkPolicy enforcement. Defaults to true so clusters enforce tenant isolation policies; set false only when an existing cluster replacement is not acceptable and equivalent NetworkPolicy enforcement is provided separately."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "labels" {


### PR DESCRIPTION
### Motivation

- The reusable GKE Terraform module previously defaulted `enable_dataplane_v2` to `false`, which caused clusters created from the minimal example to accept but not enforce Kubernetes `NetworkPolicy` resources and therefore broke Reinhardt Cloud's tenant isolation assumptions.

### Description

- Revert the insecure default by changing `enable_dataplane_v2` default to `true` in `terraform/modules/gcp/gke/variables.tf` so new clusters enforce `NetworkPolicy` via Dataplane V2.
- Clarify the module comment in `terraform/modules/gcp/gke/main.tf` to state that disabling Dataplane V2 is replacement-only and should only be done when equivalent NetworkPolicy enforcement is provided separately.
- Update the Terraform security guidance in `terraform/README.md` to document the secure default and the guidance for existing-cluster migrations.

### Testing

- Ran a small Python check that verifies the module variable default is `true`, the `datapath_provider` expression remains `var.enable_dataplane_v2 ? "ADVANCED_DATAPATH" : null`, and the example wiring still propagates the setting; this check succeeded.
- Ran `git diff --check` to ensure no whitespace issues; the check succeeded.
- Attempted `terraform fmt -check -recursive terraform` but Terraform is not installed in the environment, so the formatting check could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a425465418883278dcbad00175a76e6)